### PR TITLE
xml generator tests

### DIFF
--- a/test/xml-generator/CMakeLists.txt
+++ b/test/xml-generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -26,9 +26,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_subdirectory(test-platform)
-add_subdirectory(test-fixed-point-parameter)
-add_subdirectory(tokenizer)
-add_subdirectory(xml-generator)
-add_subdirectory(functional-tests)
-add_subdirectory(test-subsystem)
+if (BUILD_TESTING)
+
+    add_test(NAME xml-generator
+             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools/xmlGenerator
+             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test.sh)
+
+    # Custom function defined in the top-level CMakeLists
+    set_test_env(xml-generator)
+endif()

--- a/test/xml-generator/Class.xml
+++ b/test/xml-generator/Class.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SystemClass Name="Test">
+    <SubsystemInclude Path="Subsystem.xml"/>
+</SystemClass>

--- a/test/xml-generator/ParameterFrameworkConfiguration.xml
+++ b/test/xml-generator/ParameterFrameworkConfiguration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ParameterFrameworkConfiguration SystemClassName="Test" ServerPort="5066" TuningAllowed="false">
+    <SubsystemPlugins>
+    </SubsystemPlugins>
+    <StructureDescriptionFileLocation Path="Class.xml"/>
+</ParameterFrameworkConfiguration>

--- a/test/xml-generator/Subsystem.xml
+++ b/test/xml-generator/Subsystem.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Subsystem Name="test" Type="Virtual" Endianness="Little"  xmlns:xi="http://www.w3.org/2001/XInclude">
+    <ComponentLibrary>
+        <xi:include href="TuningStructure.xml"/>
+    </ComponentLibrary>
+    <InstanceDefinition>
+
+        <Component Type="Tuning" Name="tuning"/>
+
+        <ParameterBlock Name="block" ArrayLength="5">
+            <FixedPointParameter Name="q2.5" Size="8" Integral="2" Fractional="5"/>
+            <IntegerParameter Name="uint8" Signed="false" Size="8"/>
+            <StringParameter Name="string" MaxLength="20"/>
+        </ParameterBlock>
+
+    </InstanceDefinition>
+</Subsystem>

--- a/test/xml-generator/TuningSettings.xml
+++ b/test/xml-generator/TuningSettings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConfigurableDomains SystemClassName="Test">
+    <ConfigurableDomain Name="Calibration" SequenceAware="false">
+        <Configurations>
+            <Configuration Name="default">
+                <CompoundRule Type="All">
+                </CompoundRule>
+            </Configuration>
+        </Configurations>
+
+        <ConfigurableElements>
+            <ConfigurableElement Path="/Test/test/tuning/bool"/>
+        </ConfigurableElements>
+
+        <Settings>
+            <Configuration Name="default">
+                <ConfigurableElement Path="/Test/test/tuning/bool">
+                    <BooleanParameter Name="bool">1</BooleanParameter>
+                </ConfigurableElement>
+            </Configuration>
+        </Settings>
+    </ConfigurableDomain>
+</ConfigurableDomains>

--- a/test/xml-generator/TuningStructure.xml
+++ b/test/xml-generator/TuningStructure.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ComponentLibrary>
+    <ComponentType Name="Tuning">
+        <BooleanParameter Name="bool"/>
+    </ComponentType>
+</ComponentLibrary>

--- a/test/xml-generator/criteria.txt
+++ b/test/xml-generator/criteria.txt
@@ -1,0 +1,2 @@
+InclusiveCriterion Colors : Red Green Blue
+ExclusiveCriterion Switch : On Off

--- a/test/xml-generator/first.pfw
+++ b/test/xml-generator/first.pfw
@@ -1,0 +1,33 @@
+domainGroup: EddGroup
+	Colors Includes Red
+
+	# Only inherits from "EddGroup" domainGroup
+	domain: First
+		Colors Includes Blue
+
+		confGroup: Green
+			Colors Includes Green
+
+			# Inherits from "EddGroup" domainGroup, "First" domain
+			# and from "Green" confGroup
+			conf: On
+				Switch Is On
+
+				component: /Test/test/block/1
+					q2.5 = 1.2
+					string = some string
+
+			# Inherits from "EddGroup" domainGroup, "First" domain
+			# and from "Green" confGroup
+			conf: Off
+				Switch Is Off
+
+				component: /Test/test/block/1
+					q2.5 = 1.2
+					string = some string
+
+		# Inherits from "EddGroup" domainGroup and "First" domain
+		conf: Default
+			component: /Test/test/block/1
+				q2.5 = 0
+				string = some other string

