### PR TITLE
Xml Serialization: Manage the Unit and Description fields

### DIFF
--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -39,6 +39,8 @@
 
 using std::string;
 
+const std::string CElement::gDescriptionPropertyName = "Description";
+
 CElement::CElement(const string& strName) : _strName(strName), _pParent(NULL)
 {
 }
@@ -200,6 +202,14 @@ void CElement::showProperties(string& strResult) const
 {
     strResult = "\n";
     strResult += "Kind: " + getKind() + "\n";
+    showDescriptionProperty(strResult);
+}
+
+void CElement::showDescriptionProperty(std::string &strResult) const
+{
+    if (!getDescription().empty()) {
+        strResult += gDescriptionPropertyName + ": " + getDescription() + "\n";
+    }
 }
 
 // Conversion utilities
@@ -249,6 +259,8 @@ void CElement::logValue(string& strValue, CErrorContext& errorContext) const
 // From IXmlSink
 bool CElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
+    setDescription(getXmlDescriptionAttribute(xmlElement));
+
     // Propagate through children
     CXmlElement::CChildIterator childIterator(xmlElement);
 
@@ -316,7 +328,21 @@ void CElement::childrenToXml(CXmlElement& xmlElement,
 void CElement::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     setXmlNameAttribute(xmlElement);
+    setXmlDescriptionAttribute(xmlElement);
     childrenToXml(xmlElement, serializingContext);
+}
+
+void CElement::setXmlDescriptionAttribute(CXmlElement& xmlElement) const
+{
+    const string &description = getDescription();
+    if (!description.empty()) {
+        xmlElement.setAttributeString(gDescriptionPropertyName, description);
+    }
+}
+
+string CElement::getXmlDescriptionAttribute(const CXmlElement& xmlElement) const
+{
+    return xmlElement.getAttributeString(gDescriptionPropertyName);
 }
 
 void CElement::setXmlNameAttribute(CXmlElement& xmlElement) const

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -144,6 +144,30 @@ public:
 
     // Class kind
     virtual std::string getKind() const = 0;
+
+    /**
+     * Fill the Description field of the Xml Element during XML composing.
+     *
+     * @param[in,out] xmlElement to fill with the description
+     */
+    void setXmlDescriptionAttribute(CXmlElement& xmlElement) const;
+
+    /**
+     * Extract the Description field from the Xml Element during XML decomposing.
+     *
+     * @param[in] xmlElement to extract the description from.
+     *
+     * @return description represented as a string, empty if not found
+     */
+    std::string getXmlDescriptionAttribute(const CXmlElement &xmlElement) const;
+
+    /**
+     * Appends if found human readable description property.
+     *
+     * @param[out] strResult in which the description is wished to be appended.
+     */
+    void showDescriptionProperty(std::string &strResult) const;
+
 protected:
     // Content dumping
     virtual void logValue(std::string& strValue, CErrorContext& errorContext) const;
@@ -193,4 +217,6 @@ private:
     std::vector<CElement*> _childArray;
     // Parent
     CElement* _pParent;
+
+    static const std::string gDescriptionPropertyName;
 };

--- a/parameter/InstanceConfigurableElement.cpp
+++ b/parameter/InstanceConfigurableElement.cpp
@@ -216,3 +216,10 @@ bool CInstanceConfigurableElement::checkPathExhausted(CPathNavigator& pathNaviga
     }
     return true;
 }
+
+void CInstanceConfigurableElement::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+{
+    base::toXml(xmlElement, serializingContext);
+    // Since Description belongs to the Type of Element, delegate it to the type element.
+    getTypeElement()->setXmlDescriptionAttribute(xmlElement);
+}

--- a/parameter/InstanceConfigurableElement.h
+++ b/parameter/InstanceConfigurableElement.h
@@ -102,6 +102,9 @@ public:
      */
     virtual void getListOfElementsWithMapping(std::list<const CConfigurableElement*>&
                                                configurableElementPath) const;
