### PR TITLE
Various minor cleanups

### DIFF
--- a/parameter/ArrayParameter.cpp
+++ b/parameter/ArrayParameter.cpp
@@ -260,7 +260,7 @@ bool CArrayParameter::setValues(uint32_t uiStartIndex, uint32_t uiBaseOffset, co
     Tokenizer tok(strValue, Tokenizer::defaultDelimiters + ",");
 
     std::vector<string> astrValues = tok.split();
-    uint32_t uiNbValues = astrValues.size();
+    size_t uiNbValues = astrValues.size();
 
     // Check number of provided values
     if (uiNbValues + uiStartIndex > getArrayLength()) {

--- a/parameter/BinarySerializableElement.cpp
+++ b/parameter/BinarySerializableElement.cpp
@@ -41,8 +41,8 @@ CBinarySerializableElement::CBinarySerializableElement(const string& strName) : 
 void CBinarySerializableElement::binarySerialize(CBinaryStream& binaryStream)
 {
     // Propagate
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -53,12 +53,12 @@ void CBinarySerializableElement::binarySerialize(CBinaryStream& binaryStream)
 }
 
 // Data size
-uint32_t CBinarySerializableElement::getDataSize() const
+size_t CBinarySerializableElement::getDataSize() const
 {
     // Propagate
-    uint32_t uiDataSize = 0;
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiDataSize = 0;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 

--- a/parameter/BinarySerializableElement.h
+++ b/parameter/BinarySerializableElement.h
@@ -43,6 +43,6 @@ public:
     virtual void binarySerialize(CBinaryStream& binaryStream);
 
     // Data size
-    virtual uint32_t getDataSize() const;
+    virtual size_t getDataSize() const;
 protected:
 };

--- a/parameter/BinaryStream.cpp
+++ b/parameter/BinaryStream.cpp
@@ -33,7 +33,7 @@
 
 using namespace std;
 
-CBinaryStream::CBinaryStream(const string& strFileName, bool bOut, uint32_t uiDataSize, uint8_t uiStructureChecksum) :
+CBinaryStream::CBinaryStream(const string& strFileName, bool bOut, size_t uiDataSize, uint8_t uiStructureChecksum) :
     _strFileName(strFileName),
     _bOut(bOut),
     _uiDataSize(uiDataSize),
@@ -69,10 +69,10 @@ bool CBinaryStream::open(string& strError)
     if (!_bOut) {
 
         // Get file size
-        ifstream::pos_type uiFileSize = _fileStream.tellg();
+        size_t uiFileSize = _fileStream.tellg();
 
         // Validate file size
-        if (_uiDataSize + sizeof(_uiStructureChecksum) != (uint32_t)uiFileSize) {
+        if (_uiDataSize + sizeof(_uiStructureChecksum) != uiFileSize) {
 
             // Size different from expected
             strError = "Unexpected file size";
@@ -136,7 +136,7 @@ void CBinaryStream::reset()
     _uiPos = 0;
 }
 
-void CBinaryStream::write(const uint8_t* puiData, uint32_t uiSize)
+void CBinaryStream::write(const uint8_t* puiData, size_t uiSize)
 {
     assert(_uiPos + uiSize <= _uiDataSize);
 
@@ -145,7 +145,7 @@ void CBinaryStream::write(const uint8_t* puiData, uint32_t uiSize)
     _uiPos += uiSize;
 }
 
-void CBinaryStream::read(uint8_t* puiData, uint32_t uiSize)
+void CBinaryStream::read(uint8_t* puiData, size_t uiSize)
 {
     assert(_uiPos + uiSize <= _uiDataSize);
 

--- a/parameter/BinaryStream.h
+++ b/parameter/BinaryStream.h
@@ -36,7 +36,7 @@
 class CBinaryStream
 {
 public:
-    CBinaryStream(const std::string& strFileName, bool bOut, uint32_t uiDataSize, uint8_t uiStructureChecksum);
+    CBinaryStream(const std::string& strFileName, bool bOut, size_t uiDataSize, uint8_t uiStructureChecksum);
     ~CBinaryStream();
 
     // Open close
@@ -47,8 +47,8 @@ public:
     void reset();
 
     // Read/Write
-    void write(const uint8_t* puiData, uint32_t uiSize);
-    void read(uint8_t* puiData, uint32_t uiSize);
+    void write(const uint8_t* puiData, size_t uiSize);
+    void read(uint8_t* puiData, size_t uiSize);
 
     // Direction
     bool isOut() const;
@@ -63,7 +63,7 @@ private:
     // Serialization direction
     bool _bOut;
     // Data size
-    uint32_t _uiDataSize;
+    size_t _uiDataSize;
     // System structure checksum
     uint8_t _uiStructureChecksum;
     // Read/Write data
@@ -71,7 +71,7 @@ private:
     // File
     std::fstream _fileStream;
     // Ops in faile
-    uint32_t _uiPos;
+    size_t _uiPos;
     // File state
     bool _bOpen;
 };

--- a/parameter/CompoundRule.cpp
+++ b/parameter/CompoundRule.cpp
@@ -96,8 +96,8 @@ void CCompoundRule::dump(string& strResult) const
     strResult += "{";
 
     // Children
-    uint32_t uiChild;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiChild;
+    size_t uiNbChildren = getNbChildren();
     bool bFirst = true;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
@@ -121,8 +121,8 @@ void CCompoundRule::dump(string& strResult) const
 // Rule check
 bool CCompoundRule::matches() const
 {
-    uint32_t uiChild;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiChild;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 

--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -190,8 +190,8 @@ void CConfigurableDomain::composeSettings(CXmlElement& xmlElement, CXmlSerializi
     xmlElement.createChild(xmlSettingsElement, "Settings");
 
     // Serialize out all configurations settings
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChildConfiguration;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChildConfiguration;
 
     for (uiChildConfiguration = 0; uiChildConfiguration < uiNbConfigurations; uiChildConfiguration++) {
 
@@ -466,7 +466,7 @@ bool CConfigurableDomain::split(CConfigurableElement* pConfigurableElement, stri
     log_info("Splitting configurable element \"%s\" domain \"%s\"", pConfigurableElement->getPath().c_str(), getName().c_str());
 
     // Create sub domain areas for all configurable element's children
-    uint32_t uiNbConfigurableElementChildren = pConfigurableElement->getNbChildren();
+    size_t uiNbConfigurableElementChildren = pConfigurableElement->getNbChildren();
 
     if (!uiNbConfigurableElementChildren) {
 
@@ -475,7 +475,7 @@ bool CConfigurableDomain::split(CConfigurableElement* pConfigurableElement, stri
         return false;
     }
 
-    uint32_t uiChild;
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurableElementChildren; uiChild++) {
 
@@ -485,7 +485,7 @@ bool CConfigurableDomain::split(CConfigurableElement* pConfigurableElement, stri
     }
 
     // Delegate to configurations
-    uint32_t uiNbConfigurations = getNbChildren();
+    size_t uiNbConfigurations = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -833,8 +833,8 @@ void CConfigurableDomain::validate(const CParameterBlackboard* pMainBlackboard)
 {
 
     // Propagate
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -850,8 +850,8 @@ void CConfigurableDomain::validateAreas(const CConfigurableElement* pConfigurabl
     log_info("Validating domain \"" + getName() + "\" against main blackboard for configurable element \"" + pConfigurableElement->getPath() + "\"");
 
     // Propagate
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -890,8 +890,8 @@ void CConfigurableDomain::autoValidateAreas(const CConfigurableElement* pConfigu
     }
 
     // Validate all other configurations against found one, if any
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -908,8 +908,8 @@ void CConfigurableDomain::autoValidateAreas(const CConfigurableElement* pConfigu
 bool CConfigurableDomain::autoValidateConfiguration(CDomainConfiguration* pDomainConfiguration)
 {
     // Find another configuration than this one, that ought to be valid!
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -929,8 +929,8 @@ bool CConfigurableDomain::autoValidateConfiguration(CDomainConfiguration* pDomai
 // Search for a valid configuration for given configurable element
 const CDomainConfiguration* CConfigurableDomain::findValidDomainConfiguration(const CConfigurableElement* pConfigurableElement) const
 {
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -947,8 +947,8 @@ const CDomainConfiguration* CConfigurableDomain::findValidDomainConfiguration(co
 // Search for an applicable configuration
 const CDomainConfiguration* CConfigurableDomain::findApplicableDomainConfiguration() const
 {
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -1023,8 +1023,8 @@ void CConfigurableDomain::mergeAlreadyAssociatedDescendantConfigurableElements(C
 void CConfigurableDomain::mergeConfigurations(CConfigurableElement* pToConfigurableElement, CConfigurableElement* pFromConfigurableElement)
 {
     // Propagate to domain configurations
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -1054,8 +1054,8 @@ void CConfigurableDomain::doAddConfigurableElement(CConfigurableElement* pConfig
     _syncerSet += *pSyncerSet;
 
     // Inform configurations
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
@@ -1094,8 +1094,8 @@ void CConfigurableDomain::doRemoveConfigurableElement(CConfigurableElement* pCon
     pConfigurableElement->removeAttachedConfigurableDomain(this);
 
     // Inform configurations
-    uint32_t uiNbConfigurations = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurations = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 

--- a/parameter/ConfigurableDomains.cpp
+++ b/parameter/ConfigurableDomains.cpp
@@ -56,8 +56,8 @@ bool CConfigurableDomains::childrenAreDynamic() const
 void CConfigurableDomains::validate(const CParameterBlackboard* pMainBlackboard)
 {
     // Delegate to domains
-    uint32_t uiChild;
-    uint32_t uiNbConfigurableDomains = getNbChildren();
+    size_t uiChild;
+    size_t uiNbConfigurableDomains = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbConfigurableDomains; uiChild++) {
 
@@ -75,8 +75,8 @@ void CConfigurableDomains::apply(CParameterBlackboard* pParameterBlackboard, CSy
     /// Delegate to domains
 
     // Start with domains that can be synchronized all at once (with passed syncer set)
-    uint32_t uiChild;
-    uint32_t uiNbConfigurableDomains = getNbChildren();
+    size_t uiChild;
+    size_t uiNbConfigurableDomains = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbConfigurableDomains; uiChild++) {
 
@@ -364,8 +364,8 @@ void CConfigurableDomains::listDomains(string& strResult) const
     strResult = "\n";
 
     // List domains
-    uint32_t uiChild;
-    uint32_t uiNbConfigurableDomains = getNbChildren();
+    size_t uiChild;
+    size_t uiNbConfigurableDomains = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbConfigurableDomains; uiChild++) {
 
@@ -387,8 +387,8 @@ void CConfigurableDomains::listDomains(string& strResult) const
 void CConfigurableDomains::gatherAllOwnedConfigurableElements(std::set<const CConfigurableElement*>& configurableElementSet) const
 {
     // Delegate to domains
-    uint32_t uiChild;
-    uint32_t uiNbConfigurableDomains = getNbChildren();
+    size_t uiChild;
+    size_t uiNbConfigurableDomains = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbConfigurableDomains; uiChild++) {
 
@@ -498,8 +498,8 @@ bool CConfigurableDomains::getApplicationRule(const string& strDomain, const str
 void CConfigurableDomains::listLastAppliedConfigurations(string& strResult) const
 {
     // Browse domains
-    uint32_t uiChild;
-    uint32_t uiNbConfigurableDomains = getNbChildren();
+    size_t uiChild;
+    size_t uiNbConfigurableDomains = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbConfigurableDomains; uiChild++) {
 

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -49,8 +49,8 @@ CConfigurableElement::~CConfigurableElement()
 // XML configuration settings parsing
 bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const
 {
-    uint32_t uiIndex;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiIndex;
+    size_t uiNbChildren = getNbChildren();
 
     if (!configurationAccessContext.serializeOut()) {
         // Just do basic checks and propagate to children
@@ -174,8 +174,8 @@ void CConfigurableElement::getListOfElementsWithMapping(
 void CConfigurableElement::setDefaultValues(CParameterAccessContext& parameterAccessContext) const
 {
     // Propagate to children
-    uint32_t uiIndex;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiIndex;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiIndex = 0; uiIndex < uiNbChildren; uiIndex++) {
 
@@ -200,8 +200,8 @@ void CConfigurableElement::setOffset(uint32_t uiOffset)
     _uiOffset = uiOffset;
 
     // Propagate to children
-    uint32_t uiIndex;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiIndex;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiIndex = 0; uiIndex < uiNbChildren; uiIndex++) {
 
@@ -222,8 +222,8 @@ uint32_t CConfigurableElement::getOffset() const
 uint32_t CConfigurableElement::getFootPrint() const
 {
     uint32_t uiSize = 0;
-    uint32_t uiIndex;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiIndex;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiIndex = 0; uiIndex < uiNbChildren; uiIndex++) {
 
@@ -270,8 +270,8 @@ void CConfigurableElement::fillSyncerSet(CSyncerSet& syncerSet) const
 void CConfigurableElement::fillSyncerSetFromDescendant(CSyncerSet& syncerSet) const
 {
     // Dig
-    uint32_t uiIndex;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiIndex;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiIndex = 0; uiIndex < uiNbChildren; uiIndex++) {
 
@@ -401,7 +401,7 @@ void CConfigurableElement::listAssociatedDomains(std::string& strResult, bool bV
     listDomains(_configurableDomainList, strResult, bVertical);
 }
 
-uint32_t CConfigurableElement::getBelongingDomainCount() const
+size_t CConfigurableElement::getBelongingDomainCount() const
 {
     // Get belonging domain list
     std::list<const CConfigurableDomain*> configurableDomainList;

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -74,7 +74,7 @@ public:
 
     // Owning domains
     void listAssociatedDomains(std::string& strResult, bool bVertical = true) const;
-    uint32_t getBelongingDomainCount() const;
+    size_t getBelongingDomainCount() const;
 
     // Elements with no domains
     void listRogueElements(std::string& strResult) const;

--- a/parameter/ConfigurableElementAggregator.cpp
+++ b/parameter/ConfigurableElementAggregator.cpp
@@ -52,9 +52,9 @@ bool CConfigurableElementAggregator::doAggregate(const CConfigurableElement* pCo
     // Check children
     std::list<const CConfigurableElement*> childAggregateElementList;
 
-    uint32_t uiIndex;
-    uint32_t uiNbChildren = pConfigurableElement->getNbChildren();
-    uint32_t uiNbMatchingChildren = 0;
+    size_t uiIndex;
+    size_t uiNbChildren = pConfigurableElement->getNbChildren();
+    size_t uiNbMatchingChildren = 0;
 
     for (uiIndex = 0; uiIndex < uiNbChildren; uiIndex++) {
 

--- a/parameter/ConfigurableElementAggregator.h
+++ b/parameter/ConfigurableElementAggregator.h
@@ -29,10 +29,10 @@
  */
 #pragma once
 
+#include "ConfigurableElement.h"
 #include <list>
 #include <string>
 
-class CConfigurableElement;
 
 class CConfigurableElementAggregator
 {

--- a/parameter/DomainConfiguration.cpp
+++ b/parameter/DomainConfiguration.cpp
@@ -477,8 +477,8 @@ void CDomainConfiguration::split(CConfigurableElement* pFromConfigurableElement)
     const CAreaConfiguration* pAreaConfigurationToSplitFrom = getAreaConfiguration(pFromConfigurableElement);
 
     // Go through children areas to copy configuration data to them
-    uint32_t uiNbConfigurableElementChildren = pFromConfigurableElement->getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbConfigurableElementChildren = pFromConfigurableElement->getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbConfigurableElementChildren; uiChild++) {
 
@@ -675,9 +675,9 @@ void CDomainConfiguration::binarySerialize(CBinaryStream& binaryStream)
 }
 
 // Data size
-uint32_t CDomainConfiguration::getDataSize() const
+size_t CDomainConfiguration::getDataSize() const
 {
-    uint32_t uiDataSize;
+    size_t uiDataSize;
 
     // Add necessary size to store area configurations order
     uiDataSize = _areaConfigurationList.size() * sizeof(uint32_t);

--- a/parameter/DomainConfiguration.h
+++ b/parameter/DomainConfiguration.h
@@ -96,7 +96,7 @@ public:
     virtual void binarySerialize(CBinaryStream& binaryStream);
 
     // Data size
-    virtual uint32_t getDataSize() const;
+    virtual size_t getDataSize() const;
 
     // Class kind
     virtual std::string getKind() const;

--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -296,8 +296,8 @@ void CElement::childrenToXml(CXmlElement& xmlElement,
                              CXmlSerializingContext& serializingContext) const
 {
     // Browse children and propagate
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -346,8 +346,8 @@ bool CElement::rename(const string& strName, string& strError)
     // Check for conflict with brotherhood if relevant
     if (_pParent && _pParent->childrenAreDynamic()) {
 
-        uint32_t uiParentChild;
-        uint32_t uiParentNbChildren = _pParent->getNbChildren();
+        size_t uiParentChild;
+        size_t uiParentNbChildren = _pParent->getNbChildren();
 
         for (uiParentChild = 0; uiParentChild < uiParentNbChildren; uiParentChild++) {
 
@@ -387,14 +387,14 @@ void CElement::addChild(CElement* pChild)
     pChild->_pParent = this;
 }
 
-CElement* CElement::getChild(uint32_t uiIndex)
+CElement* CElement::getChild(size_t uiIndex)
 {
     assert(uiIndex <= _childArray.size());
 
     return _childArray[uiIndex];
 }
 
-const CElement* CElement::getChild(uint32_t uiIndex) const
+const CElement* CElement::getChild(size_t uiIndex) const
 {
     assert(uiIndex <= _childArray.size());
 
@@ -403,7 +403,7 @@ const CElement* CElement::getChild(uint32_t uiIndex) const
 
 CElement* CElement::getLastChild()
 {
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiNbChildren = getNbChildren();
 
     assert(uiNbChildren);
 
@@ -456,8 +456,8 @@ void CElement::listChildren(string& strChildList) const
     strChildList = "\n";
 
     // Get list of children names
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -469,7 +469,7 @@ void CElement::listChildren(string& strChildList) const
 
 string CElement::listQualifiedPaths(bool bDive, uint32_t uiLevel) const
 {
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiNbChildren = getNbChildren();
     string strResult;
 
     // Dive Will cause only leaf nodes to be printed
@@ -480,7 +480,7 @@ string CElement::listQualifiedPaths(bool bDive, uint32_t uiLevel) const
 
     if (bDive || !uiLevel) {
         // Get list of children paths
-        uint32_t uiChild;
+        size_t uiChild;
 
         for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -495,8 +495,8 @@ string CElement::listQualifiedPaths(bool bDive, uint32_t uiLevel) const
 void CElement::listChildrenPaths(string& strChildList) const
 {
     // Get list of children paths
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -506,7 +506,7 @@ void CElement::listChildrenPaths(string& strChildList) const
     }
 }
 
-uint32_t CElement::getNbChildren() const
+size_t CElement::getNbChildren() const
 {
     return _childArray.size();
 }
@@ -741,7 +741,7 @@ void CElement::appendTitle(string& strTo, const string& strTitle)
 {
     strTo += "\n" + strTitle + "\n";
 
-    uint32_t uiLength = strTitle.size();
+    string::size_type uiLength = strTitle.size();
 
     while (uiLength--) {
 

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -76,12 +76,31 @@ public:
     void listChildrenPaths(std::string& strChildPathList) const;
 
     // Hierarchy query
-    uint32_t getNbChildren() const;
+    size_t getNbChildren() const;
     CElement* findChildOfKind(const std::string& strKind);
     const CElement* findChildOfKind(const std::string& strKind) const;
     const CElement* getParent() const;
-    const CElement* getChild(uint32_t uiIndex) const;
-    CElement* getChild(uint32_t uiIndex);
+
+    /**
+     * Get a child element (const)
+     *
+     * Note: this method will assert if given a wrong child index (>= number of children)
+     *
+     * @param[in] uiIndex the index of the child element from 0 to number of children - 1
+     * @return the child element
+     */
+    const CElement* getChild(size_t uiIndex) const;
+
+    /**
+     * Get a child element
+     *
+     * Note: this method will assert if given a wrong child index (>= number of children)
+     *
+     * @param[in] uiIndex the index of the child element from 0 to number of children - 1
+     * @return the child element
+     */
+    CElement* getChild(size_t uiIndex);
+
     const CElement* findChild(const std::string& strName) const;
     CElement* findChild(const std::string& strName);
     const CElement* findDescendant(CPathNavigator& pathNavigator) const;

--- a/parameter/EnumParameterType.cpp
+++ b/parameter/EnumParameterType.cpp
@@ -63,8 +63,8 @@ void CEnumParameterType::showProperties(string& strResult) const
     strResult += "Value Pairs:\n";
 
     // Show all value pairs
-    uint32_t uiChild;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiChild;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -281,8 +281,8 @@ bool CEnumParameterType::isNumber(const string& strValue)
 // Literal - numerical conversions
 bool CEnumParameterType::getLiteral(int32_t iNumerical, string& strLiteral) const
 {
-    uint32_t uiChild;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiChild;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -301,8 +301,8 @@ bool CEnumParameterType::getLiteral(int32_t iNumerical, string& strLiteral) cons
 
 bool CEnumParameterType::getNumerical(const string& strLiteral, int& iNumerical) const
 {
-    uint32_t uiChild;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiChild;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -323,8 +323,8 @@ bool CEnumParameterType::getNumerical(const string& strLiteral, int& iNumerical)
 bool CEnumParameterType::isValid(int iNumerical, CParameterAccessContext& parameterAccessContext) const
 {
     // Check that the value is part of the allowed values for this kind of enum
-    uint32_t uiChild;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiChild;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 

--- a/parameter/FormattedSubsystemObject.cpp
+++ b/parameter/FormattedSubsystemObject.cpp
@@ -92,7 +92,7 @@ string CFormattedSubsystemObject::formatMappingValue(const string& strMappingVal
     string strFormattedValue = strMappingValue;
 
     // Search for amendment (only one supported for now)
-    size_t uiPercentPos = strFormattedValue.find('%', 0);
+    string::size_type uiPercentPos = strFormattedValue.find('%', 0);
 
     // Amendment limited to one digit (values from 1 to 9)
     assert(isAmendKeyValid(uiNbAmendKeys));

--- a/parameter/InstanceConfigurableElement.cpp
+++ b/parameter/InstanceConfigurableElement.cpp
@@ -82,8 +82,8 @@ bool CInstanceConfigurableElement::map(IMapper& mapper, std::string& strError)
     if (bKeepDiving) {
 
         // Map children
-        uint32_t uiNbChildren = getNbChildren();
-        uint32_t uiChild;
+        size_t uiNbChildren = getNbChildren();
+        size_t uiChild;
 
         for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 

--- a/parameter/MappingContext.cpp
+++ b/parameter/MappingContext.cpp
@@ -34,7 +34,7 @@
 
 using std::string;
 
-CMappingContext::CMappingContext(uint32_t uiNbItemTypes) : _pstItemArray(new CMappingContext::SItem[uiNbItemTypes]), _uiNbItemTypes(uiNbItemTypes)
+CMappingContext::CMappingContext(size_t uiNbItemTypes) : _pstItemArray(new CMappingContext::SItem[uiNbItemTypes]), _uiNbItemTypes(uiNbItemTypes)
 {
     // Clear items
     memset(_pstItemArray, 0, sizeof(*_pstItemArray) * uiNbItemTypes);
@@ -76,7 +76,7 @@ CMappingContext& CMappingContext::operator=(const CMappingContext& right)
 // Item access
 bool CMappingContext::setItem(uint32_t uiItemType, const string* pStrKey, const string* pStrItem)
 {
-    uint32_t uiIndex;
+    size_t uiIndex;
 
     // Do some checks
     for (uiIndex = 0; uiIndex < _uiNbItemTypes; uiIndex++) {
@@ -120,7 +120,7 @@ uint32_t CMappingContext::getItemAsInteger(uint32_t uiItemType) const
 
 const string* CMappingContext::getItem(const string& strKey) const
 {
-    uint32_t uiItemType;
+    size_t uiItemType;
 
     for (uiItemType = 0; uiItemType < _uiNbItemTypes; uiItemType++) {
 

--- a/parameter/MappingContext.h
+++ b/parameter/MappingContext.h
@@ -43,7 +43,7 @@ class CMappingContext
 
 public:
     // Regular Constructor
-    CMappingContext(uint32_t uiNbItemTypes);
+    CMappingContext(size_t uiNbItemTypes);
     ~CMappingContext();
 
     // Copy constructor
@@ -79,6 +79,6 @@ private:
     // Item array
     SItem* _pstItemArray;
     // Items array size
-    uint32_t _uiNbItemTypes;
+    size_t _uiNbItemTypes;
 };
 

--- a/parameter/ParameterBlackboard.cpp
+++ b/parameter/ParameterBlackboard.cpp
@@ -99,14 +99,14 @@ void CParameterBlackboard::readInteger(void* pvDstData, uint32_t uiSize, uint32_
     }
 }
 
-void CParameterBlackboard::writeString(const char* pcSrcData, uint32_t uiOffset)
+void CParameterBlackboard::writeString(const std::string &input, uint32_t uiOffset)
 {
-    strcpy((char*)_pucData + uiOffset, pcSrcData);
+    strcpy((char*)_pucData + uiOffset, input.c_str());
 }
 
-void CParameterBlackboard::readString(char* pcDstData, uint32_t uiOffset) const
+void CParameterBlackboard::readString(std::string &output, uint32_t uiOffset) const
 {
-    strcpy(pcDstData, (const char*)_pucData + uiOffset);
+    output = std::string((const char*)_pucData + uiOffset);
 }
 
 // Access from/to subsystems

--- a/parameter/ParameterBlackboard.h
+++ b/parameter/ParameterBlackboard.h
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 #include "BinaryStream.h"
+#include <string>
 
 class CParameterBlackboard
 {
@@ -45,8 +46,8 @@ public:
     // Single parameter access
     void writeInteger(const void* pvSrcData, uint32_t uiSize, uint32_t uiOffset, bool bBigEndian);
     void readInteger(void* pvDstData, uint32_t uiSize, uint32_t uiOffset, bool bBigEndian) const;
-    void writeString(const char* pcSrcData, uint32_t uiOffset);
-    void readString(char* pcDstData, uint32_t uiOffset) const;
+    void writeString(const std::string &input, uint32_t uiOffset);
+    void readString(std::string &output, uint32_t uiOffset) const;
 
     // Access from/to subsystems
     uint8_t* getLocation(uint32_t uiOffset);

--- a/parameter/ParameterBlockType.cpp
+++ b/parameter/ParameterBlockType.cpp
@@ -58,7 +58,7 @@ void CParameterBlockType::populate(CElement* pElement) const
     if (uiArrayLength) {
 
         // Create child elements
-        uint32_t uiChild;
+        size_t uiChild;
 
         for (uiChild = 0; uiChild < uiArrayLength; uiChild++) {
 

--- a/parameter/ParameterBlockType.h
+++ b/parameter/ParameterBlockType.h
@@ -47,6 +47,6 @@ private:
     // Population
     virtual void populate(CElement* pElement) const;
     // Creating sub blocks with indexes
-    static std::string computeChildName(uint32_t uiChild);
+    static std::string computeChildName(size_t uiChild);
 };
 

--- a/parameter/ParameterHandle.cpp
+++ b/parameter/ParameterHandle.cpp
@@ -436,7 +436,7 @@ bool CParameterHandle::getAsString(string& strValue, string& strError) const
 bool CParameterHandle::setAsStringArray(const std::vector<string>& astrValues, string& strError)
 {
     // Check operation validity
-    if (!checkAccessValidity(true, astrValues.size(), strError)) {
+    if (!checkAccessValidity(true, (uint32_t)astrValues.size(), strError)) {
 
         return false;
     }
@@ -475,7 +475,7 @@ bool CParameterHandle::getAsStringArray(std::vector<string>& astrValues, string&
 }
 
 // Access validity
-bool CParameterHandle::checkAccessValidity(bool bSet, uint32_t uiArrayLength, string& strError) const
+bool CParameterHandle::checkAccessValidity(bool bSet, size_t uiArrayLength, string& strError) const
 {
     if (bSet && !isRogue()) {
 

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -52,7 +52,6 @@ class CSystemClassConfiguration;
 class CParameterBlackboard;
 class CConfigurableDomains;
 class IRemoteProcessorServerInterface;
-class CBackSynchronizer;
 class CParameterHandle;
 class CSubsystemPlugins;
 class CParameterAccessContext;
@@ -572,9 +571,6 @@ private:
 
     // Remote Processor Server connection handling
     bool handleRemoteProcessingInterface(std::string& strError);
-
-    // Back synchronization
-    CBackSynchronizer* createBackSynchronizer() const;
 
     // Tuning
     bool _bTuningModeIsOn;

--- a/parameter/RuleParser.cpp
+++ b/parameter/RuleParser.cpp
@@ -148,26 +148,26 @@ bool CRuleParser::parse(CCompoundRule* pParentRule, string& strError)
 // Iterate
 bool CRuleParser::iterate(string& strError)
 {
-    string::size_type iDelimiter;
+    string::size_type delimiter;
 
     assert(_uiCurrentPos <= _strApplicationRule.length());
 
     // Consume spaces
-    if ((iDelimiter = _strApplicationRule.find_first_not_of(" ", _uiCurrentPos)) != string::npos) {
+    if ((delimiter = _strApplicationRule.find_first_not_of(" ", _uiCurrentPos)) != string::npos) {
 
         // New pos
-        _uiCurrentPos = iDelimiter;
+        _uiCurrentPos = delimiter;
     }
 
     // Parse
-    if ((_uiCurrentPos != _strApplicationRule.length()) && ((iDelimiter = _strApplicationRule.find_first_of(_acDelimiters[_eStatus], _uiCurrentPos)) != string::npos)) {
+    if ((_uiCurrentPos != _strApplicationRule.length()) && ((delimiter = _strApplicationRule.find_first_of(_acDelimiters[_eStatus], _uiCurrentPos)) != string::npos)) {
 
-        switch(_strApplicationRule[iDelimiter]) {
+        switch(_strApplicationRule[delimiter]) {
 
         case '{':
             _eStatus = EBeginCompoundRule;
             // Extract type
-            _strRuleType = _strApplicationRule.substr(_uiCurrentPos, iDelimiter - _uiCurrentPos);
+            _strRuleType = _strApplicationRule.substr(_uiCurrentPos, delimiter - _uiCurrentPos);
             _uiCurrentDeepness++;
             break;
         case '}':
@@ -183,14 +183,14 @@ bool CRuleParser::iterate(string& strError)
         case ' ':
             _eStatus = ECriterionRule;
             // Extract type
-            _strRuleType = _strApplicationRule.substr(_uiCurrentPos, iDelimiter - _uiCurrentPos);
+            _strRuleType = _strApplicationRule.substr(_uiCurrentPos, delimiter - _uiCurrentPos);
             break;
         case ',':
             _eStatus = EContinue;
             break;
         }
         // New pos
-        _uiCurrentPos = iDelimiter + 1;
+        _uiCurrentPos = delimiter + 1;
     } else {
 
         if (_uiCurrentDeepness) {
@@ -240,26 +240,26 @@ CCompoundRule* CRuleParser::grabRootRule()
 // Next word
 bool CRuleParser::next(string& strNext, string& strError)
 {
-    string::size_type iDelimiter;
+    string::size_type delimiter;
 
     // Consume spaces
-    if ((iDelimiter = _strApplicationRule.find_first_not_of(" ", _uiCurrentPos)) != string::npos) {
+    if ((delimiter = _strApplicationRule.find_first_not_of(" ", _uiCurrentPos)) != string::npos) {
 
         // New pos
-        _uiCurrentPos = iDelimiter;
+        _uiCurrentPos = delimiter;
     }
 
-    if ((iDelimiter = _strApplicationRule.find_first_of("{} ,", _uiCurrentPos)) == string::npos) {
+    if ((delimiter = _strApplicationRule.find_first_of("{} ,", _uiCurrentPos)) == string::npos) {
 
         strError = "Syntax error";
 
         return false;
     }
 
-    strNext = _strApplicationRule.substr(_uiCurrentPos, iDelimiter - _uiCurrentPos);
+    strNext = _strApplicationRule.substr(_uiCurrentPos, delimiter - _uiCurrentPos);
 
     // New pos
-    _uiCurrentPos = iDelimiter;
+    _uiCurrentPos = delimiter;
 
     return true;
 }

--- a/parameter/RuleParser.h
+++ b/parameter/RuleParser.h
@@ -78,8 +78,8 @@ private:
     std::string _strApplicationRule;
     // Criteria defintion
     const CSelectionCriteriaDefinition* _pSelectionCriteriaDefinition;
-    // Iterator
-    uint32_t _uiCurrentPos;
+    /** String iterator */
+    std::string::size_type _uiCurrentPos;
     // Deepness
     uint32_t _uiCurrentDeepness;
     // Current Type

--- a/parameter/SelectionCriteriaDefinition.cpp
+++ b/parameter/SelectionCriteriaDefinition.cpp
@@ -64,8 +64,8 @@ CSelectionCriterion* CSelectionCriteriaDefinition::getSelectionCriterion(const s
 void CSelectionCriteriaDefinition::listSelectionCriteria(std::list<std::string>& lstrResult, bool bWithTypeInfo, bool bHumanReadable) const
 {
     // Propagate
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -79,8 +79,8 @@ void CSelectionCriteriaDefinition::listSelectionCriteria(std::list<std::string>&
 void CSelectionCriteriaDefinition::resetModifiedStatus()
 {
     // Propagate
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
     CSelectionCriterion* pSelectionCriterion;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {

--- a/parameter/SelectionCriterionType.cpp
+++ b/parameter/SelectionCriterionType.cpp
@@ -77,9 +77,9 @@ bool CSelectionCriterionType::getNumericalValue(const std::string& strValue, int
 
         Tokenizer tok(strValue, _strDelimiter);
         std::vector<std::string> astrValues = tok.split();
-        uint32_t uiNbValues = astrValues.size();
+        size_t uiNbValues = astrValues.size();
         int iResult = 0;
-        uint32_t uiValueIndex;
+        size_t uiValueIndex;
         iValue = 0;
 
         // Looping on each std::string delimited by "|" token and adding the associated value

--- a/parameter/StringParameter.cpp
+++ b/parameter/StringParameter.cpp
@@ -32,7 +32,6 @@
 #include "ParameterAccessContext.h"
 #include "ConfigurationAccessContext.h"
 #include "ParameterBlackboard.h"
-#include <alloca.h>
 
 #define base CBaseParameter
 
@@ -79,19 +78,12 @@ bool CStringParameter::doSetValue(const string& strValue, uint32_t uiOffset, CPa
     // Write blackboard
     CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
 
-    pBlackboard->writeString(strValue.c_str(), uiOffset);
+    pBlackboard->writeString(strValue, uiOffset);
 
     return true;
 }
 
 void CStringParameter::doGetValue(string& strValue, uint32_t uiOffset, CParameterAccessContext& parameterAccessContext) const
 {
-    char* pcValue = (char*)alloca(getSize());
-
-    // Read blackboard
-    const CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
-
-    pBlackboard->readString(pcValue, uiOffset);
-
-    strValue = pcValue;
+    parameterAccessContext.getParameterBlackboard()->readString(strValue, uiOffset);
 }

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -175,8 +175,8 @@ bool CSubsystem::mapSubsystemElements(string& strError)
     _contextStack.push(context);
 
     // Map all instantiated subelements in subsystem
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 

--- a/parameter/SystemClass.cpp
+++ b/parameter/SystemClass.cpp
@@ -279,8 +279,8 @@ const CSubsystemLibrary* CSystemClass::getSubsystemLibrary() const
 
 void CSystemClass::checkForSubsystemsToResync(CSyncerSet& syncerSet)
 {
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
@@ -298,8 +298,8 @@ void CSystemClass::checkForSubsystemsToResync(CSyncerSet& syncerSet)
 
 void CSystemClass::cleanSubsystemsNeedToResync()
 {
-    uint32_t uiNbChildren = getNbChildren();
-    uint32_t uiChild;
+    size_t uiNbChildren = getNbChildren();
+    size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 

--- a/parameter/TypeElement.cpp
+++ b/parameter/TypeElement.cpp
@@ -83,8 +83,8 @@ void CTypeElement::showProperties(std::string& strResult) const
 void CTypeElement::populate(CElement* pElement) const
 {
     // Populate children
-    uint32_t uiChild;
-    uint32_t uiNbChildren = getNbChildren();
+    size_t uiChild;
+    size_t uiNbChildren = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 

--- a/parameter/XmlFileIncluderElement.cpp
+++ b/parameter/XmlFileIncluderElement.cpp
@@ -38,10 +38,9 @@
 #define base CKindElement
 CXmlFileIncluderElement::CXmlFileIncluderElement(const std::string& strName,
                                                  const std::string& strKind,
-                                                 bool bValidateWithSchemas) : base(strName,
-                                                                                   strKind)
+                                                 bool bValidateWithSchemas)
+    : base(strName, strKind), _bValidateSchemasOnStart(bValidateWithSchemas)
 {
-    _bValidateSchemasOnStart = bValidateWithSchemas;
 }
 
 // From IXmlSink

--- a/parameter/XmlFileIncluderElement.cpp
+++ b/parameter/XmlFileIncluderElement.cpp
@@ -119,9 +119,9 @@ std::string CXmlFileIncluderElement::getIncludedElementType() const
 {
     std::string strKind = getKind();
 
-    int iPosToRemoveFrom = strKind.rfind("Include", -1);
+    std::string::size_type pos = strKind.rfind("Include", std::string::npos);
 
-    assert(iPosToRemoveFrom != -1);
+    assert(pos != std::string::npos);
 
-    return strKind.substr(0, iPosToRemoveFrom);
+    return strKind.substr(0, pos);
 }

--- a/parameter/include/ParameterHandle.h
+++ b/parameter/include/ParameterHandle.h
@@ -92,7 +92,7 @@ public:
 
 private:
     // Access validity
-    bool checkAccessValidity(bool bSet, uint32_t uiArrayLength, std::string& strError) const;
+    bool checkAccessValidity(bool bSet, size_t uiArrayLength, std::string& strError) const;
 
     // Accessed parameter instance
     const CBaseParameter* _pBaseParameter;

--- a/remote-processor/AnswerMessage.cpp
+++ b/remote-processor/AnswerMessage.cpp
@@ -61,7 +61,7 @@ bool CAnswerMessage::success() const
 }
 
 // Size
-uint32_t CAnswerMessage::getDataSize() const
+size_t CAnswerMessage::getDataSize() const
 {
     // Answer
     return getStringSize(getAnswer());

--- a/remote-processor/AnswerMessage.h
+++ b/remote-processor/AnswerMessage.h
@@ -47,8 +47,10 @@ private:
     virtual void fillDataToSend();
     // Collect received data
     virtual void collectReceivedData();
-    // Size
-    virtual uint32_t getDataSize() const;
+
+    /** @return size of the answer message in bytes
+    */
+    virtual size_t getDataSize() const;
     // Answer
     void setAnswer(const std::string& strAnswer);
 

--- a/remote-processor/Message.cpp
+++ b/remote-processor/Message.cpp
@@ -57,7 +57,7 @@ uint8_t CMessage::getMsgId() const
 }
 
 // Data
-void CMessage::writeData(const void* pvData, uint32_t uiSize)
+void CMessage::writeData(const void* pvData, size_t uiSize)
 {
     assert(_uiIndex + uiSize <= _uiDataSize);
 
@@ -68,7 +68,7 @@ void CMessage::writeData(const void* pvData, uint32_t uiSize)
     _uiIndex += uiSize;
 }
 
-void CMessage::readData(void* pvData, uint32_t uiSize)
+void CMessage::readData(void* pvData, size_t uiSize)
 {
     assert(_uiIndex + uiSize <= _uiDataSize);
 
@@ -110,14 +110,14 @@ void CMessage::readString(string& strData)
     strData = pcData;
 }
 
-uint32_t CMessage::getStringSize(const string& strData) const
+size_t CMessage::getStringSize(const string& strData) const
 {
     // Return string length plus room to store its length
     return strData.length() + sizeof(uint32_t);
 }
 
 // Remaining data size
-uint32_t CMessage::getRemainingDataSize() const
+size_t CMessage::getRemainingDataSize() const
 {
     return _uiDataSize - _uiIndex;
 }
@@ -148,7 +148,7 @@ CMessage::Result CMessage::serialize(CSocket* pSocket, bool bOut, string& strErr
         }
 
         // Size
-        uint32_t uiSize = sizeof(_ucMsgId) + _uiDataSize;
+        uint32_t uiSize = (uint32_t)(sizeof(_ucMsgId) + _uiDataSize);
 
         if (!pSocket->write(&uiSize, sizeof(uiSize))) {
 
@@ -264,8 +264,8 @@ uint8_t CMessage::computeChecksum() const
     return uiChecksum;
 }
 
-// Data allocation
-void CMessage::allocateData(uint32_t uiSize)
+// Allocation of room to store the message
+void CMessage::allocateData(size_t uiSize)
 {
     // Remove previous one
     if (_pucData) {

--- a/remote-processor/Message.h
+++ b/remote-processor/Message.h
@@ -64,25 +64,61 @@ public:
 protected:
     // Msg Id
     uint8_t getMsgId() const;
-    // Data
-    void writeData(const void* pvData, uint32_t uiSize);
-    void readData(void* pvData, uint32_t uiSize);
+
+    /** Write raw data to the message
+    *
+    * @param[in] pvData pointer to the data array
+    * @param[in] uiSize array size in bytes
+    */
+    void writeData(const void* pvData, size_t uiSize);
+
+    /** Read raw data from the message
+    *
+    * @param[out] pvData pointer to the data array
+    * @param[in] uiSize array size in bytes
+    */
+    void readData(void* pvData, size_t uiSize);
+
+    /** Write string to the message
+    *
+    * @param[in] strData the string to write
+    */
     void writeString(const std::string& strData);
+
+    /** Write string to the message
+    *
+    * @param[out] strData the string to read to
+    */
     void readString(std::string& strData);
-    uint32_t getStringSize(const std::string& strData) const;
-    // Remaining data size
-    uint32_t getRemainingDataSize() const;
+
+    /** @return string length plus room to store its length
+    *
+    * @param[in] strData the string to get the size from
+    */
+    size_t getStringSize(const std::string& strData) const;
+
+    /** @return remaining data size to read or to write depending on the context
+    * (request: write, answer: read)
+    */
+    size_t getRemainingDataSize() const;
 private:
     CMessage(const CMessage&);
     CMessage& operator=(const CMessage&);
-    // Data allocation
-    void allocateData(uint32_t uiDataSize);
+
+    /** Allocate room to store the message
+    *
+    * @param[int] uiDataSize the szie to allocate in bytes
+    */
+    void allocateData(size_t uiDataSize);
     // Fill data to send
     virtual void fillDataToSend() = 0;
     // Collect received data
     virtual void collectReceivedData() = 0;
-    // Size
-    virtual uint32_t getDataSize() const = 0;
+
+    /** @return size of the transaction data in bytes
+    */
+    virtual size_t getDataSize() const = 0;
+
     // Checksum
     uint8_t computeChecksum() const;
 
@@ -90,8 +126,8 @@ private:
     uint8_t _ucMsgId;
     // Data
     uint8_t* _pucData;
-    // Data size
-    uint32_t _uiDataSize;
-    // Read/Write Index
-    uint32_t _uiIndex;
+    /** Size of the allocated memory to store the message */
+    size_t _uiDataSize;
+    /** Read/Write Index used to iterate across the message data */
+    size_t _uiIndex;
 };

--- a/remote-processor/RemoteCommandHandlerTemplate.h
+++ b/remote-processor/RemoteCommandHandlerTemplate.h
@@ -190,7 +190,7 @@ private:
 
                 const CRemoteCommandParserItem* pRemoteCommandParserItem = _remoteCommandParserVector[uiIndex];
 
-                uint32_t uiRemoteCommandUsageLength = pRemoteCommandParserItem->usage().length();
+                uint32_t uiRemoteCommandUsageLength = (uint32_t)pRemoteCommandParserItem->usage().length();
 
                 if (uiRemoteCommandUsageLength > _uiMaxCommandUsageLength) {
 
@@ -220,7 +220,7 @@ private:
             strResult += strUsage;
 
             // Align
-            uint32_t uiToSpacesAdd = _uiMaxCommandUsageLength + 5 - strUsage.length();
+            uint32_t uiToSpacesAdd = _uiMaxCommandUsageLength + 5 - (uint32_t)strUsage.length();
 
             while (uiToSpacesAdd--) {
 

--- a/remote-processor/RequestMessage.cpp
+++ b/remote-processor/RequestMessage.cpp
@@ -140,10 +140,10 @@ void CRequestMessage::collectReceivedData()
 }
 
 // Size
-uint32_t CRequestMessage::getDataSize() const
+size_t CRequestMessage::getDataSize() const
 {
     // Command
-    uint32_t uiSize = getStringSize(getCommand());
+    size_t uiSize = getStringSize(getCommand());
 
     // Arguments
     uint32_t uiArgument;

--- a/remote-processor/RequestMessage.h
+++ b/remote-processor/RequestMessage.h
@@ -64,7 +64,10 @@ private:
     // Collect received data
     virtual void collectReceivedData();
     // Size
-    virtual uint32_t getDataSize() const;
+    /**
+     * @return size of the request message in bytes
+     */
+    virtual size_t getDataSize() const;
     // Trim input std::string
     static std::string trim(const std::string& strToTrim);
 

--- a/xmlserializer/XmlElement.cpp
+++ b/xmlserializer/XmlElement.cpp
@@ -175,10 +175,10 @@ bool CXmlElement::getChildElement(const string& strType, const string& strNameAt
     return false;
 }
 
-uint32_t CXmlElement::getNbChildElements() const
+size_t CXmlElement::getNbChildElements() const
 {
     CXmlElement childElement;
-    uint32_t uiNbChildren = 0;
+    size_t uiNbChildren = 0;
 
     CChildIterator childIterator(*this);
 

--- a/xmlserializer/XmlElement.h
+++ b/xmlserializer/XmlElement.h
@@ -61,7 +61,7 @@ public:
     // Navigation
     bool getChildElement(const std::string& strType, CXmlElement& childElement) const;
     bool getChildElement(const std::string& strType, const std::string& strNameAttribute, CXmlElement& childElement) const;
-    uint32_t getNbChildElements() const;
+    size_t getNbChildElements() const;
     bool getParentElement(CXmlElement& parentElement) const;
 
     // Setters

--- a/xmlserializer/XmlStringDocSource.cpp
+++ b/xmlserializer/XmlStringDocSource.cpp
@@ -39,7 +39,7 @@ CXmlStringDocSource::CXmlStringDocSource(const std::string& strXmlInput,
                                          const std::string& strRootElementName,
                                          const std::string& strNameAttrituteName,
                                          bool bValidateWithSchema) :
-    base(xmlReadMemory(strXmlInput.c_str(), strXmlInput.size(), "", NULL, 0),
+    base(xmlReadMemory(strXmlInput.c_str(), (int)strXmlInput.size(), "", NULL, 0),
          strXmlSchemaFile,
          strRootElementType,
          strRootElementName,


### PR DESCRIPTION
pick c5c716c Change blackboard write/readString prototype
pick e4ceda6 CXmlFileIncluderElement constructor cleanup
pick e7d4c02 Type mismatch corrections (Windows 64 bits)
pick fd33002 Inconsistent name of variable in RuleParser
pick b436977 Fix for BackSynchronizer related crash on windows
pick f1798d2 stop messing around with useless pointer

