### PR TITLE
Fix error message in case of unknown criterion value

### DIFF
--- a/parameter/SelectionCriterionRule.cpp
+++ b/parameter/SelectionCriterionRule.cpp
@@ -105,7 +105,8 @@ bool CSelectionCriterionRule::parse(CRuleParser& ruleParser, string& strError)
     // Value
     if (!_pSelectionCriterion->getCriterionType()->getNumericalValue(strValue, _iMatchValue)) {
 
-        strError = "Value error: " + strError;
+        strError = "Value error: \"" + strValue + "\" is not part of criterion \"" +
+                   _pSelectionCriterion->getCriterionName() + "\"";
 
         return false;
     }


### PR DESCRIPTION
When failing to parse a criterion rule, the pfw was outputing: `Value error:`
This did not help to find the root cause.

With this patch it would have output:
`Value error: <Input value> is not part of criterion <Criterion>`
(Of course replacing <*> by the apropriate value)