### PR TITLE
xml coverage: fix a copy-paste mistake

### DIFF
--- a/tools/coverage/coverage.py
+++ b/tools/coverage/coverage.py
@@ -1021,10 +1021,10 @@ class ArgumentParser:
                 errorToIgnore.append(Configuration.IneligibleConfigurationAppliedError)
 
             if options.incoherentCriterionFlag:
-                errorToIgnore.append(ParsePFWlog.ChangeRequestOnUnknownCriterion)
+                errorToIgnore.append(Criterion.ChangeRequestToNonAccessibleState)
 
             if options.unknwonCriterionFlag:
-                errorToIgnore.append(Criterion.ChangeRequestToNonAccessibleState)
+                errorToIgnore.append(ParsePFWlog.ChangeRequestOnUnknownCriterion)
 
             self.errorToIgnore = tuple(errorToIgnore)
 


### PR DESCRIPTION
Commit ccb164c15d0f46fb233b67075f37bede8f8ad855 introduced the possibility to
ignore changes to unknown criterion through an option passed to coverage.py but
a copy-paste mistake swapped the action of this option with the option ignoring
incoherent criterion state changes.

Both flags are set by 'aplog2coverage.sh -f' so the mistake went unnoticed but
it must be fixed nevertheless.

Signed-off-by: David Wagner <david.wagner@intel.com>