### PR TITLE
Fix pointer arithmetic instead of concat

### DIFF
--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -440,7 +440,7 @@ bool CSubsystem::handleSubsystemObjectCreation(
                 pSubsystemObjectCreator->getMaxConfigurableElementSize()) {
 
                 string strSizeError = "Size should not exceed " +
-                                      pSubsystemObjectCreator->getMaxConfigurableElementSize();
+                                      toString(pSubsystemObjectCreator->getMaxConfigurableElementSize());
 
                 strError = getMappingError(strKey, strSizeError, pInstanceConfigurableElement);
 


### PR DESCRIPTION
`"my number " + 5` does not produces `"my number 5"` but rather `"mber "`.
If the number was greater than `len(string) + 2`
(pointing to the \0 and one past the end in authorized, more in UB)
the result would have been undefined behaviour.

Concatenate the number with a string stream.