### PR TITLE
Fixed point test rework

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -29,7 +29,7 @@
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 
-find_package(PythonLibs)
+find_package(PythonLibs REQUIRED)
 include_directories(${PYTHON_INCLUDE_PATH})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -40,11 +40,6 @@ set_property(SOURCE pfw.i PROPERTY SWIG_FLAGS "-Wall" "-Werror")
 swig_add_module(PyPfw python pfw.i)
 swig_link_libraries(PyPfw parameter ${PYTHON_LIBRARIES})
 
-include(FindPythonLibs)
-if(NOT PYTHONLIBS_FOUND)
-    message(SEND_ERROR "python librarires not found. please instal python
-    development packages")
-endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/parameter/include ${PYTHON_INCLUDE_DIRS})
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -30,9 +30,9 @@ find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 
 find_package(PythonLibs REQUIRED)
-include_directories(${PYTHON_INCLUDE_PATH})
+include_directories(${PYTHON_INCLUDE_DIRS})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${PROJECT_SOURCE_DIR}/parameter/include)
 
 set_property(SOURCE pfw.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE pfw.i PROPERTY SWIG_FLAGS "-Wall" "-Werror")
@@ -40,8 +40,6 @@ set_property(SOURCE pfw.i PROPERTY SWIG_FLAGS "-Wall" "-Werror")
 swig_add_module(PyPfw python pfw.i)
 swig_link_libraries(PyPfw parameter ${PYTHON_LIBRARIES})
 
-
-include_directories(${PROJECT_SOURCE_DIR}/parameter/include ${PYTHON_INCLUDE_DIRS})
 
 # The 'unused-but-set-variable' warning must be disabled because SWIG generates
 # files that do not respect that contraint.

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -49,7 +49,19 @@ swig_link_libraries(PyPfw parameter ${PYTHON_LIBRARIES})
 # class/interface class and as such cannot be destroyed.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable -DSWIG_PYTHON_SILENT_MEMLEAK")
 
-install(TARGETS _PyPfw LIBRARY DESTINATION lib)
+
+# Find the python modules install path.
+# plat_specific is needed because we are installing a shared-library python
+# module and not only a pure python module.
+# prefix='' makes get_python_lib return a relative path.
+find_package(PythonInterp)
+execute_process(COMMAND
+    ${PYTHON_EXECUTABLE} -c
+        "from distutils import sysconfig;\\
+         print(sysconfig.get_python_lib(plat_specific=True, prefix=''))"
+    OUTPUT_VARIABLE PYTHON_MODULE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+install(TARGETS _PyPfw LIBRARY DESTINATION ${PYTHON_MODULE_PATH})
 
 # install the generated Python file as well
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PyPfw.py DESTINATION lib)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PyPfw.py DESTINATION ${PYTHON_MODULE_PATH})

--- a/test/test-fixed-point-parameter/Main.py
+++ b/test/test-fixed-point-parameter/Main.py
@@ -160,7 +160,7 @@ class FixedPointTester():
         returns: the value the parameter-framework returns us after the get
         returns: True if we are able to set, False otherwise
         """
-        (_, firstGet, _) = self._pfwClient.get(self._paramPath)
+        firstGet = self._pfwClient.get(self._paramPath)
 
         try:
             returnValue = Decimal(firstGet)
@@ -201,7 +201,8 @@ class FixedPointTester():
         returns: value the parameter-framework returns us after the second get
         returns: True if we are able to set, False otherwise
         """
-        (_, secondGet, _) = pfw.get(self._paramPath)
+        secondGet = pfw.get(self._paramPath)
+
         if secondGet != valuePreviouslySet:
             return secondGet, False
 
@@ -228,8 +229,12 @@ class PfwClient():
 
     def get(self, parameter):
         (success, value, errorMsg) = self._instance.accessParameterValue(parameter, "", False)
+        if not success:
+            raise Exception("A getParameter failed, which is unexpected. The"
+                            "parameter-framework answered:\n%s" % errorMsg)
+
         print('get %s ---> %s' % (parameter, value))
-        return success, value, errorMsg
+        return value
 
 if __name__ == '__main__':
     # It is necessary to add a ./ in front of the path, otherwise the parameter-framework

--- a/test/test-fixed-point-parameter/Main.py
+++ b/test/test-fixed-point-parameter/Main.py
@@ -90,6 +90,8 @@ class FixedPointTester():
         runSuccess = True
 
         for value in self._shouldWork:
+            value = value.normalize()
+
             print('Testing %s for %s' % (value, self._paramPath))
             value, success = self.checkBounds(value)
             if not success:
@@ -116,6 +118,7 @@ class FixedPointTester():
                 continue
 
         for value in self._shouldBreak:
+            value = value.normalize()
             print('Testing invalid value %s for %s' % (value, self._paramPath))
             value, success = self.checkBounds(value)
             if success:

