### PR TITLE
Allows 64 values for inclusive criterion

### DIFF
--- a/bindings/python/pfw.i
+++ b/bindings/python/pfw.i
@@ -198,11 +198,11 @@ class ISelectionCriterionTypeInterface
 %}
 
 public:
-    virtual bool addValuePair(int iValue, const std::string& strValue, std::string& strError) = 0;
-    virtual bool getNumericalValue(const std::string& strValue, int& iValue) const = 0;
-    virtual bool getLiteralValue(int iValue, std::string& strValue) const = 0;
+    virtual bool addValuePair(uint64_t iValue, const std::string& strValue, std::string& strError) = 0;
+    virtual bool getNumericalValue(const std::string& strValue, uint64_t& iValue) const = 0;
+    virtual bool getLiteralValue(uint64_t iValue, std::string& strValue) const = 0;
     virtual bool isTypeInclusive() const = 0;
-    virtual std::string getFormattedState(int iValue) const = 0;
+    virtual std::string getFormattedState(uint64_t iValue) const = 0;
 
 protected:
     virtual ~ISelectionCriterionTypeInterface() {}
@@ -215,8 +215,8 @@ class ISelectionCriterionInterface
 %}
 
 public:
-    virtual void setCriterionState(int iState) = 0;
-    virtual int getCriterionState() const = 0;
+    virtual void setCriterionState(uint64_t iState) = 0;
+    virtual uint64_t getCriterionState() const = 0;
     virtual std::string getCriterionName() const = 0;
     virtual const ISelectionCriterionTypeInterface* getCriterionType() const = 0;
 

--- a/parameter/SelectionCriterion.cpp
+++ b/parameter/SelectionCriterion.cpp
@@ -59,7 +59,7 @@ void CSelectionCriterion::resetModifiedStatus()
 
 /// From ISelectionCriterionInterface
 // State
-void CSelectionCriterion::setCriterionState(int iState)
+void CSelectionCriterion::setCriterionState(uint64_t iState)
 {
     // Check for a change
     if (_iState != iState) {
@@ -83,7 +83,7 @@ void CSelectionCriterion::setCriterionState(int iState)
     }
 }
 
-int CSelectionCriterion::getCriterionState() const
+uint64_t CSelectionCriterion::getCriterionState() const
 {
     return _iState;
 }
@@ -101,24 +101,24 @@ const ISelectionCriterionTypeInterface* CSelectionCriterion::getCriterionType() 
 }
 
 /// Match methods
-bool CSelectionCriterion::is(int iState) const
+bool CSelectionCriterion::is(uint64_t iState) const
 {
     return _iState == iState;
 }
 
-bool CSelectionCriterion::isNot(int iState) const
+bool CSelectionCriterion::isNot(uint64_t iState) const
 {
     return _iState != iState;
 }
 
-bool CSelectionCriterion::includes(int iState) const
+bool CSelectionCriterion::includes(uint64_t iState) const
 {
     // For inclusive criterion, Includes checks if ALL the bit sets in iState are set in the
     // current _iState.
     return (_iState & iState) == iState;
 }
 
-bool CSelectionCriterion::excludes(int iState) const
+bool CSelectionCriterion::excludes(uint64_t iState) const
 {
     return (_iState & iState) == 0;
 }

--- a/parameter/SelectionCriterion.h
+++ b/parameter/SelectionCriterion.h
@@ -45,8 +45,8 @@ public:
 
     /// From ISelectionCriterionInterface
     // State
-    virtual void setCriterionState(int iState);
-    virtual int getCriterionState() const;
+    virtual void setCriterionState(uint64_t iState);
+    virtual uint64_t getCriterionState() const;
     // Name
     virtual std::string getCriterionName() const;
     // Type
@@ -56,10 +56,10 @@ public:
     void resetModifiedStatus();
 
     /// Match methods
-    bool is(int iState) const;
-    bool isNot(int iState) const;
-    bool includes(int iState) const;
-    bool excludes(int iState) const;
+    bool is(uint64_t iState) const;
+    bool isNot(uint64_t iState) const;
+    bool includes(uint64_t iState) const;
+    bool excludes(uint64_t iState) const;
 
     /// User request
     std::string getFormattedDescription(bool bWithTypeInfo, bool bHumanReadable) const;
@@ -77,7 +77,7 @@ public:
     virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
 private:
     // Current state