--- a/test/xml-generator/fourth.xml
+++ b/test/xml-generator/fourth.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConfigurableDomain Name="Fourth" SequenceAware="false">
+    <Configurations>
+        <Configuration Name="default">
+            <CompoundRule Type="All">
+            </CompoundRule>
+        </Configuration>
+    </Configurations>
+
+    <ConfigurableElements>
+        <ConfigurableElement Path="/Test/test/block/4"/>
+    </ConfigurableElements>
+
+    <Settings>
+        <Configuration Name="default">
+            <ConfigurableElement Path="/Test/test/block/4">
+                <ParameterBlock Name="4">
+                    <FixedPointParameter Name="q2.5">1.23</FixedPointParameter>
+                    <IntegerParameter Name="uint8">200</IntegerParameter>
+                    <StringParameter Name="string">blah</StringParameter>
+                </ParameterBlock>
+            </ConfigurableElement>
+        </Configuration>
+    </Settings>
+</ConfigurableDomain>

--- a/test/xml-generator/reference.xml
+++ b/test/xml-generator/reference.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+  <ConfigurableDomain Name="Calibration" SequenceAware="false">
+    <Configurations>
+      <Configuration Name="default">
+        <CompoundRule Type="All"/>
+      </Configuration>
+    </Configurations>
+    <ConfigurableElements>
+      <ConfigurableElement Path="/Test/test/tuning/bool"/>
+    </ConfigurableElements>
+    <Settings>
+      <Configuration Name="default">
+        <ConfigurableElement Path="/Test/test/tuning/bool">
+          <BooleanParameter Name="bool">1</BooleanParameter>
+        </ConfigurableElement>
+      </Configuration>
+    </Settings>
+  </ConfigurableDomain>
+  <ConfigurableDomain Name="Third" SequenceAware="false">
+    <Configurations>
+      <Configuration Name="default">
+        <CompoundRule Type="All"/>
+      </Configuration>
+    </Configurations>
+    <ConfigurableElements>
+      <ConfigurableElement Path="/Test/test/block/3"/>
+    </ConfigurableElements>
+    <Settings>
+      <Configuration Name="default">
+        <ConfigurableElement Path="/Test/test/block/3">
+          <ParameterBlock Name="3">
+            <FixedPointParameter Name="q2.5">1.21875</FixedPointParameter>
+            <IntegerParameter Name="uint8">200</IntegerParameter>
+            <StringParameter Name="string">blah</StringParameter>
+          </ParameterBlock>
+        </ConfigurableElement>
+      </Configuration>
+    </Settings>
+  </ConfigurableDomain>
+  <ConfigurableDomain Name="Fourth" SequenceAware="false">
+    <Configurations>
+      <Configuration Name="default">
+        <CompoundRule Type="All"/>
+      </Configuration>
+    </Configurations>
+    <ConfigurableElements>
+      <ConfigurableElement Path="/Test/test/block/4"/>
+    </ConfigurableElements>
+    <Settings>
+      <Configuration Name="default">
+        <ConfigurableElement Path="/Test/test/block/4">
+          <ParameterBlock Name="4">
+            <FixedPointParameter Name="q2.5">1.21875</FixedPointParameter>
+            <IntegerParameter Name="uint8">200</IntegerParameter>
+            <StringParameter Name="string">blah</StringParameter>
+          </ParameterBlock>
+        </ConfigurableElement>
+      </Configuration>
+    </Settings>
+  </ConfigurableDomain>
+  <ConfigurableDomain Name="EddGroup.First" SequenceAware="false">
+    <Configurations>
+      <Configuration Name="Green.On">
+        <CompoundRule Type="All">
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Red"/>
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Blue"/>
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Green"/>
+          <SelectionCriterionRule SelectionCriterion="Switch" MatchesWhen="Is" Value="On"/>
+        </CompoundRule>
+      </Configuration>
+      <Configuration Name="Green.Off">
+        <CompoundRule Type="All">
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Red"/>
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Blue"/>
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Green"/>
+          <SelectionCriterionRule SelectionCriterion="Switch" MatchesWhen="Is" Value="Off"/>
+        </CompoundRule>
+      </Configuration>
+      <Configuration Name="Default">
+        <CompoundRule Type="All">
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Red"/>
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Blue"/>
+        </CompoundRule>
+      </Configuration>
+    </Configurations>
+    <ConfigurableElements>
+      <ConfigurableElement Path="/Test/test/block/1/q2.5"/>
+      <ConfigurableElement Path="/Test/test/block/1/string"/>
+    </ConfigurableElements>
+    <Settings>
+      <Configuration Name="Green.On">
+        <ConfigurableElement Path="/Test/test/block/1/q2.5">
+          <FixedPointParameter Name="q2.5">1.18750</FixedPointParameter>
+        </ConfigurableElement>
+        <ConfigurableElement Path="/Test/test/block/1/string">
+          <StringParameter Name="string">some string</StringParameter>
+        </ConfigurableElement>
+      </Configuration>
+      <Configuration Name="Green.Off">
+        <ConfigurableElement Path="/Test/test/block/1/q2.5">
+          <FixedPointParameter Name="q2.5">1.18750</FixedPointParameter>
+        </ConfigurableElement>
+        <ConfigurableElement Path="/Test/test/block/1/string">
+          <StringParameter Name="string">some string</StringParameter>
+        </ConfigurableElement>
+      </Configuration>
+      <Configuration Name="Default">
+        <ConfigurableElement Path="/Test/test/block/1/q2.5">
+          <FixedPointParameter Name="q2.5">0.00000</FixedPointParameter>
+        </ConfigurableElement>
+        <ConfigurableElement Path="/Test/test/block/1/string">
+          <StringParameter Name="string">some other string</StringParameter>
+        </ConfigurableElement>
+      </Configuration>
+    </Settings>
+  </ConfigurableDomain>
+  <ConfigurableDomain Name="EddGroup.Second" SequenceAware="false">
+    <Configurations>
+      <Configuration Name="Blue.On">
+        <CompoundRule Type="All">
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Red"/>
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Blue"/>
+          <SelectionCriterionRule SelectionCriterion="Switch" MatchesWhen="Is" Value="On"/>
+        </CompoundRule>
+      </Configuration>
+      <Configuration Name="Blue.Off">
+        <CompoundRule Type="All">
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Red"/>
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Blue"/>
+        </CompoundRule>
+      </Configuration>
+      <Configuration Name="Green">
+        <CompoundRule Type="All">
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Red"/>
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Green"/>
+        </CompoundRule>
+      </Configuration>
+      <Configuration Name="Default">
+        <CompoundRule Type="All">
+          <SelectionCriterionRule SelectionCriterion="Colors" MatchesWhen="Includes" Value="Red"/>
+        </CompoundRule>
+      </Configuration>
+    </Configurations>
+    <ConfigurableElements>
+      <ConfigurableElement Path="/Test/test/block/2/uint8"/>
+    </ConfigurableElements>
+    <Settings>
+      <Configuration Name="Blue.On">
+        <ConfigurableElement Path="/Test/test/block/2/uint8">
+          <IntegerParameter Name="uint8">3</IntegerParameter>
+        </ConfigurableElement>
+      </Configuration>
+      <Configuration Name="Blue.Off">
+        <ConfigurableElement Path="/Test/test/block/2/uint8">
+          <IntegerParameter Name="uint8">4</IntegerParameter>
+        </ConfigurableElement>
+      </Configuration>
+      <Configuration Name="Green">
+        <ConfigurableElement Path="/Test/test/block/2/uint8">
+          <IntegerParameter Name="uint8">5</IntegerParameter>
+        </ConfigurableElement>
+      </Configuration>
+      <Configuration Name="Default">
+        <ConfigurableElement Path="/Test/test/block/2/uint8">
+          <IntegerParameter Name="uint8">6</IntegerParameter>
+        </ConfigurableElement>
+      </Configuration>
+    </Settings>
+  </ConfigurableDomain>
+</ConfigurableDomains>