--- a/test/test-fixed-point-parameter/Main.py
+++ b/test/test-fixed-point-parameter/Main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2.7
 #
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -83,29 +83,35 @@ class FixedPointTester():
                 Decimal(self._upperAllowedBound) + Decimal(littleValue)
                 ]
 
-
     def run(self):
         """ Runs the test suite for a given Qn.m number
         """
+
+        runSuccess = True
+
         for value in self._shouldWork:
             print('Testing %s for %s' % (value, self._paramPath))
             value, success = self.checkBounds(value)
             if not success:
+                runSuccess = False
                 print('Bound ERROR for %s' % self._paramPath)
                 continue
 
             value, success = self.checkSanity(value)
             if not success:
+                runSuccess = False
                 print('Sanity ERROR %s' % self._paramPath)
                 continue
 
             value, success = self.checkConsistency(value)
             if not success:
+                runSuccess = False
                 print('Consistency ERROR %s' % self._paramPath)
                 continue
 
             value, success = self.checkBijectivity(value)
             if not success:
+                runSuccess = False
                 print('Bijectivity ERROR %s' % self._paramPath)
                 continue
 
@@ -113,7 +119,10 @@ class FixedPointTester():
             print('Testing invalid value %s for %s' % (value, self._paramPath))
             value, success = self.checkBounds(value)
             if success:
+                runSuccess = False
                 print("ERROR: This test should have failed but it has not")
+
+        return runSuccess
 
     def checkBounds(self, valueToSet):
         """ Checks if we are able to set valueToSet via the parameter-framework
@@ -232,10 +241,13 @@ if __name__ == '__main__':
     # does not recognize the string as a path.
     configPath = './ParameterFrameworkConfiguration.xml'
 
+    success = True
+
     with PfwClient(configPath) as pfw:
         for size in [8, 16, 32]:
             for integral in range(0,  size):
                 for fractional in range (0,  size - integral):
                     tester = FixedPointTester(pfw, size, integral, fractional)
-                    tester.run()
+                    success = tester.run() and success
 
+    exit(0 if success else 1)

--- a/test/test-fixed-point-parameter/Main.py
+++ b/test/test-fixed-point-parameter/Main.py
@@ -94,6 +94,13 @@ class FixedPointTester():
                 Decimal(self._upperAllowedBound) + Decimal(littleValue)
                 ]
 
+        self._chainingTests = [
+                ('Bound', self.checkBounds),
+                ('Sanity', self.checkSanity),
+                ('Consistency', self.checkConsistency),
+                ('Bijectivity', self.checkBijectivity)]
+
+
     def run(self):
         """ Runs the test suite for a given Qn.m number
         """
@@ -102,31 +109,14 @@ class FixedPointTester():
 
         for value in self._shouldWork:
             value = value.normalize()
-
             print('Testing %s for %s' % (value, self._paramPath))
-            value, success = self.checkBounds(value)
-            if not success:
-                runSuccess = False
-                print('Bound ERROR for %s' % self._paramPath)
-                continue
 
-            value, success = self.checkSanity(value)
-            if not success:
-                runSuccess = False
-                print('Sanity ERROR %s' % self._paramPath)
-                continue
-
-            value, success = self.checkConsistency(value)
-            if not success:
-                runSuccess = False
-                print('Consistency ERROR %s' % self._paramPath)
-                continue
-
-            value, success = self.checkBijectivity(value)
-            if not success:
-                runSuccess = False
-                print('Bijectivity ERROR %s' % self._paramPath)
-                continue
+            for testName, testFunc in self._chainingTests:
+                value, success = testFunc(value)
+                if not success:
+                    runSuccess = False
+                    print("%s ERROR for %s" % (testName, self._paramPath))
+                    break
 
         for value in self._shouldBreak:
             value = value.normalize()

--- a/test/test-fixed-point-parameter/Main.py
+++ b/test/test-fixed-point-parameter/Main.py
@@ -32,6 +32,7 @@ import PyPfw
 
 import logging
 from decimal import Decimal
+from math import log10
 
 class PfwLogger(PyPfw.ILogger):
     def __init__(self):
@@ -85,7 +86,7 @@ class FixedPointTester():
         # bigValue is to be sure a value far out of range is refused
         bigValue = (2 * self._quantum)
         # little is to be sure a value just out of range is refused
-        littleValue  = 10 ** -fractional
+        littleValue = 10 ** -(int(fractional * log10(2)))
         self._shouldBreak = [
                 Decimal(self._lowerAllowedBound) - Decimal(bigValue),
                 Decimal(self._upperAllowedBound) + Decimal(bigValue),


### PR DESCRIPTION
The fixed point test was not returning any error code which made it seem as though it was successful...

In addition to this fix, the test suite now uses the python bindings instead of the remote interface which makes them much faster to execute.

However, some tests are failing in some cases (some incorrect values with high precision are accepted as valid by the parameter-framework).