### PR TITLE
Turn off optimizations when building in Debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ project(parameter-framework)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra")
 
+# Turn off optimizations for debug mode
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 


### PR DESCRIPTION
CMake default debug flags contains contains only '-g' flag.
The optimization leads to coverage inconsistency when using
both clang and gcc compiler.
This patch adds '-O0' flag for Debug mode build to turn off
optimizations.