### PR TITLE
travis: set the installation prefix to /usr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,16 @@ install:
 # how to build
 script:
   - ( mkdir build && cd build &&
-        cmake .. &&
+        cmake -DCMAKE_INSTALL_PREFIX=/usr .. &&
         make -j &&
         sudo make install &&
         CTEST_OUTPUT_ON_FAILURE=1 make test )
   - ( cd skeleton-subsystem &&
-        cmake . &&
+        cmake -DCMAKE_INSTALL_PREFIX=/usr . &&
         make &&
         sudo make install )
   - ( cd build &&
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON .. &&
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON .. &&
         make -j &&
         sudo make install &&
         CTEST_OUTPUT_ON_FAILURE=1 make ExperimentalTest ExperimentalCoverage ExperimentalMemCheck )


### PR DESCRIPTION
CMake defaults to /usr/local which results in libraries being installed in
/usr/local/lib. Unfortunately, this path isn't in the loader's default
locations.

The canonical installation path is /usr. /usr/local is recommended for stuff
not handled by the package manager but in the context of the CI, this isn't
relevant.

Signed-off-by: David Wagner <david.wagner@intel.com>