### PR TITLE
xmlcoverage: be able to ignore changes to unknown criteria

### DIFF
--- a/tools/coverage/aplog2coverage.sh
+++ b/tools/coverage/aplog2coverage.sh
@@ -54,6 +54,7 @@ help () {
 # Default values
 outputFile="-"
 coverage_report_generator_ignorable_errors="\
+--ignore-unknown-criterion \
 --ignore-incoherent-criterion-state \
 --ignore-ineligible-configuration-application"
 coverage_report_generator_options=""

--- a/tools/coverage/coverage.py
+++ b/tools/coverage/coverage.py
@@ -720,6 +720,14 @@ class ParsePFWlog():
     MATCH = "match"
     ACTION = "action"
 
+    class ChangeRequestOnUnknownCriterion(CustomError):
+        def __init__(self, criterion):
+            self.criterion = criterion
+
+        def __str__(self):
+            return ("Change request on an unknown criterion %s." %
+                self.criterion)
+
     def __init__(self, domains, criteria, ErrorsToIgnore=()):
 
         self.domains = domains;
@@ -802,7 +810,10 @@ class ParsePFWlog():
 
         path = [criterionName]
         changeCriterionOperation = lambda criterion : criterion.changeState(newCriterionState)
-        self.criteria.operationOnChild(path, changeCriterionOperation)
+        try:
+            self.criteria.operationOnChild(path, changeCriterionOperation)
+        except ChildNotFoundError:
+            raise self.ChangeRequestOnUnknownCriterion(criterionName)
 
     def _configApplication(self, matchConfig):
         # Unpack
@@ -968,6 +979,13 @@ class ArgumentParser:
                     )
 
             myArgParser.add_argument(
+                        '--ignore-unknown-criterion',
+                        dest="unknwonCriterionFlag",
+                        action='store_true',
+                        help="ignore unknown criterion"
+                    )
+
+            myArgParser.add_argument(
                         '--ignore-incoherent-criterion-state',
                         dest="incoherentCriterionFlag",
                         action='store_true',
@@ -1003,6 +1021,9 @@ class ArgumentParser:
                 errorToIgnore.append(Configuration.IneligibleConfigurationAppliedError)
 
             if options.incoherentCriterionFlag:
+                errorToIgnore.append(ParsePFWlog.ChangeRequestOnUnknownCriterion)
+
+            if options.unknwonCriterionFlag:
                 errorToIgnore.append(Criterion.ChangeRequestToNonAccessibleState)
 
             self.errorToIgnore = tuple(errorToIgnore)


### PR DESCRIPTION
Since a parameter-framework client may set a criterion before calling start(),
the logs may show changes to criteria before the coverage script knows the list
of criteria. It used to cause an unrecoverable error even with the "--force"
option.

This option now makes the coverage script ignore such errors. The script
already takes the initial values of criteria into account when the
parameter-framework starts, so there isn't any information loss.

However, if this error happens for any other error than described in the first
paragraph, you probably don't want to silence it.

Signed-off-by: David Wagner <david.wagner@intel.com>