### PR TITLE
libremote-processor must link against libpfw_utility

### DIFF
--- a/remote-processor/Android.mk
+++ b/remote-processor/Android.mk
@@ -60,6 +60,8 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := $(common_src_files)
 
+LOCAL_STATIC_LIBRARIES := libpfw_utility
+
 LOCAL_CFLAGS := $(common_cflags)
 LOCAL_LDLIBS := $(common_ldlibs)
 
@@ -76,6 +78,8 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := $(common_src_files)
+
+LOCAL_STATIC_LIBRARIES := libpfw_utility_host
 
 LOCAL_CFLAGS := $(common_cflags)
 LOCAL_LDLIBS := $(common_ldlibs)

--- a/remote-processor/CMakeLists.txt
+++ b/remote-processor/CMakeLists.txt
@@ -41,6 +41,6 @@ find_package(Threads REQUIRED)
 
 include_directories("${PROJECT_SOURCE_DIR}/utility")
 
-target_link_libraries(remote-processor ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(remote-processor pfw_utility ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS remote-processor LIBRARY DESTINATION lib)

--- a/utility/Android.mk
+++ b/utility/Android.mk
@@ -34,7 +34,8 @@ LOCAL_PATH := $(call my-dir)
 common_src_files := \
     Tokenizer.cpp \
     Utility.cpp \
-    NaiveTokenizer.cpp
+    NaiveTokenizer.cpp \
+    FullIo.cpp \
 
 common_module := libpfw_utility
 common_module_tags := optional


### PR DESCRIPTION
It uses Utility::fullRead and Utility::fullWrite and must therefore link
against libpfw_utility.