### PR TITLE
Output parameter within getNumericalValue not initialized

### DIFF
--- a/parameter/SelectionCriterionType.cpp
+++ b/parameter/SelectionCriterionType.cpp
@@ -80,6 +80,7 @@ bool CSelectionCriterionType::getNumericalValue(const std::string& strValue, int
         uint32_t uiNbValues = astrValues.size();
         int iResult = 0;
         uint32_t uiValueIndex;
+        iValue = 0;
 
         // Looping on each std::string delimited by "|" token and adding the associated value
         for (uiValueIndex = 0; uiValueIndex < uiNbValues; uiValueIndex++) {


### PR DESCRIPTION
When calling getNumericalValue on inclusive criterion, the value
to be outputed is never initialized. The Criterion type will append
the value corresponding to each literal value to the uninitialized value
leading to undefined behavior.

This patch initializes the output value.

Issue: GMINL-6007

Change-Id: Id9fc8b010b4d0b6dfc921825387817789d35e5ba
Signed-off-by: Francois Gaffie <francois.gaffie@intel.com>