+
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
+
 protected:
     // Syncer
     virtual ISyncer* getSyncer() const;

--- a/parameter/ParameterType.cpp
+++ b/parameter/ParameterType.cpp
@@ -36,6 +36,8 @@
 
 using std::string;
 
+const std::string CParameterType::gUnitPropertyName = "Unit";
+
 CParameterType::CParameterType(const string& strName) : base(strName), _uiSize(0)
 {
 }
@@ -68,13 +70,31 @@ string CParameterType::getUnit() const
     return _strUnit;
 }
 
+void CParameterType::setUnit(const std::string& strUnit)
+{
+    _strUnit = strUnit;
+}
+
 // From IXmlSink
 bool CParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
-    // Unit
-    _strUnit = xmlElement.getAttributeString("Unit");
-
+    setUnit(xmlElement.getAttributeString(gUnitPropertyName));
     return base::fromXml(xmlElement, serializingContext);
+}
+
+// From IXmlSource
+void CParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+{
+    base::toXml(xmlElement, serializingContext);
+    setXmlUnitAttribute(xmlElement);
+}
+
+void CParameterType::setXmlUnitAttribute(CXmlElement& xmlElement) const
+{
+    const string& unit = getUnit();
+    if (!unit.empty()) {
+        xmlElement.setAttributeString(gUnitPropertyName, unit);
+    }
 }
 
 // XML Serialization value space handling
@@ -91,10 +111,9 @@ void CParameterType::showProperties(string& strResult) const
 {
     base::showProperties(strResult);
 
-    // Unit
-    if (!_strUnit.empty()) {
-
-        strResult += "Unit: " + _strUnit + "\n";
+    // Add Unit property if found
+    if (!getUnit().empty()) {
+        strResult += gUnitPropertyName + ": " + getUnit() + "\n";
     }
 
     // Scalar size

--- a/parameter/ParameterType.h
+++ b/parameter/ParameterType.h
@@ -50,9 +50,13 @@ public:
 
     // Unit
     std::string getUnit() const;
+    void setUnit(const std::string& strUnit);
 
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+
+    // From IXmlSource
+    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
 
     /// Conversions
     // String
@@ -118,6 +122,8 @@ protected:
     }
 
 private:
+    void setXmlUnitAttribute(CXmlElement& xmlElement) const;
+
     // Instantiation
     virtual CInstanceConfigurableElement* doInstantiate() const;
     // Generic Access
@@ -130,4 +136,6 @@ private:
     uint32_t _uiSize;
     // Unit
     std::string _strUnit;
+
+    static const std::string gUnitPropertyName;
 };

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -104,6 +104,10 @@ bool CSubsystem::needResync(bool bClear)
 // From IXmlSink
 bool CSubsystem::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
+    // Subsystem class does not rely on generic fromXml algorithm of Element class.
+    // So, setting here the description if found as XML attribute.
+    setDescription(getXmlDescriptionAttribute(xmlElement));
+
     // Context
     CXmlParameterSerializingContext& parameterBuildContext = static_cast<CXmlParameterSerializingContext&>(serializingContext);
 

--- a/parameter/TypeElement.cpp
+++ b/parameter/TypeElement.cpp
@@ -76,8 +76,11 @@ bool CTypeElement::hasMappingData() const
 // Element properties
 void CTypeElement::showProperties(std::string& strResult) const
 {
-    (void)strResult;
-    // Prevent base from being called in that context!
+    // The description attribute may be found in the type and not from instance.
+    showDescriptionProperty(strResult);
+    // Prevent base from being called from the Parameter Type context as
+    // it would lead to duplicate the name attribute (duplicated in the type and instance
+    // which have a common base Element)
 }
 
 void CTypeElement::populate(CElement* pElement) const


### PR DESCRIPTION
This patchs adds the support of Unit and Description fields for the import / export and showProperties commands.