### PR TITLE
Require PTHREAD using cmake canonic way

### DIFF
--- a/remote-processor/CMakeLists.txt
+++ b/remote-processor/CMakeLists.txt
@@ -37,12 +37,8 @@ add_library(remote-processor SHARED
         RemoteProcessorServerBuilder.cpp)
 
 set(CMAKE_THREAD_PREFER_PTHREAD 1)
-include(FindThreads)
-if(NOT CMAKE_USE_PTHREADS_INIT)
-    message(SEND_ERROR "
-    pthread library not found! Please install the POSIX thread library and
-    headers.")
-endif(NOT CMAKE_USE_PTHREADS_INIT)
+find_package(Threads REQUIRED)
+
 target_link_libraries(remote-processor ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS remote-processor LIBRARY DESTINATION lib)


### PR DESCRIPTION
Pthread was required by included directly findPthread.cmake
then testing for success.

Use the find_package command and require success with the REQUIRED
option.