### PR TITLE
Make CParameterMgr::init private

### DIFF
--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -118,7 +118,6 @@ public:
       * @return true if no error occurred, false otherwise.
       */
     bool load(std::string& strError);
-    virtual bool init(std::string& strError);
 
     // Selection Criteria
     CSelectionCriterionType* createSelectionCriterionType(bool bIsInclusive);
@@ -358,6 +357,9 @@ public:
 private:
     CParameterMgr(const CParameterMgr&);
     CParameterMgr& operator=(const CParameterMgr&);
+
+    // Init
+    virtual bool init(std::string& strError);
 
     // Logging (done by root)
     virtual void doLog(bool bIsWarning, const std::string& strLog) const;

--- a/parameter/ParameterMgrFullConnector.cpp
+++ b/parameter/ParameterMgrFullConnector.cpp
@@ -52,7 +52,7 @@ CParameterMgrFullConnector::~CParameterMgrFullConnector()
 bool CParameterMgrFullConnector::start(string& strError)
 {
     // Create data structure & Init flow
-    return _pParameterMgr->load(strError) && _pParameterMgr->init(strError);
+    return _pParameterMgr->load(strError);
 }
 
 void CParameterMgrFullConnector::setLogger(CParameterMgrFullConnector::ILogger* pLogger)


### PR DESCRIPTION
Since 3adb785eb097028750fc1b4c5ecab3bebf1a9ae3, CParameterMgr::init should not
be called directly. However, it was kept public and CParameterMgrFullConnector
was using it.

Make it private and remove its use from CParameterMgrFullConnector.

Signed-off-by: Frederic Boisnard <frederic.boisnard@intel.com>
Signed-off-by: David Wagner <david.wagner@intel.com>