### PR TITLE
test-platform: fix boolean remote getter commands output

### DIFF
--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -245,11 +245,10 @@ CTestPlatform::CommandReturn CTestPlatform::getter(
         const IRemoteCommand& remoteCommand, string& strResult)
 {
     (void)remoteCommand;
-    (void)strResult;
 
     strResult = (_pParameterMgrPlatformConnector->*getFunction)() ? "true" : "false";
 
-    return  CTestPlatform::CCommandHandler::EDone;
+    return  CTestPlatform::CCommandHandler::ESucceeded;
 }
 
 CTestPlatform::CommandReturn CTestPlatform::setCriterionState(


### PR DESCRIPTION
Getter commands return a boolean value ("true" or "false") were implemented by
a generic method.  However, this method returned a "Done" result, which
suppresses the normal output and prints "Done" instead.

This is fixed by making this method return a "Success" result, which is
interpreted as "give the output to the user".

In the same time, we remove a useless "cast to void" which is usually a
workaround for unused variables.

Change-Id: I49115d3b29967fd455ffc0b703dfb4f4d438280e
Signed-off-by: David Wagner <david.wagner@intel.com>