### PR TITLE
Restore pull request #88 "improve travis debug build"  after fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ install:
 
 # how to build
 script:
+  - ( mkdir build_debug && cd build_debug &&
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON .. &&
+        make -j &&
+        CTEST_OUTPUT_ON_FAILURE=1 make ExperimentalTest ExperimentalMemCheck )
   - ( mkdir build && cd build &&
         cmake .. &&
         make -j &&
@@ -32,19 +36,14 @@ script:
         make &&
         sudo make install &&
         sudo ldconfig )
-  - ( cd build &&
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON .. &&
-        make -j &&
-        sudo make install &&
-        sudo ldconfig &&
-        CTEST_OUTPUT_ON_FAILURE=1 make ExperimentalTest ExperimentalCoverage ExperimentalMemCheck )
 
 after_success:
     # Push coverage info on coveralls.io.
     # Ignore generated files, samples and tests
     - coveralls
-          --exclude "build/bindings/python"
-          --exclude "build/CMakeFiles"
+          --exclude "build_debug/bindings/python"
+          --exclude "build_debug/CMakeFiles"
+          --exclude "build"
           --exclude "skeleton-subsystem"
           --exclude "test/test-subsystem"
           --exclude "bindings/c/Test.cpp"

--- a/ctest/CMakeLists.txt
+++ b/ctest/CMakeLists.txt
@@ -37,8 +37,8 @@ set(MEMORYCHECK_COMMAND_OPTIONS
 set(MEMORYCHECK_COMMAND_OPTIONS
     "${MEMORYCHECK_COMMAND_OPTIONS} --error-exitcode=255 --log-fd=2")
 
-# Ignore errors from third-partie libraries
-set(MEMORYCHECK_SUPPRESSIONS_FILE "${CMAKE_CURRENT_LIST_DIR}/valgrind.supp")
+set(MEMORYCHECK_COMMAND_OPTIONS
+    "${MEMORYCHECK_COMMAND_OPTIONS} --suppressions=${CMAKE_CURRENT_LIST_DIR}/valgrind.supp")
 
 # Enable tests, coverage, memcheck, ...
 # See http://www.cmake.org/Wiki/CMake/Testing_With_CTest#Dashboard_Preparation


### PR DESCRIPTION
The pull request #88 was reverted as it broke travis build.

ctest uses a cache variable MEMCHECK_SUPPRESSION_FILE.
It sets it during the `include(ctest)` evaluation.

Cache variable are set on creation, they can not be modify after by a
CMakeList.mk (except with set's FORCE option).

ef5736e sets MEMCHECK_SUPPRESSION_FILE as a normal variable.
This does not set the cache variable as expected but rather create
a second local variable (not part of the cache) with the same name.

If cmake was run once (as during travis build since patch 4e41ff7,
until its revert d17b931a3dcc70cf9e892db6d709df58a5b4e9fa), the local variable has no effect
thus the suppression file was never saved in the cache.

If cmake was run twice, during the second time, as the cache version
is not recreated (cache variables are persistent),
the call to set MEMCHECK_SUPPRESSION_FILE changes the cache version as
it was first expected.

As a result the build worked if cmake was invoked twice but failed
if only called once.

For more information, see the *** Variable types in CMake *** section at:
http://www.cmake.org/cmake/help/v2.8.11/cmake.html#command%3aset

This pull request fixes all that by not using MEMCHECK_SUPPRESSION_FILE.
but rather setting directly the option in valgrind.

It then restores the #88 pull request by reverting its revert.