### PR TITLE
ParameterMgr: make the logger mutable

### DIFF
--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -612,7 +612,7 @@ private:
     pthread_mutex_t _blackboardMutex;
 
     /** Application main logger based on the one provided by the client */
-    core::log::Logger _logger;
+    mutable core::log::Logger _logger;
 
     /** If set to false, the remote interface won't be started no matter what.
      * If set to true - the default - it has no impact on the policy for


### PR DESCRIPTION
If it isn't mutable, we can't possibly log from const methods.

Signed-off-by: David Wagner <david.wagner@intel.com>