### PR TITLE
android/python bindings: force gcc and 32bits compilation

### DIFF
--- a/bindings/python/Android.mk
+++ b/bindings/python/Android.mk
@@ -38,6 +38,11 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := _PyPfw
 
 LOCAL_CPP_EXTENSION := .cxx
+# As long as the parameter-framework is compiled with gcc, we must avoid
+# compiling the bindings with clang and compile with gcc instead.
+LOCAL_CLANG := false
+# Android only provides a 32bit version of python.
+LOCAL_32_BIT_ONLY := true
 
 LOCAL_SHARED_LIBRARIES := libparameter_host
 LOCAL_STATIC_LIBRARIES := libxmlserializer_host

--- a/support/android/build_pfw_settings.mk
+++ b/support/android/build_pfw_settings.mk
@@ -36,8 +36,11 @@ $(LOCAL_BUILT_MODULE): MY_TOOL := $(HOST_OUT)/bin/domainGenerator.py
 # host's default python because the low-level python binding has been compiled
 # against Android's Python headers.
 $(LOCAL_BUILT_MODULE): MY_PYTHON := prebuilts/python/linux-x86/2.7.5/bin/python
-# The parameter-framework binding module is installed there on Android
-$(LOCAL_BUILT_MODULE): MY_ENV := PYTHONPATH=$(HOST_LIBRARY_PATH)
+# The parameter-framework binding module is installed on these locations on
+# Android (On 64bit machines, PyPfw.py is installed in the 'lib64' directory
+# and _PyPfw.so is installed in the 'lib' directory, hence the need for these
+# two directories in the PYTHONPATH)
+$(LOCAL_BUILT_MODULE): MY_ENV := PYTHONPATH=$(HOST_OUT_SHARED_LIBRARIES):$(2ND_HOST_OUT_SHARED_LIBRARIES)
 
 $(LOCAL_BUILT_MODULE): MY_TOPLEVEL_FILE := $(PFW_TOPLEVEL_FILE)
 $(LOCAL_BUILT_MODULE): MY_CRITERIA_FILE := $(PFW_CRITERIA_FILE)


### PR DESCRIPTION
Since Android only provides a 32bits version of the python interpreter and
libs, we need to compile for 32bits even on 64bits hosts.

Also, since it seems that clang is the default compiler for host, we need to
explicitely forbid it as long as the parameter-framework is compiled with gcc.

Change-Id: I5d484c0e58c304680192f443acd81258de179e52
Signed-off-by: David Wagner <david.wagner@intel.com>