--- a/test/xml-generator/second.pfw
+++ b/test/xml-generator/second.pfw
@@ -1,0 +1,29 @@
+domainGroup: EddGroup
+	Colors Includes Red
+
+	domain: Second
+
+		confType: On
+			Switch Is On
+
+		confGroup: Blue
+			Colors Includes Blue
+
+			# Inherits from "EddGroup" domainGroup, "Blue" confGroup
+			# and from "On" confType
+			conf: On
+				/Test/test/block/2/uint8 = 3
+
+			# Inherits from "EddGroup" domainGroup and "Blue" confGroup
+			conf: Off
+				/Test/test/block/2/uint8 = 4
+
+		# Only inherits from "EddGroup" domainGroup
+		conf: Green
+			Colors Includes Green
+
+			/Test/test/block/2/uint8 = 5
+
+		# Only inherits from "EddGroup" domainGroup
+		conf: Default
+			/Test/test/block/2/uint8 = 6

--- a/test/xml-generator/test.sh
+++ b/test/xml-generator/test.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -26,9 +26,14 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_subdirectory(test-platform)
-add_subdirectory(test-fixed-point-parameter)
-add_subdirectory(tokenizer)
-add_subdirectory(xml-generator)
-add_subdirectory(functional-tests)
-add_subdirectory(test-subsystem)
+basedir=$(dirname $0)
+
+./domainGenerator.py --validate \
+    --toplevel-config $basedir/ParameterFrameworkConfiguration.xml \
+    --criteria $basedir/criteria.txt \
+    --initial-settings $basedir/TuningSettings.xml \
+    --add-edds $basedir/first.pfw $basedir/second.pfw \
+    --add-domains $basedir/third.xml $basedir/fourth.xml \
+    --schemas-dir $basedir/../../Schemas | \
+    \
+    diff --brief $basedir/reference.xml -

