### PR TITLE
Add a configuration file for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: cpp
+compiler:
+  - gcc
+#  - clang # not supported yet
+
+# install SWIG for bindings generation
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y swig
+
+# how to build
+script: cmake . && make -j && sudo make install && make test
+
+notifications:
+  email:
+    - david.wagner@intel.com
+  irc:
+    - "chat.freenode.net#parameter-framework"
+
+env:
+  global:
+   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+   #   via the "travis encrypt" command using the project repo's public key
+   - secure: "Y+iKBg65e4dleuMwxAo1XSl/QkF4AtCe35ltu2DhPbeMJCywBmu0aeDb04oEaZJL+BxP+KMoRqRjeoGI3W/sh0gAq03iQ+P4C8KwRb9fdYPPVwH3NP3fyN27gFBH9GS8uMth68o2KP/oO/aqNwii/KbMZtubp7MhY/wnvz4DLCQ="
+
+addons:
+  coverity_scan:
+    project:
+      name: "dawagner/parameter-framework"
+      description: "Plugin-based and rule-based framework for managing parameters"
+    notification_email: david.wagner@intel.com
+    build_command_prepend: "cmake ."
+    build_command: "make -j 12"
+    branch_pattern: coverity_scan

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # parameter-framework
 
+[![Build Status](https://travis-ci.org/01org/parameter-framework.svg?branch=master)](https://travis-ci.org/01org/parameter-framework)
+
 ## Introduction
 
 The parameter-framework is a plugin-based and rule-based framework for handling


### PR DESCRIPTION
Travis will build each new commit and each pull request and publish the results
here:

    https://travis-ci.org/01org/parameter-framework

and on the #parameter-framework channel on FreeNode.

This commit also adds a build status icon in the Readme.

Signed-off-by: David Wagner <david.wagner@intel.com>