-    int _iState;
+    uint64_t _iState;
     // Type
     const CSelectionCriterionType* _pType;
 

--- a/parameter/SelectionCriterionRule.h
+++ b/parameter/SelectionCriterionRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -87,7 +87,7 @@ private:
     MatchesWhen _eMatchesWhen;
 
     // Value
-    int32_t _iMatchValue;
+    uint64_t _iMatchValue;
 
     // Used for XML MatchesWhen attribute parsing
     static const SMatchingRuleDescription _astMatchesWhen[ENbMatchesWhen];

--- a/parameter/SelectionCriterionType.cpp
+++ b/parameter/SelectionCriterionType.cpp
@@ -51,7 +51,7 @@ std::string CSelectionCriterionType::getKind() const
 
 // From ISelectionCriterionTypeInterface
 bool CSelectionCriterionType::addValuePair(
-        int iValue, const std::string& strValue, std::string& strError)
+        uint64_t iValue, const std::string& strValue, std::string& strError)
 {
     // Check 1 bit set only for inclusive types
     if (_bInclusive && (!iValue || (iValue & (iValue - 1)))) {
@@ -81,14 +81,14 @@ bool CSelectionCriterionType::addValuePair(
     return true;
 }
 
-bool CSelectionCriterionType::getNumericalValue(const std::string& strValue, int& iValue) const
+bool CSelectionCriterionType::getNumericalValue(const std::string& strValue, uint64_t& iValue) const
 {
     if (_bInclusive) {
 
         Tokenizer tok(strValue, _strDelimiter);
         std::vector<std::string> astrValues = tok.split();
         size_t uiNbValues = astrValues.size();
-        int iResult = 0;
+        uint64_t iResult = 0;
         size_t uiValueIndex;
         iValue = 0;
 
@@ -106,7 +106,7 @@ bool CSelectionCriterionType::getNumericalValue(const std::string& strValue, int
     return getAtomicNumericalValue(strValue, iValue);
 }
 
-bool CSelectionCriterionType::getAtomicNumericalValue(const std::string& strValue, int& iValue) const
+bool CSelectionCriterionType::getAtomicNumericalValue(const std::string& strValue, uint64_t& iValue) const
 {
     NumToLitMapConstIt it = _numToLitMap.find(strValue);
 
@@ -119,7 +119,7 @@ bool CSelectionCriterionType::getAtomicNumericalValue(const std::string& strValu
     return false;
 }
 
-bool CSelectionCriterionType::getLiteralValue(int iValue, std::string& strValue) const
+bool CSelectionCriterionType::getLiteralValue(uint64_t iValue, std::string& strValue) const
 {
     NumToLitMapConstIt it;
 
@@ -166,19 +166,19 @@ std::string CSelectionCriterionType::listPossibleValues() const
 }
 
 // Formatted state
-std::string CSelectionCriterionType::getFormattedState(int iValue) const
+std::string CSelectionCriterionType::getFormattedState(uint64_t iValue) const
 {
     std::string strFormattedState;
 
     if (_bInclusive) {
 
         // Need to go through all set bit
-        uint32_t uiBit;
+        uint64_t uiBit;
         bool bFirst = true;
 
         for (uiBit = 0; uiBit < sizeof(iValue) * 8; uiBit++) {
 
-            int iSingleBitValue = iValue & (1 << uiBit);
+            uint64_t iSingleBitValue = iValue & (0x1ull << uiBit);
 
             // Check if current bit is set
             if (!iSingleBitValue) {

--- a/parameter/SelectionCriterionType.h
+++ b/parameter/SelectionCriterionType.h
@@ -36,13 +36,13 @@
 
 class CSelectionCriterionType : public CElement, public ISelectionCriterionTypeInterface
 {
-    typedef std::map<std::string, int>::const_iterator NumToLitMapConstIt;
+    typedef std::map<std::string, uint64_t>::const_iterator NumToLitMapConstIt;
 
 public:
     CSelectionCriterionType(bool bIsInclusive);
 
     // From ISelectionCriterionTypeInterface
-    virtual bool addValuePair(int iValue, const std::string& strValue, std::string& strError);
+    virtual bool addValuePair(uint64_t iValue, const std::string& strValue, std::string& strError);
     /**
      * Retrieve the numerical value from the std::string representation of the criterion type.
      *
@@ -53,15 +53,15 @@ public:
      *
      * @return true if integer value retrieved from the std::string one, false otherwise.
      */
-    virtual bool getNumericalValue(const std::string& strValue, int& iValue) const;
-    virtual bool getLiteralValue(int iValue, std::string& strValue) const;
+    virtual bool getNumericalValue(const std::string& strValue, uint64_t& iValue) const;
+    virtual bool getLiteralValue(uint64_t iValue, std::string& strValue) const;
     virtual bool isTypeInclusive() const;
 
     // Value list
     std::string listPossibleValues() const;
 
     // Formatted state
-    virtual std::string getFormattedState(int iValue) const;
+    virtual std::string getFormattedState(uint64_t iValue) const;
 
     /**
       * Export to XML
@@ -84,9 +84,9 @@ private:
      *
      * @return true if integer value retrieved from the std::string one, false otherwise.
      */
-    bool getAtomicNumericalValue(const std::string& strValue, int& iValue) const;
+    bool getAtomicNumericalValue(const std::string& strValue, uint64_t& iValue) const;
     bool _bInclusive;
-    std::map<std::string, int> _numToLitMap;
+    std::map<std::string, uint64_t> _numToLitMap;
 
     static const std::string _strDelimiter; /**< Inclusive criterion type delimiter. */
 };

--- a/parameter/include/SelectionCriterionInterface.h
+++ b/parameter/include/SelectionCriterionInterface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -30,14 +30,15 @@
 #pragma once
 
 #include <string>
+#include <stdint.h>
 
 #include "SelectionCriterionTypeInterface.h"
 
 class ISelectionCriterionInterface
 {
 public:
-    virtual void setCriterionState(int iState) = 0;
-    virtual int getCriterionState() const = 0;
+    virtual void setCriterionState(uint64_t iState) = 0;
+    virtual uint64_t getCriterionState() const = 0;
     virtual std::string getCriterionName() const = 0;
     virtual const ISelectionCriterionTypeInterface* getCriterionType() const = 0;
 

--- a/parameter/include/SelectionCriterionTypeInterface.h
+++ b/parameter/include/SelectionCriterionTypeInterface.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <string>
+#include <stdint.h>
 
 class ISelectionCriterionTypeInterface
 {
@@ -43,11 +44,11 @@ public:
      * @param[out] strError string containing error information we can provide to client
      * @return true if succeed false otherwise
      */
-    virtual bool addValuePair(int iValue, const std::string& strValue, std::string& strError) = 0;
-    virtual bool getNumericalValue(const std::string& strValue, int& iValue) const = 0;
-    virtual bool getLiteralValue(int iValue, std::string& strValue) const = 0;
+    virtual bool addValuePair(uint64_t value, const std::string& strValue, std::string& strError) = 0;
+    virtual bool getNumericalValue(const std::string& strValue, uint64_t& iValue) const = 0;
+    virtual bool getLiteralValue(uint64_t iValue, std::string& strValue) const = 0;
     virtual bool isTypeInclusive() const = 0;
-    virtual std::string getFormattedState(int iValue) const = 0;
+    virtual std::string getFormattedState(uint64_t iValue) const = 0;
 
 protected:
     virtual ~ISelectionCriterionTypeInterface() {}

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -260,7 +260,7 @@ CTestPlatform::CommandReturn CTestPlatform::setCriterionState(
     // Reset errno to check if it is updated during the conversion (strtol/strtoul)
     errno = 0;
 
-    uint32_t state = strtoul(pcState, &pcStrEnd, 0);
+    uint64_t state = strtoull(pcState, &pcStrEnd, 0);
 
     if (!errno && (*pcStrEnd == '\0')) {
         // Sucessfull conversion, set criterion state by numerical state
@@ -303,7 +303,7 @@ bool CTestPlatform::createExclusiveSelectionCriterionFromStateList(
     assert(pCriterionType != NULL);
 
     uint32_t uiNbStates = remoteCommand.getArgumentCount() - 1;
-    uint32_t uiState;
+    uint64_t uiState;
 
     for (uiState = 0; uiState < uiNbStates; uiState++) {
 
@@ -336,21 +336,21 @@ bool CTestPlatform::createInclusiveSelectionCriterionFromStateList(
 
     uint32_t uiNbStates = remoteCommand.getArgumentCount() - 1;
 
-    if (uiNbStates > 32) {
+    if (uiNbStates > 64) {
 
-        strResult = "Maximum number of states for inclusive criterion is 32";
+        strResult = "Maximum number of states for inclusive criterion is 64";
 
         return false;
     }
 
-    uint32_t uiState;
+    uint64_t uiState;
 
     for (uiState = 0; uiState < uiNbStates; uiState++) {
 
         const std::string& strValue = remoteCommand.getArgument(uiState + 1);
 
         if (!pCriterionType->addValuePair(
-                    0x1 << uiState, strValue, strResult)) {
+                    0x1ull << uiState, strValue, strResult)) {
 
             strResult = "Unable to add value: " + strValue + ": " + strResult;
 
@@ -371,7 +371,7 @@ bool CTestPlatform::createExclusiveSelectionCriterion(const string& strName,
     ISelectionCriterionTypeInterface* pCriterionType =
         _pParameterMgrPlatformConnector->createSelectionCriterionType(false);
 
-    uint32_t uistate;
+    uint64_t uistate;
 
     for (uistate = 0; uistate < uiNbStates; uistate++) {
 
@@ -402,24 +402,24 @@ bool CTestPlatform::createInclusiveSelectionCriterion(const string& strName,
     ISelectionCriterionTypeInterface* pCriterionType =
         _pParameterMgrPlatformConnector->createSelectionCriterionType(true);
 
-    if (uiNbStates > 32) {
+    if (uiNbStates > 64) {
 
-        strResult = "Maximum number of states for inclusive criterion is 32";
+        strResult = "Maximum number of states for inclusive criterion is 64";
 
         return false;
     }
 
-    uint32_t uiState;
+    uint64_t uiState;
 
     for (uiState = 0; uiState < uiNbStates; uiState++) {
 
 	std::ostringstream ostrValue;
 
         ostrValue << "State_0x";
-        ostrValue << (0x1 << uiState);
+        ostrValue << (0x1ull << uiState);
 
         if (!pCriterionType->addValuePair(
-                    0x1 << uiState, ostrValue.str(), strResult)) {
+                    0x1ull << uiState, ostrValue.str(), strResult)) {
 
             strResult = "Unable to add value: "
                 + ostrValue.str() + ": " + strResult;
@@ -433,7 +433,7 @@ bool CTestPlatform::createInclusiveSelectionCriterion(const string& strName,
     return true;
 }
 
-bool CTestPlatform::setCriterionState(const string& strName, uint32_t uiState, string& strResult)
+bool CTestPlatform::setCriterionState(const string& strName, uint64_t uiState, string& strResult)
 {
     ISelectionCriterionInterface* pCriterion =
         _pParameterMgrPlatformConnector->getSelectionCriterion(strName);
@@ -482,7 +482,7 @@ bool CTestPlatform::setCriterionStateByLexicalSpace(const IRemoteCommand& remote
     }
 
     /// Translate lexical state to numerical state
-    int iNumericalState = 0;
+    uint64_t iNumericalState = 0;
     uint32_t uiLexicalSubStateIndex;
 
     // Parse lexical substates

--- a/test/test-platform/TestPlatform.h
+++ b/test/test-platform/TestPlatform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -138,7 +138,7 @@ private:
 
     bool createExclusiveSelectionCriterion(const std::string& strName, uint32_t uiNbValues, std::string& strResult);
     bool createInclusiveSelectionCriterion(const std::string& strName, uint32_t uiNbValues, std::string& strResult);
-    bool setCriterionState(const std::string& strName, uint32_t uiState, std::string& strResult);
+    bool setCriterionState(const std::string& strName, uint64_t uiState, std::string& strResult);
     bool setCriterionStateByLexicalSpace(const IRemoteCommand& remoteCommand, std::string& strResult);
 
     // Connector


### PR DESCRIPTION
Current implementation allows only 32 values for an inclusive
criterion. It comes from the use of a 32 bit integer for the
internal state representation.
This patch replaces the state representation by a 64 bit integer
which allows 64 bit. This is a temporary patch as the entire
interface should be reworked to avoid such problems in the
future.

Change-Id: I0521569a0a9cd40d83b75fe5c046bbf48c155a07
Tracked-On: https://jira01.devtools.intel.com/browse/IMINAN-31110
Signed-off-by: Jules Clero <julesx.clero@intel.com>