--- a/test/xml-generator/third.xml
+++ b/test/xml-generator/third.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConfigurableDomain Name="Third" SequenceAware="false">
+    <Configurations>
+        <Configuration Name="default">
+            <CompoundRule Type="All">
+            </CompoundRule>
+        </Configuration>
+    </Configurations>
+
+    <ConfigurableElements>
+        <ConfigurableElement Path="/Test/test/block/3"/>
+    </ConfigurableElements>
+
+    <Settings>
+        <Configuration Name="default">
+            <ConfigurableElement Path="/Test/test/block/3">
+                <ParameterBlock Name="3">
+                    <FixedPointParameter Name="q2.5">1.23</FixedPointParameter>
+                    <IntegerParameter Name="uint8">200</IntegerParameter>
+                    <StringParameter Name="string">blah</StringParameter>
+                </ParameterBlock>
+            </ConfigurableElement>
+        </Configuration>
+    </Settings>
+</ConfigurableDomain>


### PR DESCRIPTION
Introduce basic tests for domainGenerator.py. No error case is covered yet.

As it stood, the XML validity checking code wasn't covered. This new test also
covers it. Same applies for <xi:include> tags: there wasn't any test suite
using them. This one does. Each of these features should have their own test
but this is a quick and easy solution.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/118%23issuecomment-105538077%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23issuecomment-105544120%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23issuecomment-105835389%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23issuecomment-105958425%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31115561%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31116017%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31116928%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31117203%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31117323%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31117608%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31127829%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31127967%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31129200%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31129701%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/118%23issuecomment-105538077%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20please%20review%22%2C%20%22created_at%22%3A%20%222015-05-26T14%3A13%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Coveralls%20seems%20somewhat%20broken%20but%20this%20PR%20does%20in%20fact%20improve%20coverage%20from%2070.19%25%20to%2072.44%25%20%21%22%2C%20%22created_at%22%3A%20%222015-05-26T14%3A30%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Remove%20the%20empty%20file%20_test/xml-generator/output.xml_%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-05-27T09%3A19%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/2662033/badge%29%5D%28https%3A//coveralls.io/builds/2662033%29%5Cn%5CnCoverage%20increased%20%28%2B2.08%25%29%20to%2072.23%25%20when%20pulling%20%2A%2Afceb4636a1460274770efdc3219a8c59b71f129a%20on%20dawagner%3Axmlgenerator-smoketest%2A%2A%20into%20%2A%2Aa460839bd77647606c9db21fc13b92c8a254f2d8%20on%2001org%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222015-05-27T15%3A27%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2034d3eec15e3921a61ac35848ec3b12424045d15e%20test/xml-generator/Class.xml%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31116017%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Are%20you%20sure%20this%20file%20is%20rely%20needed%20%3F%20Is%20it%20adding%20something%20in%20your%20coverage%20%3F%22%2C%20%22created_at%22%3A%20%222015-05-27T09%3A21%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well...%20this%20is%20the%20SystemClass.%20If%20it%27s%20not%20defined%2C%20the%20Parameter%20Framework%20will%20not%20start.%22%2C%20%22created_at%22%3A%20%222015-05-27T09%3A39%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%2C%20%60SystemClass%60%20does%20not%20need%20to%20have%20it%27s%20dedicated%20file%2C%20you%20can%20replace%20%60%3CSubsystemInclude%20Path%3D%5C%22Subsystem.xml%5C%22/%3E%60%20by%20the%20content%20of%20%2ASubsystem.xml%2A.%22%2C%20%22created_at%22%3A%20%222015-05-27T12%3A29%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Whaaaaat%20%3F%20How%20did%20I%20not%20know/forget%20about%20that%20%3F%20ok%20then%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-05-27T12%3A48%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/xml-generator/Class.xml%3AL1-5%22%7D%2C%20%22Pull%2034d3eec15e3921a61ac35848ec3b12424045d15e%20test/xml-generator/ParameterFrameworkConfiguration.xml%203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31117203%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20are%20some%20xml%20file%20name%20in%20upper%20case%20and%20other%20in%20lower%20case%20%3F%22%2C%20%22created_at%22%3A%20%222015-05-27T09%3A37%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20used%20UpperCamelCase%20for%20the%20files%20that%20are%20used%20directly%20by%20the%20parameter%20framework%20instance%20started%20by%20the%20test%20suite%20because%20that%27s%20how%20we%20have%20done%20it%20historically.%20I%27ve%20used%20a%20%5C%22free%20format%5C%22%20for%20the%20files%20that%20are%20imported%20by%20the%20xml%20generator.%22%2C%20%22created_at%22%3A%20%222015-05-27T09%3A43%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20do%20not%20know%2C%20I%20think%20we%20discouraged%20upper%20case%20file%20names%20in%20the%20coding%20style%2C%20didn%27t%20we%20%3F%22%2C%20%22created_at%22%3A%20%222015-05-27T12%3A31%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20think%20we%20have.%22%2C%20%22created_at%22%3A%20%222015-05-27T12%3A55%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/xml-generator/ParameterFrameworkConfiguration.xml%3AL1-7%22%7D%2C%20%22Pull%2034d3eec15e3921a61ac35848ec3b12424045d15e%20test/xml-generator/CMakeLists.txt%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/118%23discussion_r31115561%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Alignment%22%2C%20%22created_at%22%3A%20%222015-05-27T09%3A14%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222015-05-27T09%3A33%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/xml-generator/CMakeLists.txt%3AL1-38%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/118#issuecomment-105538077'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard please review
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Coveralls seems somewhat broken but this PR does in fact improve coverage from 70.19% to 72.44% !
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Remove the empty file _test/xml-generator/output.xml_
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/2662033/badge)](https://coveralls.io/builds/2662033)
Coverage increased (+2.08%) to 72.23% when pulling **fceb4636a1460274770efdc3219a8c59b71f129a on dawagner:xmlgenerator-smoketest** into **a460839bd77647606c9db21fc13b92c8a254f2d8 on 01org:master**.
- [ ] <a href='#crh-comment-Pull 34d3eec15e3921a61ac35848ec3b12424045d15e test/xml-generator/CMakeLists.txt 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/118#discussion_r31115561'>File: test/xml-generator/CMakeLists.txt:L1-38</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Alignment
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> done
- [ ] <a href='#crh-comment-Pull 34d3eec15e3921a61ac35848ec3b12424045d15e test/xml-generator/Class.xml 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/118#discussion_r31116017'>File: test/xml-generator/Class.xml:L1-5</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Are you sure this file is rely needed ? Is it adding something in your coverage ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Well... this is the SystemClass. If it's not defined, the Parameter Framework will not start.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> No, `SystemClass` does not need to have it's dedicated file, you can replace `<SubsystemInclude Path="Subsystem.xml"/>` by the content of *Subsystem.xml*.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Whaaaaat ? How did I not know/forget about that ? ok then :)
- [ ] <a href='#crh-comment-Pull 34d3eec15e3921a61ac35848ec3b12424045d15e test/xml-generator/ParameterFrameworkConfiguration.xml 3'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/118#discussion_r31117203'>File: test/xml-generator/ParameterFrameworkConfiguration.xml:L1-7</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Why are some xml file name in upper case and other in lower case ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I used UpperCamelCase for the files that are used directly by the parameter framework instance started by the test suite because that's how we have done it historically. I've used a "free format" for the files that are imported by the xml generator.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I do not know, I think we discouraged upper case file names in the coding style, didn't we ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I don't think we have.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/118?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/118?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/118'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>