### PR TITLE
Improve travis debug build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ install:
 
 # how to build
 script:
+  - ( mkdir build_debug && cd build_debug &&
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON .. &&
+        make -j &&
+        CTEST_OUTPUT_ON_FAILURE=1 make ExperimentalTest ExperimentalMemCheck )
   - ( mkdir build && cd build &&
         cmake .. &&
         make -j &&
@@ -32,19 +36,14 @@ script:
         make &&
         sudo make install &&
         sudo ldconfig )
-  - ( cd build &&
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON .. &&
-        make -j &&
-        sudo make install &&
-        sudo ldconfig &&
-        CTEST_OUTPUT_ON_FAILURE=1 make ExperimentalTest ExperimentalMemCheck )
 
 after_success:
     # Push coverage info on coveralls.io.
     # Ignore generated files, samples and tests
     - coveralls
-          --exclude "build/bindings/python"
-          --exclude "build/CMakeFiles"
+          --exclude "build_debug/bindings/python"
+          --exclude "build_debug/CMakeFiles"
+          --exclude "build"
           --exclude "skeleton-subsystem"
           --exclude "test/test-subsystem"
           --exclude "bindings/c/Test.cpp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
         make -j &&
         sudo make install &&
         sudo ldconfig &&
-        CTEST_OUTPUT_ON_FAILURE=1 make ExperimentalTest ExperimentalCoverage ExperimentalMemCheck )
+        CTEST_OUTPUT_ON_FAILURE=1 make ExperimentalTest ExperimentalMemCheck )
 
 after_success:
     # Push coverage info on coveralls.io.


### PR DESCRIPTION
- Avoid running `gcov` twice.
- Run `make test` *without* `make install` in debug.
- Fix coveralls reporting headers with 0 code as 0% covered instead of 100%.