### PR TITLE
coveralls: send coverage report to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
   - sudo add-apt-repository --yes ppa:kalakris/cmake # Non official cmake backport
   - sudo apt-get update -qq
+  - sudo pip install cpp-coveralls
 
 install:
   - sudo apt-get install --yes swig cmake valgrind g++-4.8
@@ -37,6 +38,18 @@ script:
         sudo make install &&
         sudo ldconfig &&
         CTEST_OUTPUT_ON_FAILURE=1 make ExperimentalTest ExperimentalCoverage ExperimentalMemCheck )
+
+after_success:
+    # Push coverage info on coveralls.io.
+    # Ignore generated files, samples and tests
+    - coveralls
+          --exclude "build/bindings/python"
+          --exclude "build/CMakeFiles"
+          --exclude "skeleton-subsystem"
+          --exclude "test/test-subsystem"
+          --exclude "bindings/c/Test.cpp"
+          --exclude "test/tokenizer"
+          --gcov-options '\-lp'
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # parameter-framework
 
 [![Build Status](https://travis-ci.org/01org/parameter-framework.svg?branch=master)](https://travis-ci.org/01org/parameter-framework)
+[![Coverage Status](https://coveralls.io/repos/01org/parameter-framework/badge.svg?branch=master)](https://coveralls.io/r/01org/parameter-framework)
 
 ## Introduction
 


### PR DESCRIPTION
coveralls.io is a service that uses information from gcov (generated during
"make test") to provide a coverage report online:

    https://coveralls.io/r/01org/parameter-framework

Some files must be ignored, specifically: generated files (python bindings and
files generated by CMake), tests (because they would inflate the coverage rate)
and samples (for now, only the skeleton subsystem).

A "badge" is also added to the readme showing the coverage rate.

Signed-off-by: David Wagner <david.wagner@intel.com>