### PR TITLE
python bindings: activate thread-safety code generation

### DIFF
--- a/bindings/python/pfw.i
+++ b/bindings/python/pfw.i
@@ -32,7 +32,7 @@
 // like derived C++ classes (calls to virtual methods will be properly
 // forwarded to Python) - only on classes for which is it specified, see
 // ILogger below..
-%module(directors="1") PyPfw
+%module(directors="1", threads="1") PyPfw
 
 %feature("director:except") {
     if ($error != NULL) {


### PR DESCRIPTION
The Parameter Framework may spawn a thread listening to request for command
execution. In this case, whenever a command produces a log, a callback function
provided by the client is called. When the client is a python script using the
python bindings, this causes a python function to be called in a different
context than the main thread. This can only work safely if a specific lock is
held before hand; see

    https://docs.python.org/2/c-api/init.html#non-python-created-threads

Fortunately, SWIG can generate the corresponding code automatically using

    %module(threads=1, ...) mymodule

Signed-off-by: David Wagner <david.wagner@intel.com>