### PR TITLE
Parameter manager multithreading usage

### DIFF
--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -88,6 +88,7 @@
 #include "XmlStringDocSource.h"
 #include "XmlMemoryDocSink.h"
 #include "XmlMemoryDocSource.h"
+#include "XmlUtil.h"
 #include "SelectionCriteriaDefinition.h"
 #include "Utility.h"
 #include <sstream>
@@ -2638,4 +2639,9 @@ bool CParameterMgr::exportElementToXMLString(const IXmlSource* pXmlSource,
     }
 
     return bProcessSuccess;
+}
+
+void CParameterMgr::initForMultiThreading()
+{
+    CXmlUtil::initForMultiThreading();
 }

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -353,6 +353,21 @@ public:
 
     // CElement
     virtual std::string getKind() const;
+
+    /**
+     * Call this method at program start in the "main thread" if you plan to use
+     * the parameter manager through several threads
+     *
+     * The "main thread" is a thread that lives until process exit, for instance the
+     * thread that calls the main() method.
+     *
+     * Note: this method doesn't make the parameter manager thread safe, it allows
+     * only to use the parameter framework library by several thread sequentially.
+     *
+     * This call is due to a libxml2 library requirement, which is a dependency
+     * of the parameter manager.
+     */
+    static void initForMultiThreading();
 
 private:
     CParameterMgr(const CParameterMgr&);

--- a/parameter/ParameterMgrPlatformConnector.cpp
+++ b/parameter/ParameterMgrPlatformConnector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -193,4 +193,9 @@ void CParameterMgrPlatformConnector::doLog(bool bIsWarning, const string& strLog
 
         _pLogger->log(bIsWarning, strLog);
     }
+}
+
+void CParameterMgrPlatformConnector::initForMultiThreading()
+{
+    CParameterMgr::initForMultiThreading();
 }

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -155,6 +155,21 @@ public:
      * @return areSchemasValidated
      */
     bool getValidateSchemasOnStart();
+
+    /**
+     * Call this method at program start in the "main thread" if you plan to use
+     * the parameter manager through several threads.
+     *
+     * The "main thread" is a thread that lives until process exit, for instance the
+     * thread that calls the main() method.
+     *
+     * Note: this method doesn't make the parameter manager thread safe, it allows
+     * only to use the parameter framework library by several thread sequentially.
+     *
+     * This call is due to a libxml2 library requirement, which is a dependency
+     * of the parameter manager.
+     */
+    static void initForMultiThreading();
 
 private:
     CParameterMgrPlatformConnector(const CParameterMgrPlatformConnector&);

--- a/xmlserializer/Android.mk
+++ b/xmlserializer/Android.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2014, Intel Corporation
+# Copyright (c) 2011-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -40,7 +40,8 @@ common_src_files := \
         XmlStringDocSink.cpp \
         XmlFileDocSink.cpp \
         XmlFileDocSource.cpp \
-        XmlStringDocSource.cpp
+        XmlStringDocSource.cpp \
+        XmlUtil.cpp
 
 common_module := libxmlserializer
 

--- a/xmlserializer/CMakeLists.txt
+++ b/xmlserializer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -35,7 +35,8 @@ add_library(xmlserializer SHARED
     XmlStringDocSink.cpp
     XmlFileDocSink.cpp
     XmlFileDocSource.cpp
-    XmlStringDocSource.cpp)
+    XmlStringDocSource.cpp
+    XmlUtil.cpp)
 
 include(FindLibXml2)
 if(NOT LIBXML2_FOUND)

--- a/xmlserializer/XmlUtil.cpp
+++ b/xmlserializer/XmlUtil.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "XmlUtil.h"
+#include <libxml/parser.h>
+
+void CXmlUtil::initForMultiThreading()
+{
+    /* xmlInitParser must be called in the main thread if multithreading is required
+     * @see http://xmlsoft.org/threads.html
+     * @see http://www.programmershare.com/1669782/
+     */
+    xmlInitParser();
+}

--- a/xmlserializer/XmlUtil.h
+++ b/xmlserializer/XmlUtil.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+/* Provides miscellaneous utility functions */
+class CXmlUtil
+{
+public:
+    /**
+    * Call this method at program start in the "main thread" if you plan to use
+    * the xml serializer through several threads.
+    *
+    * The "main thread" is a thread that lives until process exit, for instance the
+    * thread that calls the main() method.
+    *
+    * This call is due to a libxml2 library requirement.
+    */
+    static void initForMultiThreading();
+};


### PR DESCRIPTION
The libxml2 library, which is a dependency of
the parameter framework, requires a specific usage
in case of multithreading.

Indeed, if the libxml2 library is used by several
threads, the function xmlInitParser() has to be called
at program start in the main thread (i.e. a thread that
lives until process exit).

This patch introduces a static method "initForMultithreading"
to follow this requirement. The user has to call it at program
start in the main thread if multithreading is used.

Signed-off-by: Thomas Cahuzac <thomasx.cahuzac@intel.com>