### PR TITLE
Check libc call failure

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -48,6 +48,7 @@ if(BUILD_TESTING)
     # copy it in a standard location (/usr/include on most linux distribution).
     find_path(CATCH_HEADER catch.hpp)
     include_directories(${CATCH_HEADER})
+    include_directories("${PROJECT_SOURCE_DIR}/utility")
 
     # Add unit test
     add_executable(cparameterUnitTest Test.cpp)
@@ -57,7 +58,7 @@ if(BUILD_TESTING)
     # proper failure.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonnull")
 
-    target_link_libraries(cparameterUnitTest cparameter)
+    target_link_libraries(cparameterUnitTest cparameter pfw_utility)
     add_test(NAME cparameterUnitTest
              COMMAND cparameterUnitTest)
 

--- a/bindings/c/Test.cpp
+++ b/bindings/c/Test.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "ParameterFramework.h"
+#include "FullIo.hpp"
 
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
 #include <catch.hpp>
@@ -84,7 +85,7 @@ struct Test
             CAPTURE(errno);
             REQUIRE(mFd != -1);
             mPath = tmpName;
-            write(mFd, content.c_str(), content.length());
+            REQUIRE(utility::fullWrite(mFd, content.c_str(), content.length()));
         }
         ~TmpFile() {
             CHECK(close(mFd) != -1);

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -2531,12 +2531,12 @@ bool CParameterMgr::handleRemoteProcessingInterface(string& strError)
 
         log_info("Starting remote processor server on port %d", getConstFrameworkConfiguration()->getServerPort());
         // Start
-        if (!_pRemoteProcessorServer->start()) {
+        if (!_pRemoteProcessorServer->start(strError)) {
 
             ostringstream oss;
             oss << "ParameterMgr: Unable to start remote processor server on port "
                 << getConstFrameworkConfiguration()->getServerPort();
-            strError = oss.str();
+            strError = oss.str() + ": " + strError;
 
             return false;
         }

--- a/remote-processor/CMakeLists.txt
+++ b/remote-processor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -38,6 +38,8 @@ add_library(remote-processor SHARED
 
 set(CMAKE_THREAD_PREFER_PTHREAD 1)
 find_package(Threads REQUIRED)
+
+include_directories("${PROJECT_SOURCE_DIR}/utility")
 
 target_link_libraries(remote-processor ${CMAKE_THREAD_LIBS_INIT})
 

--- a/remote-processor/ListeningSocket.cpp
+++ b/remote-processor/ListeningSocket.cpp
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -39,6 +39,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <cstring>
 
 #define base CSocket
 
@@ -52,7 +53,7 @@ CListeningSocket::CListeningSocket()
 }
 
 // Listen
-bool CListeningSocket::listen(uint16_t uiPort)
+bool CListeningSocket::listen(uint16_t uiPort, string &strError)
 {
     struct sockaddr_in server_addr;
 
@@ -62,19 +63,17 @@ bool CListeningSocket::listen(uint16_t uiPort)
     // Bind
     if (bind(getFd(), (struct sockaddr*)&server_addr, sizeof(struct sockaddr)) == -1) {
 
-	std::ostringstream oss;
-        oss << "CListeningSocket::listen::bind port " << uiPort;
-        perror(oss.str().c_str());
-
+        std::ostringstream oss;
+        oss << uiPort;
+        strError = "Could not bind socket to port " + oss.str() + ": " + strerror(errno);
         return false;
     }
 
     if (::listen(getFd(), 5) == -1) {
 
-	std::ostringstream oss;
-        oss << "CListeningSocket::listen::bind port " << uiPort;
-        perror(oss.str().c_str());
-
+        std::ostringstream oss;
+        oss << uiPort;
+        strError = "Could not listen to port " + oss.str() + ": " + strerror(errno);
         return false;
     }
     return true;

--- a/remote-processor/ListeningSocket.h
+++ b/remote-processor/ListeningSocket.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -37,7 +37,7 @@ public:
     CListeningSocket();
 
     // Listen
-    bool listen(uint16_t uiPort);
+    bool listen(uint16_t uiPort, std::string &strError);
 
     // Accept
     CSocket* accept();

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -99,7 +99,12 @@ void CRemoteProcessorServer::stop()
 
     // Cause exiting of the thread
     uint8_t ucData = 0;
-    utility::fullWrite(_aiInbandPipe[1], &ucData, sizeof(ucData));
+    if (not utility::fullWrite(_aiInbandPipe[1], &ucData, sizeof(ucData))) {
+        std::cerr << "Could not query command processor thread to terminate: "
+                     "fail to write on inband pipe: "
+                  << strerror(errno) << std::endl;
+        assert(false);
+    }
 
     // Join thread
     pthread_join(_ulThreadId, NULL);
@@ -149,7 +154,11 @@ void CRemoteProcessorServer::run()
 
             // Consume exit request
             uint8_t ucData;
-            utility::fullRead(_aiInbandPipe[0], &ucData, sizeof(ucData));
+            if (not utility::fullRead(_aiInbandPipe[0], &ucData, sizeof(ucData))) {
+                    std::cerr << "Remote processor could not receive exit request"
+                              << strerror(errno) << std::endl;
+                    assert(false);
+            }
 
             // Exit
             return;

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -53,7 +53,7 @@ CRemoteProcessorServer::~CRemoteProcessorServer()
 }
 
 // State
-bool CRemoteProcessorServer::start()
+bool CRemoteProcessorServer::start(string &error)
 {
     assert(!_bIsStarted);
 
@@ -62,11 +62,12 @@ bool CRemoteProcessorServer::start()
 
     // Create inband pipe
     if (pipe(_aiInbandPipe) == -1) {
-        std::cerr << "Could not create a pipe for remote processor communication: " << strerror(errno);
+        error = "Could not create a pipe for remote processor communication: ";
+        error += strerror(errno);
         return false;
     }
 
-    if (!_pListeningSocket->listen(_uiPort)) {
+    if (!_pListeningSocket->listen(_uiPort, error)) {
 
         // Remove listening socket
         delete _pListeningSocket;

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -29,6 +29,7 @@
  */
 #include "RemoteProcessorServer.h"
 #include "ListeningSocket.h"
+#include "FullIo.hpp"
 #include <iostream>
 #include <memory>
 #include <assert.h>
@@ -98,7 +99,7 @@ void CRemoteProcessorServer::stop()
 
     // Cause exiting of the thread
     uint8_t ucData = 0;
-    write(_aiInbandPipe[1], &ucData, sizeof(ucData));
+    utility::fullWrite(_aiInbandPipe[1], &ucData, sizeof(ucData));
 
     // Join thread
     pthread_join(_ulThreadId, NULL);
@@ -148,7 +149,7 @@ void CRemoteProcessorServer::run()
 
             // Consume exit request
             uint8_t ucData;
-            read(_aiInbandPipe[0], &ucData, sizeof(ucData));
+            utility::fullRead(_aiInbandPipe[0], &ucData, sizeof(ucData));
 
             // Exit
             return;

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -75,7 +75,8 @@ bool CRemoteProcessorServer::start(string &error)
     // Thread needs to access to the listning socket.
     _pListeningSocket = pListeningSocket.get();
     // Create thread
-    if (pthread_create(&_ulThreadId, NULL, thread_func, this) != 0) {
+    errno = pthread_create(&_ulThreadId, NULL, thread_func, this);
+    if (errno != 0) {
 
         error = "Could not create a remote processor thread: ";
         error += strerror(errno);
@@ -107,7 +108,12 @@ void CRemoteProcessorServer::stop()
     }
 
     // Join thread
-    pthread_join(_ulThreadId, NULL);
+    errno = pthread_join(_ulThreadId, NULL);
+    if (errno != 0) {
+        std::cout << "Could not join with remote processor thread: "
+                  << strerror(errno) << std::endl;
+        assert(false);
+    }
 
     _bIsStarted = false;
 

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -34,7 +34,8 @@
 #include <assert.h>
 #include <poll.h>
 #include <unistd.h>
-#include <strings.h>
+#include <string.h>
+#include <errno.h>
 #include "RequestMessage.h"
 #include "AnswerMessage.h"
 #include "RemoteCommandHandler.h"
@@ -44,8 +45,6 @@ using std::string;
 CRemoteProcessorServer::CRemoteProcessorServer(uint16_t uiPort, IRemoteCommandHandler* pCommandHandler) :
     _uiPort(uiPort), _pCommandHandler(pCommandHandler), _bIsStarted(false), _pListeningSocket(NULL), _ulThreadId(0)
 {
-    // Create inband pipe
-    pipe(_aiInbandPipe);
 }
 
 CRemoteProcessorServer::~CRemoteProcessorServer()
@@ -60,6 +59,12 @@ bool CRemoteProcessorServer::start()
 
     // Create server socket
     _pListeningSocket = new CListeningSocket;
+
+    // Create inband pipe
+    if (pipe(_aiInbandPipe) == -1) {
+        std::cerr << "Could not create a pipe for remote processor communication: " << strerror(errno);
+        return false;
+    }
 
     if (!_pListeningSocket->listen(_uiPort)) {
 

--- a/remote-processor/RemoteProcessorServer.h
+++ b/remote-processor/RemoteProcessorServer.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -43,7 +43,7 @@ public:
     virtual ~CRemoteProcessorServer();
 
     // State
-    virtual bool start();
+    virtual bool start(std::string &error);
     virtual void stop();
     virtual bool isStarted() const;
 

--- a/remote-processor/RemoteProcessorServerInterface.h
+++ b/remote-processor/RemoteProcessorServerInterface.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -30,11 +30,12 @@
 #pragma once
 
 #include "RequestMessage.h"
+#include <string>
 
 class IRemoteProcessorServerInterface
 {
 public:
-    virtual bool start() = 0;
+    virtual bool start(std::string &strError) = 0;
     virtual void stop() = 0;
     virtual bool isStarted() const = 0;
 

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -163,12 +163,9 @@ CTestPlatform::CommandReturn CTestPlatform::exit(
 bool CTestPlatform::load(std::string& strError)
 {
     // Start remote processor server
-    if (!_pRemoteProcessorServer->start()) {
+    if (!_pRemoteProcessorServer->start(strError)) {
 
-	std::ostringstream oss;
-        oss << "TestPlatform: Unable to start remote processor server on port " << _portNumber;
-        strError = oss.str();
-
+        strError = "TestPlatform: Unable to start remote processor server: " + strError;
         return false;
     }
 

--- a/test/test-platform/main.cpp
+++ b/test/test-platform/main.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "TestPlatform.h"
+#include "FullIo.hpp"
 
 #include <iostream>
 #include <cstdlib>
@@ -115,14 +116,14 @@ static bool startDaemonTestPlatform(const char *filePath, int portNumber, string
 
             // Notify parent of failure;
             msgToParent = false;
-            write(pipefd[1], &msgToParent, sizeof(msgToParent));
+            utility::fullWrite(pipefd[1], &msgToParent, sizeof(msgToParent));
 
             sem_destroy(&sem);
         } else {
 
             // Notify parent of success
             msgToParent = true;
-            write(pipefd[1], &msgToParent, sizeof(msgToParent));
+            utility::fullWrite(pipefd[1], &msgToParent, sizeof(msgToParent));
 
             // Block here
             sem_wait(&sem);
@@ -143,7 +144,7 @@ static bool startDaemonTestPlatform(const char *filePath, int portNumber, string
         // Message received from the child process
         bool msgFromChild = false;
 
-        if (read(pipefd[0], &msgFromChild, sizeof(msgFromChild)) <= 0) {
+        if (not utility::fullRead(pipefd[0], &msgFromChild, sizeof(msgFromChild))) {
 
             strError = "Read pipe failed";
         }

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -29,6 +29,7 @@
 add_library(pfw_utility STATIC
     Tokenizer.cpp
     Utility.cpp
+    FullIo.cpp
     NaiveTokenizer.cpp)
 
 # '-fPIC' needed for linking against shared libraries (e.g. libparameter)

--- a/utility/FullIo.cpp
+++ b/utility/FullIo.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "FullIo.hpp"
+
+#include <cerrno>
+#include <unistd.h>
+
+namespace utility
+{
+
+/** Workaround c++ `void *` arithmetic interdiction. */
+template <class Ptr>
+Ptr *add(Ptr *ptr, size_t count) {
+    return (char *)ptr + count;
+}
+
+template <class Buff>
+static bool fullAccess(ssize_t (&accessor)(int, Buff, size_t),
+                       bool (&accessFailed)(ssize_t),
+                       int fd, Buff buf, size_t count) {
+    size_t done = 0; // Bytes already access in previous iterations
+    while (done < count) {
+        ssize_t accessed = accessor(fd, add(buf, done), count - done);
+        if (accessFailed(accessed)) {
+            return false;
+        }
+        done += accessed;
+    }
+    return true;
+}
+
+static bool accessFailed(ssize_t accessRes) {
+    return accessRes == -1 and errno != EAGAIN and errno != EINTR;
+}
+
+bool fullWrite(int fd, const void *buf, size_t count) {
+    return fullAccess(::write, accessFailed, fd, buf, count);
+}
+
+static bool readFailed(ssize_t readRes) {
+    if (readRes == 0) { // read should not return 0 (EOF)
+        errno = 0;
+        return true;
+    }
+    return accessFailed(readRes);
+}
+bool fullRead(int fd, void *buf, size_t count) {
+    return fullAccess(::read, readFailed, fd, buf, count);
+}
+
+} // namespace utility
+

--- a/utility/FullIo.hpp
+++ b/utility/FullIo.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace utility
+{
+
+/** Write *completely* a buffer in a file descriptor.
+ *
+ * A wrapper around unistd::write that resumes write on incomplete access
+ * and EAGAIN/EINTR error.
+ *
+ * @see man 2 write for the parameters.
+ *
+ * @return true if the buffer could be completely written,
+ *        false on failure (see write's man errno section).
+ */
+bool fullWrite(int fd, const void *buf, size_t count);
+
+/** Fill a buffer from a file descriptor.
+ *
+ * A wrapper around unistd::read that resumes read on incomplete access
+ * and EAGAIN/EINTR error.
+ *
+ * @see man 2 read for the parameters.
+ *
+ * @return true if the buffer could be completely fill,
+ *        false on failure (see read's man errno section).
+ *
+ * If the buffer could not be filled due to an EOF, return false but set
+ * errno to 0.
+ * @TODO Add a custom strerror to prevent logging "success" (`sterror(0)`) on
+ *       EOF errors ?
+ */
+bool fullRead(int fd, void *buf, size_t count);
+
+} // namespace utility
+


### PR DESCRIPTION
The parameter framework was not compiling on chrome because the libc is forcing call status to be checked  

Handle failure of calls by returning an error if possible or just logging if not.
