### PR TITLE
Link parameter-framework.so with dl

### DIFF
--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -185,7 +185,8 @@ include_directories(
     "${PROJECT_SOURCE_DIR}/remote-processor")
 
 # No need to link with libremote-processor: it is accessed via dlopen()
-target_link_libraries(parameter xmlserializer pfw_utility)
+find_library(dl dl)
+target_link_libraries(parameter xmlserializer pfw_utility dl)
 
 install(TARGETS parameter LIBRARY DESTINATION lib)
 # Client headers


### PR DESCRIPTION
The parameter-framework was using dl{open,close,error} but was not
requesting to link with dl. This leaded to compilation failure on non
implicit dl distributions.

Add explict dependency to dl.

Signed-off-by: Kevin Rocard <kevinx.rocard@intel.com>