### PR TITLE
Use minidom factory methods in xml coverage generator

### DIFF
--- a/tools/coverage/coverage.py
+++ b/tools/coverage/coverage.py
@@ -204,14 +204,14 @@ class Element():
                 str(dumpedDescription) for dumpedDescription in
                         self._dumpDescription(withCoverage, withNbUse))
 
-    def exportToXML(self, domElement=None):
+    def exportToXML(self, document, domElement=None):
         if domElement == None:
-            domElement = xml.dom.minidom.Element(self.tag)
+            domElement = document.createElement(self.tag)
 
         self._XMLaddAttributes(domElement)
 
         for child in self.children :
-            domElement.appendChild(child.exportToXML())
+            domElement.appendChild(child.exportToXML(document))
 
         return domElement
 
@@ -877,10 +877,10 @@ class Root(Element):
     def exportToXML(self):
         """Export tree to an xml document"""
         impl = xml.dom.minidom.getDOMImplementation()
-        newdoc = impl.createDocument(namespaceURI=None, qualifiedName=self.tag, doctype=None)
-        super().exportToXML(newdoc.documentElement)
+        document = impl.createDocument(namespaceURI=None, qualifiedName=self.tag, doctype=None)
+        super().exportToXML(document, document.documentElement)
 
-        return newdoc
+        return document
 
 # ============================
 # Command line argument parser


### PR DESCRIPTION
The exportToXML was creating an minidom.Element using it's constructor, which is forbidden in the documentation:
> Applications should not instantiate the classes themselves; they should use the creator functions available on the Document object.
http://docs.python.org/library/xml.dom.minidom.html

Since python 3.4 this method no longer works (private interface change) thus the xml coverage generation was broken.

Fix by calling the recommended method Document.createElement.

See bug: http://bugs.python.org/issue15290

Signed-off-by: Kevin Rocard <kevin.rocard@intel.com>