### PR TITLE
Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ env:
 
 compiler:
     - gcc
-    # clang not supported yet
-    # - clang
+    - clang
 
 # Install a recent gcc and gcov,
 # it will not be necessary once travis worker is based on ubuntu > 12.04.
@@ -20,7 +19,6 @@ addons:
         sources:
             - ubuntu-toolchain-r-test
         packages:
-            - swig
             - valgrind
             - g++-4.8
 
@@ -28,6 +26,14 @@ install:
     - pip install --user cpp-coveralls; export PATH=$HOME/.local/bin:$PATH
     - wget --directory-prefix $PREFIX/include
               https://raw.github.com/philsquared/Catch/master/single_include/catch.hpp
+    # Install recent swig.
+    # Avoid make install check because documentation generation will fail as yodl2man command is
+    # missing and the corresponding paquet is not available in travis whitelist.
+    - ( mkdir build_swig && cd build_swig &&
+          wget https://github.com/swig/swig/archive/rel-2.0.12.tar.gz &&
+          tar -xf rel-2.0.12.tar.gz && cd swig-rel-2.0.12/ && ./autogen.sh &&
+          ./configure --prefix=$PREFIX && make && make install ;
+          echo "Dropping documentation generation error" )
 
 before_script:
     - if [ "$CC" = "gcc" ]; then export CC=gcc-4.8 CXX=g++-4.8; fi
@@ -55,6 +61,7 @@ after_success:
           --exclude "build_debug/bindings/python"
           --exclude "build_debug/CMakeFiles"
           --exclude "build"
+          --exclude "build_swig"
           --exclude "skeleton-subsystem"
           --exclude "test/test-subsystem"
           --exclude "bindings/c/Test.cpp"

--- a/bindings/python/Android.mk
+++ b/bindings/python/Android.mk
@@ -80,5 +80,7 @@ $(generated-sources-dir)/pfw_wrap.cxx: $(LOCAL_PATH)/pfw.i
 		-Iprebuilts/misc/common/swig/include/2.0.11/ \
 		-Wall -Werror -v -python -c++ -outdir $(HOST_LIBRARY_PATH)/ -o $@ $^
 
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_HOST_SHARED_LIBRARY)
 

--- a/bindings/python/Android.mk
+++ b/bindings/python/Android.mk
@@ -46,13 +46,11 @@ LOCAL_C_INCLUDES := \
     prebuilts/python/linux-x86/2.7.5/include/python2.7 \
     $(HOST_OUT_HEADERS)/parameter
 
-# The 'unused-but-set-variable' warning must be disabled because SWIG generates
-# files that do not respect that constraint.
 # '-DSWIG_PYTHON_SILENT_MEMLEAK' is needed because the "memleak" warning
 # pollutes the standard output. At the time of writing, the only warning is
 # spurious anyway, as it relates to "ILogger *" which is an abstract
 # class/interface class and as such cannot be destroyed.
-LOCAL_CFLAGS := -Wno-unused-but-set-variable -fexceptions -DSWIG_PYTHON_SILENT_MEMLEAK
+LOCAL_CFLAGS := -fexceptions -DSWIG_PYTHON_SILENT_MEMLEAK
 
 # Undefined symbols will be resolved at runtime
 LOCAL_ALLOW_UNDEFINED_SYMBOLS := true

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -54,13 +54,11 @@ swig_link_libraries(PyPfw parameter ${PYTHON_LIBRARIES})
 # ${CMAKE_CURRENT_BINARY_DIR}.
 set_property(TARGET _PyPfw PROPERTY LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-# The 'unused-but-set-variable' warning must be disabled because SWIG generates
-# files that do not respect that contraint.
 # '-DSWIG_PYTHON_SILENT_MEMLEAK' is needed because the "memleak" warning
 # pollutes the standard output. At the time of writing, the only warning is
 # spurious anyway, as it relates to "ILogger *" which is an abstract
 # class/interface class and as such cannot be destroyed.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable -DSWIG_PYTHON_SILENT_MEMLEAK")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSWIG_PYTHON_SILENT_MEMLEAK")
 
 
 # Find the python modules install path.

--- a/parameter/Android.mk
+++ b/parameter/Android.mk
@@ -158,8 +158,8 @@ LOCAL_STATIC_LIBRARIES := libxmlserializer libpfw_utility libxml2
 
 LOCAL_REQUIRED_MODULES := libremote-processor
 
-LOCAL_CLANG := false
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_SHARED_LIBRARY)
 
 ##############################
@@ -186,7 +186,8 @@ LOCAL_STATIC_LIBRARIES := libxmlserializer_host libpfw_utility_host libxml2
 
 LOCAL_LDLIBS += -ldl
 
-LOCAL_CLANG := false
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_HOST_SHARED_LIBRARY)
 
 ################################

--- a/parameter/BitParameter.cpp
+++ b/parameter/BitParameter.cpp
@@ -87,7 +87,7 @@ bool CBitParameter::accessAsBoolean(bool& bValue, bool bSet, CParameterAccessCon
     }
 
     // Rely on integer access
