### PR TITLE
Remove explicit server stop

### DIFF
--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -154,9 +154,6 @@ CTestPlatform::CommandReturn CTestPlatform::exit(
 {
     (void)remoteCommand;
 
-    // Stop local server
-    _pRemoteProcessorServer->stop();
-
     // Release the main blocking semaphore to quit application
     sem_post(&_exitSemaphore);
 


### PR DESCRIPTION
Stopping the remote-processor in the stop command has two side effect:
 - stopping the remote-processor thread will fail as it is not possible
   to join a thread to itself. This leads to the leak of all the thread
   object (destructor not called).
 - the server will not return the exit command status as it has been
   stopped during it's execution.

Remove the remote-processor stop as it will be called during it's
destruction.