### PR TITLE
Install c parameter-framework bindings

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -35,6 +35,8 @@ install(FILES ParameterFramework.h
 
 target_link_libraries(cparameter parameter)
 
+install(TARGETS cparameter LIBRARY DESTINATION lib)
+
 if(BUILD_TESTING)
     # Add catch unit test framework
     # TODO Use gtest as it is the team recommendation


### PR DESCRIPTION
C bindings were compiled and tested but never installed.

Add the missing install command.