### PR TITLE
Stop using stlport in Android.

### DIFF
--- a/parameter/Android.mk
+++ b/parameter/Android.mk
@@ -125,7 +125,8 @@ common_cflags := \
         -Wall \
         -Werror \
         -Wextra \
-        -Wno-unused-parameter
+        -Wno-unused-parameter \
+        -Wno-maybe-uninitialized \
 
 common_c_includes := \
     $(LOCAL_PATH)/include/ \
@@ -159,7 +160,6 @@ LOCAL_STATIC_LIBRARIES := libxmlserializer libpfw_utility libxml2
 LOCAL_REQUIRED_MODULES := libremote-processor
 
 LOCAL_CLANG := false
-include external/stlport/libstlport.mk
 include $(BUILD_SHARED_LIBRARY)
 
 ##############################

--- a/remote-process/Android.mk
+++ b/remote-process/Android.mk
@@ -68,7 +68,6 @@ LOCAL_SHARED_LIBRARIES := $(common_shared_libraries)
 LOCAL_STATIC_LIBRARIES := $(common_static_libraries)
 
 
-include external/stlport/libstlport.mk
 include $(BUILD_EXECUTABLE)
 
 ##############################

--- a/remote-processor/Android.mk
+++ b/remote-processor/Android.mk
@@ -67,7 +67,6 @@ LOCAL_MODULE := $(common_module)
 LOCAL_MODULE_OWNER := intel
 LOCAL_MODULE_TAGS := $(common_module_tags)
 
-include external/stlport/libstlport.mk
 include $(BUILD_SHARED_LIBRARY)
 
 ##############################

--- a/test/test-platform/Android.mk
+++ b/test/test-platform/Android.mk
@@ -63,7 +63,6 @@ LOCAL_LDLIBS := $(common_ldlibs)
 LOCAL_STATIC_LIBRARIES := libpfw_utility
 LOCAL_SHARED_LIBRARIES := $(common_shared_libraries)
 
-include external/stlport/libstlport.mk
 include $(BUILD_EXECUTABLE)
 
 ##############################

--- a/utility/Android.mk
+++ b/utility/Android.mk
@@ -60,7 +60,6 @@ LOCAL_MODULE_TAGS := $(common_module_tags)
 
 LOCAL_CFLAGS := $(common_cflags)
 
-include external/stlport/libstlport.mk
 include $(BUILD_STATIC_LIBRARY)
 
 ##############################

--- a/xmlserializer/Android.mk
+++ b/xmlserializer/Android.mk
@@ -79,7 +79,6 @@ LOCAL_STATIC_LIBRARIES := $(common_static_libraries)
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
-include external/stlport/libstlport.mk
 include $(BUILD_STATIC_LIBRARY)
 
 ##############################


### PR DESCRIPTION
Stlport has been deprecated in Android for a while now, and is finally
being removed very soon.