### PR TITLE
Missing std prefix in skeleton plugin

### DIFF
--- a/skeleton-subsystem/SkeletonSubsystem.h
+++ b/skeleton-subsystem/SkeletonSubsystem.h
@@ -34,7 +34,7 @@
 class CSkeletonSubsystem : public CSubsystem
 {
 public:
-    CSkeletonSubsystem(const string& strName);
+    CSkeletonSubsystem(const std::string& strName);
 
 };
 

--- a/skeleton-subsystem/SkeletonSubsystemObject.cpp
+++ b/skeleton-subsystem/SkeletonSubsystemObject.cpp
@@ -43,6 +43,8 @@
 
 #define base CFormattedSubsystemObject
 
+using std::string;
+
 CSkeletonSubsystemObject::CSkeletonSubsystemObject(
             const string& strMappingValue,
             CInstanceConfigurableElement* pInstanceConfigurableElement,
@@ -105,7 +107,7 @@ bool CSkeletonSubsystemObject::sendToHW(string& strError)
         blackboardRead(pvValue, _uiScalarSize);
 
         // Send here the value
-        cout << "Sending to HW: " << _strMessage << endl;
+        std::cout << "Sending to HW: " << _strMessage << std::endl;
     }
 
     return true;
@@ -122,7 +124,7 @@ bool CSkeletonSubsystemObject::receiveFromHW(string& strError)
     for (uiIndex = 0 ; uiIndex < _uiArraySize ; uiIndex++) {
 
         // Retreive here the value
-        cout << "Retreive from HW: " << _strMessage << endl;
+        std::cout << "Retreive from HW: " << _strMessage << std::endl;
 
         // Write Value in Blackboard
         blackboardWrite(pvValue, _uiScalarSize);


### PR DESCRIPTION
The skeleton plugin is not compiled when compiling
the root pfw project. As a result, when `using namespaces`
was removed from the pfw headers the skeleton plugin
was left unchecked and unfortunately broken.

Fix the missing `std::` by adding them where needed or
inserting a `using std::string`.

Signed-off-by: Kevin Rocard <kevin.rocard@intel.com>