### PR TITLE
Integrate fix point parameter test in cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,6 @@ Also, CMake can build a project out-of-tree, which is the recommended method:
     cd /path/to/build/directory
     cmake /path/to/parameter-framework/sources
     make
+
+After an install you may want to run the parameter-framework tests with
+`make test`.

--- a/test/test-fixed-point-parameter/CMakeLists.txt
+++ b/test/test-fixed-point-parameter/CMakeLists.txt
@@ -26,28 +26,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# has been tested on 2.8 only - might work on older versions
-cmake_minimum_required(VERSION 2.8)
+find_program(python2 python2)
 
-# linking policy (see cmake --help-policy CMP0003)
-if(COMMAND cmake_policy)
-  cmake_policy(SET CMP0003 NEW)
-endif(COMMAND cmake_policy)
-
-project(parameter-framework)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra")
-
-add_subdirectory(xmlserializer)
-add_subdirectory(parameter)
-add_subdirectory(utility)
-add_subdirectory(remote-processor)
-
-add_subdirectory(remote-process)
-
-enable_testing()
-add_subdirectory(test/test-platform)
-add_subdirectory(test/test-fixed-point-parameter)
-
-add_subdirectory(tools/xmlGenerator)
-add_subdirectory(tools/xmlValidator)
+if(python2)
+    add_test(NAME fix_point_parameter
+             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+             COMMAND ${python2} Main.py)
+else(python2)
+    message(WARNING "Disabling fix point parameter test as python2 is not installed.")
+endif(python2)


### PR DESCRIPTION
cmake can manage test with ctest. Running them when make test
is run. Unfortunately the only automatic tests the pfw has
(fix point parameter test) are not declared in cmake.

Add a test target and declare the fix point parameter test in cmake.
Thus a simple make test after the make install will run all tests.