-    uint64_t uiValue;
+    uint32_t uiValue;
 
     if (bSet) {
 
@@ -108,7 +108,7 @@ bool CBitParameter::accessAsBoolean(bool& bValue, bool bSet, CParameterAccessCon
 }
 
 // Integer Access
-bool CBitParameter::accessAsInteger(uint64_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CBitParameter::accessAsInteger(uint32_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
 {
     uint32_t uiOffset = getOffset();
 

--- a/parameter/BitParameter.h
+++ b/parameter/BitParameter.h
@@ -49,7 +49,7 @@ public:
     virtual bool accessAsBoolean(bool& bValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
 
     // Integer Access
-    virtual bool accessAsInteger(uint64_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool accessAsInteger(uint32_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
 
     // AreaConfiguration creation
     virtual CAreaConfiguration* createAreaConfiguration(const CSyncerSet* pSyncerSet) const;

--- a/parameter/BitParameterType.cpp
+++ b/parameter/BitParameterType.cpp
@@ -191,7 +191,7 @@ bool CBitParameterType::toBlackboard(uint64_t uiUserValue, uint64_t& uiValue, CP
     return true;
 }
 
-void CBitParameterType::fromBlackboard(uint64_t& uiUserValue, uint64_t uiValue, CParameterAccessContext& parameterAccessContext) const
+void CBitParameterType::fromBlackboard(uint32_t& uiUserValue, uint64_t uiValue, CParameterAccessContext& parameterAccessContext) const
 {
     (void)parameterAccessContext;
 

--- a/parameter/BitParameterType.h
+++ b/parameter/BitParameterType.h
@@ -53,7 +53,7 @@ public:
     void fromBlackboard(std::string& strValue, const uint64_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
     // Integer
     bool toBlackboard(uint64_t uiUserValue, uint64_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    void fromBlackboard(uint64_t& uiUserValue, uint64_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    void fromBlackboard(uint32_t& uiUserValue, uint64_t uiValue, CParameterAccessContext& parameterAccessContext) const;
     // Access from area configuration
     uint64_t merge(uint64_t uiOriginData, uint64_t uiNewData) const;
 

--- a/remote-process/Android.mk
+++ b/remote-process/Android.mk
@@ -68,7 +68,8 @@ LOCAL_SHARED_LIBRARIES := $(common_shared_libraries)
 LOCAL_STATIC_LIBRARIES := $(common_static_libraries)
 
 
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_EXECUTABLE)
 
 ##############################
@@ -92,4 +93,6 @@ LOCAL_SHARED_LIBRARIES := $(foreach shared_library, $(common_shared_libraries), 
 LOCAL_STATIC_LIBRARIES := $(foreach static_library, $(common_static_libraries), \
     $(static_library)_host)
 
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_HOST_EXECUTABLE)

--- a/remote-processor/Android.mk
+++ b/remote-processor/Android.mk
@@ -51,7 +51,7 @@ common_cflags := \
         -Wno-unused-parameter \
         -pthread
 
-common_ldlibs := -pthread
+common_ldlibs := -lpthread
 
 #############################
 # Target build
@@ -67,7 +67,8 @@ LOCAL_MODULE := $(common_module)
 LOCAL_MODULE_OWNER := intel
 LOCAL_MODULE_TAGS := $(common_module_tags)
 
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_SHARED_LIBRARY)
 
 ##############################
@@ -85,4 +86,6 @@ LOCAL_MODULE_OWNER := intel
 LOCAL_MODULE_TAGS := $(common_module_tags)
 
 
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_HOST_SHARED_LIBRARY)

--- a/test/test-platform/Android.mk
+++ b/test/test-platform/Android.mk
@@ -43,7 +43,7 @@ common_c_includes := \
     $(LOCAL_PATH)/../../parameter/include \
     $(LOCAL_PATH)/../../remote-processor/
 
-common_ldlibs := -pthread
+common_ldlibs := -lpthread
 
 common_shared_libraries := libparameter libremote-processor
 #############################
@@ -63,7 +63,8 @@ LOCAL_LDLIBS := $(common_ldlibs)
 LOCAL_STATIC_LIBRARIES := libpfw_utility
 LOCAL_SHARED_LIBRARIES := $(common_shared_libraries)
 
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_EXECUTABLE)
 
 ##############################
@@ -84,4 +85,6 @@ LOCAL_STATIC_LIBRARIES := libpfw_utility_host
 LOCAL_SHARED_LIBRARIES := $(foreach shared_library, $(common_shared_libraries), \
     $(shared_library)_host)
 
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_HOST_EXECUTABLE)

--- a/utility/Android.mk
+++ b/utility/Android.mk
@@ -60,7 +60,8 @@ LOCAL_MODULE_TAGS := $(common_module_tags)
 
 LOCAL_CFLAGS := $(common_cflags)
 
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_STATIC_LIBRARY)
 
 ##############################
@@ -78,4 +79,6 @@ LOCAL_MODULE_TAGS := $(common_module_tags)
 
 LOCAL_CFLAGS := $(common_cflags)
 
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_HOST_STATIC_LIBRARY)

--- a/xmlserializer/Android.mk
+++ b/xmlserializer/Android.mk
@@ -79,7 +79,8 @@ LOCAL_STATIC_LIBRARIES := $(common_static_libraries)
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
-include external/stlport/libstlport.mk
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_STATIC_LIBRARY)
 
 ##############################
@@ -102,6 +103,8 @@ LOCAL_STATIC_LIBRARIES := libxml2
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
+LOCAL_CLANG := true
+include external/libcxx/libcxx.mk
 include $(BUILD_HOST_STATIC_LIBRARY)
 
 ################################


### PR DESCRIPTION
Add clang support to parameter-framework project.
Clang comes in Android with its standard library which supports c++11.