### PR TITLE
Improve integration error log

### DIFF
--- a/parameter/SystemClass.cpp
+++ b/parameter/SystemClass.cpp
@@ -256,7 +256,8 @@ bool CSystemClass::loadPlugins(list<string>& lstrPluginFiles, list<string>& lstr
             lstrError.push_back("Subsystem plugin " + strPluginFileName +
                                 " does not contain " + strPluginSymbol + " symbol.");
 
-            continue;
+            // Serious error, break loop to throw it to caller.
+            break;
         }
 
         // Account for this success


### PR DESCRIPTION
Currently, dlsym() error is considered as dependancy issue.

This is most likely integration issue and must be reported
to the caller.

Signed-off-by: Miguel Gaio <miguel.gaio@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/106%23issuecomment-95878637%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/106%23discussion_r29341294%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/106%23issuecomment-95878637%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/2413551/badge%29%5D%28https%3A//coveralls.io/builds/2413551%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2070.13%25%20when%20pulling%20%2A%2A5efcee0b84f79bb8b89425176a8842c2e648ae5f%20on%20miguelgaio%3Afix-dlsum-error-path%2A%2A%20into%20%2A%2A9d1bcf046870f2c3bafede70dbb86c977b93c360%20on%2001org%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222015-04-24T09%3A56%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205efcee0b84f79bb8b89425176a8842c2e648ae5f%20parameter/SystemClass.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/106%23discussion_r29341294%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Unfortunately%20this%20will%20not%20stop%20plugin%20loads%20if%20at%20least%20one%20plugin%20successfully%20loaded.%20The%20outer%20loop%20will%20continue%20%5Bparameter/SystemClass.cpp%23L162%5D%28https%3A//github.com/01org/parameter-framework/blob/b3cb31f1b5aac2788e928879712109338548cfc1/parameter/SystemClass.cpp%23L162%29%5Cr%5Cn%5Cr%5CnMaybe%20the%20function%20should%20return%20an%20status%20%7B%20success%2C%20loadError%2C%20fatalError%20%7D.%5Cr%5Cn%5Cr%5CnNevertheless%2C%20your%20patch%20is%20better%20than%20nothing.%22%2C%20%22created_at%22%3A%20%222015-04-29T14%3A34%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/SystemClass.cpp%3AL256-264%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/106#issuecomment-95878637'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/2413551/badge)](https://coveralls.io/builds/2413551)
Coverage remained the same at 70.13% when pulling **5efcee0b84f79bb8b89425176a8842c2e648ae5f on miguelgaio:fix-dlsum-error-path** into **9d1bcf046870f2c3bafede70dbb86c977b93c360 on 01org:master**.
- [ ] <a href='#crh-comment-Pull 5efcee0b84f79bb8b89425176a8842c2e648ae5f parameter/SystemClass.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/106#discussion_r29341294'>File: parameter/SystemClass.cpp:L256-264</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Unfortunately this will not stop plugin loads if at least one plugin successfully loaded. The outer loop will continue [parameter/SystemClass.cpp#L162](https://github.com/01org/parameter-framework/blob/b3cb31f1b5aac2788e928879712109338548cfc1/parameter/SystemClass.cpp#L162)
Maybe the function should return an status { success, loadError, fatalError }.
Nevertheless, your patch is better than nothing.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/106?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/106?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/106'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>