### PR TITLE
Install bash completions in /usr/share

### DIFF
--- a/tools/bash_completion/CMakeLists.txt
+++ b/tools/bash_completion/CMakeLists.txt
@@ -27,4 +27,4 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 INSTALL(FILES remote-process
-        DESTINATION etc/bash_completion.d/)
+        DESTINATION share/bash-completion/completions/)


### PR DESCRIPTION
With a classic cmake install prefix '/usr', bash completions were installed in _/usr/etc/bash_completion.d/_ which even before bash-completion 1.9 was incorrect.

Since v1.9 all completions are to be installed in _/usr/share/bash-completion/completions_
See: http://anonscm.debian.org/cgit/bash-completion/bash-completion.git/tree/CHANGES#n324

Change the completions install path accordingly