### PR TITLE
libcriterion: Make a separate library for Criteria

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -28,7 +28,9 @@
 
 add_library(cparameter SHARED ParameterFramework.cpp)
 
-include_directories("${PROJECT_SOURCE_DIR}/parameter/include")
+include_directories(
+    "${PROJECT_SOURCE_DIR}/parameter/criterion/include"
+    "${PROJECT_SOURCE_DIR}/parameter/include")
 
 install(FILES ParameterFramework.h
         DESTINATION "include/parameter/c")

--- a/bindings/c/ParameterFramework.cpp
+++ b/bindings/c/ParameterFramework.cpp
@@ -41,12 +41,12 @@
 #include <cstdlib>
 
 using std::string;
+using core::criterion::CriterionInterface;
 
 /** Rename long pfw types to short ones in pfw namespace. */
 namespace pfw
 {
-    typedef ISelectionCriterionInterface Criterion;
-    typedef std::map<string, Criterion *> Criteria;
+    typedef std::map<string, CriterionInterface *> Criteria;
     typedef CParameterMgrPlatformConnector Pfw;
 }
 
@@ -188,7 +188,7 @@ bool PfwHandler::createCriteria(const PfwCriterion criteriaArray[], size_t crite
         }
 
         // Create criterion
-        ISelectionCriterionInterface *newCriterion = (criterion.inclusive ?
+        CriterionInterface *newCriterion = (criterion.inclusive ?
                 pfw->createInclusiveCriterion(criterion.name) :
                 pfw->createExclusiveCriterion(criterion.name));
         assert(newCriterion != NULL);
@@ -256,8 +256,7 @@ const char *pfwGetLastError(const PfwHandler *handle)
     return handle == NULL ? NULL : handle->lastStatus.msg().c_str();
 }
 
-static pfw::Criterion *getCriterion(const pfw::Criteria &criteria,
-                                    const string &name)
+static CriterionInterface *getCriterion(const pfw::Criteria &criteria, const string &name)
 {
     pfw::Criteria::const_iterator it = criteria.find(name);
     return it == criteria.end() ? NULL : it->second;
@@ -275,7 +274,7 @@ bool pfwSetCriterion(PfwHandler *handle, const char name[], int value)
         return status.failure("Can not set criterion \"" + string(name) +
                               "\" as the parameter framework is not started.");
     }
-    pfw::Criterion *criterion = getCriterion(handle->criteria, name);
+    CriterionInterface *criterion = getCriterion(handle->criteria, name);
     if (criterion == NULL) {
         return status.failure("Can not set criterion " + string(name) + " as does not exist");
     }
@@ -298,7 +297,7 @@ bool pfwGetCriterion(const PfwHandler *handle, const char name[], int *value)
         return status.failure("Can not get criterion \"" + string(name) +
                               "\" as the out value is NULL.");
     }
-    pfw::Criterion *criterion = getCriterion(handle->criteria, name);
+    CriterionInterface *criterion = getCriterion(handle->criteria, name);
     if (criterion == NULL) {
         return status.failure("Can not get criterion " + string(name) + " as it does not exist");
     }

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -36,7 +36,9 @@ find_package(PythonInterp 2.7 REQUIRED)
 find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
 
-include_directories(${PROJECT_SOURCE_DIR}/parameter/include)
+include_directories(
+    ${PROJECT_SOURCE_DIR}/parameter/include
+    ${PROJECT_SOURCE_DIR}/parameter/criterion/include)
 
 set_property(SOURCE pfw.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE pfw.i PROPERTY SWIG_FLAGS "-Wall" "-Werror")

--- a/bindings/python/pfw.i
+++ b/bindings/python/pfw.i
@@ -80,9 +80,14 @@ public:
 
     void setLogger(ILogger* pLogger);
 
-    ISelectionCriterionInterface* createExclusiveCriterion(const std::string& strName);
-    ISelectionCriterionInterface* createInclusiveCriterion(const std::string& strName);
-    ISelectionCriterionInterface* getSelectionCriterion(const std::string& strName);
+    core::criterion::CriterionInterface*
+    createExclusiveCriterion(const std::string& name);
+
+    core::criterion::CriterionInterface*
+    createInclusiveCriterion(const std::string& name);
+
+    core::criterion::CriterionInterface*
+    getSelectionCriterion(const std::string& name);
 
     // Configuration application
     void applyConfigurations();
@@ -192,10 +197,15 @@ class ILogger
 typedef CParameterMgrFullConnector::ILogger ILogger;
 %}
 
-class ISelectionCriterionInterface
+namespace core
+{
+namespace criterion
+{
+
+class CriterionInterface
 {
 %{
-#include "SelectionCriterionInterface.h"
+#include <criterion/client/CriterionInterface.h>
 %}
 
 public:
@@ -215,5 +225,8 @@ public:
     virtual bool isInclusive() const = 0;
 
 protected:
-    virtual ~ISelectionCriterionInterface() {}
+    virtual ~CriterionInterface() {}
 };
+
+} /** criterion namespace */
+} /** core namespace */

--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -26,6 +26,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+add_subdirectory(criterion)
+
 add_library(parameter SHARED
     AreaConfiguration.cpp
     ArrayParameter.cpp
@@ -59,7 +61,6 @@ add_library(parameter SHARED
     FormattedSubsystemObject.cpp
     FrameworkConfigurationLocation.cpp
     HardwareBackSynchronizer.cpp
-    InclusiveCriterion.cpp
     InstanceConfigurableElement.cpp
     InstanceDefinition.cpp
     IntegerParameterType.cpp
@@ -81,8 +82,6 @@ add_library(parameter SHARED
     PathNavigator.cpp
     PluginLocation.cpp
     RuleParser.cpp
-    SelectionCriteria.cpp
-    SelectionCriterion.cpp
     SelectionCriterionRule.cpp
     SimulatedBackSynchronizer.cpp
     StringParameter.cpp
@@ -105,11 +104,12 @@ include_directories(
     "${PROJECT_SOURCE_DIR}/xmlserializer"
     "${PROJECT_SOURCE_DIR}/utility"
     "${PROJECT_SOURCE_DIR}/remote-processor"
-    "${PROJECT_SOURCE_DIR}/parameter/log/include")
+    "${PROJECT_SOURCE_DIR}/parameter/log/include"
+    "${PROJECT_SOURCE_DIR}/parameter/criterion/include")
 
 # No need to link with libremote-processor: it is accessed via dlopen()
 find_library(dl dl)
-target_link_libraries(parameter xmlserializer pfw_utility dl)
+target_link_libraries(parameter xmlserializer pfw_utility dl criterion)
 
 install(TARGETS parameter LIBRARY DESTINATION lib)
 # Client headers
@@ -118,7 +118,6 @@ install(FILES
     include/ParameterMgrLoggerForward.h
     include/ParameterMgrFullConnector.h
     include/ParameterMgrPlatformConnector.h
-    include/SelectionCriterionInterface.h
     DESTINATION "include/parameter/client")
 # Core (plugin) headers
 install(FILES

--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -771,7 +771,7 @@ bool CConfigurableDomain::getElementSequence(const string& strConfiguration, str
 
 bool CConfigurableDomain::setApplicationRule(const string& strConfiguration,
                                              const string& strApplicationRule,
-                                             const CSelectionCriteria& criteria,
+                                             const core::criterion::Criteria& criteria,
                                              string& strError)
 {
     // Find Domain configuration

--- a/parameter/ConfigurableDomain.h
+++ b/parameter/ConfigurableDomain.h
@@ -88,7 +88,7 @@ public:
      */
     bool setApplicationRule(const std::string& strConfiguration,
                             const std::string& strApplicationRule,
-                            const CSelectionCriteria& criteria,
+                            const core::criterion::Criteria& criteria,
                             std::string& strError);
 
     bool clearApplicationRule(const std::string& strConfiguration, std::string& strError);

--- a/parameter/ConfigurableDomains.cpp
+++ b/parameter/ConfigurableDomains.cpp
@@ -465,7 +465,7 @@ bool CConfigurableDomains::getElementSequence(const string& strDomain, const str
 bool CConfigurableDomains::setApplicationRule(const string& strDomain,
                                               const string& strConfiguration,
                                               const string& strApplicationRule,
-                                              const CSelectionCriteria& criteria,
+                                              const core::criterion::Criteria& criteria,
                                               string& strError)
 {
     CConfigurableDomain* domain = findConfigurableDomain(strDomain, strError);

--- a/parameter/ConfigurableDomains.h
+++ b/parameter/ConfigurableDomains.h
@@ -30,8 +30,9 @@
 #pragma once
 
 #include "BinarySerializableElement.h"
-#include "SelectionCriteria.h"
 #include "Results.h"
+#include <criterion/Criteria.h>
+
 #include <set>
 #include <string>
 
@@ -132,7 +133,7 @@ public:
     bool setApplicationRule(const std::string& strDomain,
                             const std::string& strConfiguration,
                             const std::string& strApplicationRule,
-                            const CSelectionCriteria& criteria,
+                            const core::criterion::Criteria& criteria,
                             std::string& strError);
 
     bool clearApplicationRule(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);

--- a/parameter/DomainConfiguration.cpp
+++ b/parameter/DomainConfiguration.cpp
@@ -289,7 +289,7 @@ void CDomainConfiguration::getElementSequence(string& strResult) const
 
 // Application rule
 bool CDomainConfiguration::setApplicationRule(const string& strApplicationRule,
-                                              const CSelectionCriteria& criteria,
+                                              const core::criterion::Criteria& criteria,
                                               string& strError)
 {
     // Parser

--- a/parameter/DomainConfiguration.h
+++ b/parameter/DomainConfiguration.h
@@ -30,8 +30,9 @@
 #pragma once
 
 #include "BinarySerializableElement.h"
-#include "SelectionCriteria.h"
 #include "Results.h"
+#include <criterion/Criteria.h>
+
 #include <list>
 #include <string>
 
@@ -68,7 +69,7 @@ public:
      * @result true is success false otherwise
      */
     bool setApplicationRule(const std::string& strApplicationRule,
-                            const CSelectionCriteria& criteria,
+                            const core::criterion::Criteria& criteria,
                             std::string& strError);
 
     void clearApplicationRule();

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -722,20 +722,20 @@ bool CParameterMgr::xmlParse(CXmlElementSerializingContext& elementSerializingCo
     return true;
 }
 
-CSelectionCriterion* CParameterMgr::createExclusiveCriterion(const string& name)
+criterion::Criterion* CParameterMgr::createExclusiveCriterion(const string& name)
 {
     // Propagate
     return _criteria.createExclusiveCriterion(name, _logger);
 }
 
-CSelectionCriterion* CParameterMgr::createInclusiveCriterion(const string& name)
+criterion::Criterion* CParameterMgr::createInclusiveCriterion(const string& name)
 {
     // Propagate
     return _criteria.createInclusiveCriterion(name, _logger);
 }
 
 // Selection criterion retrieval
-CSelectionCriterion* CParameterMgr::getSelectionCriterion(const string& strName)
+criterion::Criterion* CParameterMgr::getSelectionCriterion(const string& strName)
 {
     // Propagate
     return _criteria.getSelectionCriterion(strName);

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -34,16 +34,16 @@
 #include <vector>
 #include "RemoteCommandHandlerTemplate.h"
 #include "PathNavigator.h"
-#include "SelectionCriterion.h"
 #include "Element.h"
 #include "XmlDocSink.h"
 #include "XmlDocSource.h"
 #include "XmlDomainExportContext.h"
 #include "Results.h"
 #include "ParameterFrameworkConfiguration.h"
-#include "SelectionCriteria.h"
+#include "criterion/Criteria.h"
 #include "ConfigurableDomains.h"
 #include "SystemClass.h"
+#include <criterion/Criterion.h>
 #include <log/LogWrapper.h>
 #include <log/Context.h>
 
@@ -111,17 +111,17 @@ public:
      * @param[in] name, the criterion name
      * @return raw pointer on the created criterion
      */
-    CSelectionCriterion* createExclusiveCriterion(const std::string& name);
+    core::criterion::Criterion* createExclusiveCriterion(const std::string& name);
 
     /** Create a new Inclusive criterion
      *
      * @param[in] name, the criterion name
      * @return raw pointer on the created criterion
      */
-    CSelectionCriterion* createInclusiveCriterion(const std::string& name);
+    core::criterion::Criterion* createInclusiveCriterion(const std::string& name);
 
     // Selection criterion retrieval
-    CSelectionCriterion* getSelectionCriterion(const std::string& strName);
+    core::criterion::Criterion* getSelectionCriterion(const std::string& strName);
 
     // Configuration application
     void applyConfigurations();
@@ -747,7 +747,7 @@ private:
     CParameterFrameworkConfiguration _pfwConfiguration;
 
     /** Selection Criteria used in application rules */
-    CSelectionCriteria _criteria;
+    core::criterion::Criteria _criteria;
 
     /** Subsystems handler */
     CSystemClass _systemClass;

--- a/parameter/ParameterMgrFullConnector.cpp
+++ b/parameter/ParameterMgrFullConnector.cpp
@@ -34,6 +34,7 @@
 #include <list>
 
 using std::string;
+using core::criterion::CriterionInterface;
 
 CParameterMgrFullConnector::CParameterMgrFullConnector(const string& strConfigurationFilePath) :
     _pParameterMgrLogger(new CParameterMgrLogger<CParameterMgrFullConnector>(*this)),
@@ -83,19 +84,17 @@ CParameterHandle* CParameterMgrFullConnector::createParameterHandle(const string
     return _pParameterMgr->createParameterHandle(strPath, strError);
 }
 
-ISelectionCriterionInterface*
-CParameterMgrFullConnector::createExclusiveCriterion(const string& name)
+CriterionInterface* CParameterMgrFullConnector::createExclusiveCriterion(const string& name)
 {
     return _pParameterMgr->createExclusiveCriterion(name);
 }
 
-ISelectionCriterionInterface*
-CParameterMgrFullConnector::createInclusiveCriterion(const string& name)
+CriterionInterface* CParameterMgrFullConnector::createInclusiveCriterion(const string& name)
 {
     return _pParameterMgr->createInclusiveCriterion(name);
 }
 
-ISelectionCriterionInterface* CParameterMgrFullConnector::getSelectionCriterion(
+CriterionInterface* CParameterMgrFullConnector::getSelectionCriterion(
         const string& strName)
 {
     return _pParameterMgr->getSelectionCriterion(strName);

--- a/parameter/ParameterMgrPlatformConnector.cpp
+++ b/parameter/ParameterMgrPlatformConnector.cpp
@@ -33,6 +33,7 @@
 #include <assert.h>
 
 using std::string;
+using core::criterion::CriterionInterface;
 
 // Construction
 CParameterMgrPlatformConnector::CParameterMgrPlatformConnector(
@@ -49,24 +50,22 @@ CParameterMgrPlatformConnector::~CParameterMgrPlatformConnector()
     delete _pParameterMgrLogger;
 }
 
-ISelectionCriterionInterface*
-CParameterMgrPlatformConnector::createExclusiveCriterion(const string& name)
+CriterionInterface* CParameterMgrPlatformConnector::createExclusiveCriterion(const string& name)
 {
     assert(!_bStarted);
 
     return _pParameterMgr->createExclusiveCriterion(name);
 }
 
-ISelectionCriterionInterface*
-CParameterMgrPlatformConnector::createInclusiveCriterion(const string& name)
+CriterionInterface* CParameterMgrPlatformConnector::createInclusiveCriterion(const string& name)
 {
     assert(!_bStarted);
 
     return _pParameterMgr->createInclusiveCriterion(name);
 }
 
-// Selection criterion retrieval
-ISelectionCriterionInterface* CParameterMgrPlatformConnector::getSelectionCriterion(const string& strName) const
+CriterionInterface*
+CParameterMgrPlatformConnector::getSelectionCriterion(const string& strName) const
 {
     return _pParameterMgr->getSelectionCriterion(strName);
 }

--- a/parameter/RuleParser.cpp
+++ b/parameter/RuleParser.cpp
@@ -33,6 +33,7 @@
 #include <assert.h>
 
 using std::string;
+using namespace core;
 
 // Matches
 const char* CRuleParser::_acDelimiters[CRuleParser::ENbStatuses] = {
@@ -44,7 +45,7 @@ const char* CRuleParser::_acDelimiters[CRuleParser::ENbStatuses] = {
     ""      // EDone
 };
 
-CRuleParser::CRuleParser(const string& strApplicationRule, const CSelectionCriteria& criteria) :
+CRuleParser::CRuleParser(const string& strApplicationRule, const criterion::Criteria& criteria) :
     _strApplicationRule(strApplicationRule),
     mCriteria(criteria),
     _uiCurrentPos(0),
@@ -220,7 +221,7 @@ const string& CRuleParser::getType() const
 }
 
 // Criteria defintion
-const CSelectionCriteria& CRuleParser::getCriteria() const
+const criterion::Criteria& CRuleParser::getCriteria() const
 {
     return mCriteria;
 }

--- a/parameter/RuleParser.h
+++ b/parameter/RuleParser.h
@@ -29,12 +29,14 @@
  */
 #pragma once
 
-#include "SelectionCriteria.h"
+#include <criterion/Criteria.h>
 
 #include <string>
 #include <stdint.h>
 
 class CCompoundRule;
+
+// FIXME: Add RuleParser  in core namespace
 
 class CRuleParser
 {
@@ -50,7 +52,8 @@ public:
         ENbStatuses
     };
 
-    CRuleParser(const std::string& strApplicationRule, const CSelectionCriteria& Criteria);
+    CRuleParser(const std::string& strApplicationRule,
+                const core::criterion::Criteria& criteria);
     ~CRuleParser();
 
     // Parse
@@ -66,7 +69,7 @@ public:
     const std::string& getType() const;
 
     /** Criteria getter */
-    const CSelectionCriteria& getCriteria() const;
+    const core::criterion::Criteria& getCriteria() const;
 
     // Root rule
     CCompoundRule* grabRootRule();
@@ -79,7 +82,7 @@ private:
     std::string _strApplicationRule;
 
     /** Criteria definition */
-    const CSelectionCriteria& mCriteria;
+    const core::criterion::Criteria& mCriteria;
 
     /** String iterator */
     std::string::size_type _uiCurrentPos;

--- a/parameter/SelectionCriterionRule.cpp
+++ b/parameter/SelectionCriterionRule.cpp
@@ -28,10 +28,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "SelectionCriterionRule.h"
-#include "SelectionCriterion.h"
 #include "XmlDomainSerializingContext.h"
 #include "XmlDomainImportContext.h"
 #include "RuleParser.h"
+#include <criterion/Criterion.h>
+
 #include <assert.h>
 
 #define base CRule

--- a/parameter/SelectionCriterionRule.h
+++ b/parameter/SelectionCriterionRule.h
@@ -30,10 +30,11 @@
 #pragma once
 
 #include "Rule.h"
+#include <criterion/Criterion.h>
 
 #include <string>
 
-class CSelectionCriterion;
+// FIXME: Add SelectionCriterionRule in core namespace
 
 class CSelectionCriterionRule : public CRule
 {
@@ -62,7 +63,7 @@ protected:
     virtual void logValue(std::string& strValue, CErrorContext& errorContext) const;
 private:
     // Selection criterion
-    const CSelectionCriterion* _pSelectionCriterion;
+    const core::criterion::Criterion* _pSelectionCriterion;
 
     /** Method name used to match the criterion state
      *

--- a/parameter/XmlDomainImportContext.h
+++ b/parameter/XmlDomainImportContext.h
@@ -30,8 +30,8 @@
 #pragma once
 
 #include "XmlDomainSerializingContext.h"
-#include "SelectionCriteria.h"
 #include "SystemClass.h"
+#include <criterion/Criteria.h>
 
 #include <string>
 
@@ -41,7 +41,7 @@ public:
     CXmlDomainImportContext(std::string& strError,
                             bool bWithSettings,
                             CSystemClass& systemClass,
-                            const CSelectionCriteria& criteria)
+                            const core::criterion::Criteria& criteria)
         : base(strError, bWithSettings), _systemClass(systemClass), mCriteria(criteria),
           _bAutoValidationRequired(true)
     {}
@@ -52,7 +52,7 @@ public:
         return _systemClass;
     }
 
-    const CSelectionCriteria& getCriteria() const
+    const core::criterion::Criteria& getCriteria() const
     {
         return mCriteria;
     }
@@ -75,7 +75,7 @@ private:
     CSystemClass& _systemClass;
 
     /** Selection criteria definition for rule creation */
-    const CSelectionCriteria& mCriteria;
+    const core::criterion::Criteria& mCriteria;
 
     // Auto validation of configurations
     bool _bAutoValidationRequired;

--- a/parameter/criterion/CMakeLists.txt
+++ b/parameter/criterion/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -26,19 +26,21 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_executable(test-platform
-    main.cpp
-    TestPlatform.cpp)
-
-# FIXME: Supress the need for the -Wno-unused-parameter
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
+add_library(criterion STATIC
+    src/InclusiveCriterion.cpp
+    src/Criteria.cpp
+    src/Criterion.cpp)
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/parameter/criterion/include"
-    "${PROJECT_SOURCE_DIR}/parameter/include"
-    "${PROJECT_SOURCE_DIR}/remote-processor"
-    "${PROJECT_SOURCE_DIR}/utility")
+    include
+    "${PROJECT_SOURCE_DIR}/parameter/log/include"
+    "${PROJECT_SOURCE_DIR}/xmlserializer/"
+    "${PROJECT_SOURCE_DIR}/utility/")
 
-target_link_libraries(test-platform parameter remote-processor)
+# '-fPIC' needed for shared library to link against libcriterion
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
-install(TARGETS test-platform RUNTIME DESTINATION bin)
+# Client headers
+install(FILES
+    include/criterion/client/CriterionInterface.h
+    DESTINATION "include/parameter/client/criterion")

--- a/parameter/criterion/include/criterion/Criteria.h
+++ b/parameter/criterion/include/criterion/Criteria.h
@@ -29,8 +29,8 @@
  */
 #pragma once
 
+#include "criterion/Criterion.h"
 #include "XmlSource.h"
-#include "SelectionCriterion.h"
 #include <log/Logger.h>
 
 #include <string>
@@ -38,62 +38,82 @@
 #include <map>
 #include <memory>
 
+namespace core
+{
+namespace criterion
+{
+
 /** Criteria Handler */
-class CSelectionCriteria : public IXmlSource
+class Criteria : public IXmlSource
 {
 public:
-    CSelectionCriteria();
+    Criteria();
 
     /** Create a new Exclusive criterion
      *
-     * @param[in] name, the criterion name
+     * @param[in] name the criterion name
+     * @param[in] logger the application main logger
      * @return raw pointer on the created criterion
      */
-    CSelectionCriterion* createExclusiveCriterion(const std::string& name,
-                                                  core::log::Logger& logger);
+    Criterion* createExclusiveCriterion(const std::string& name,
+                                        core::log::Logger& logger);
 
     /** Create a new Inclusive criterion
      *
-     * @param[in] name, the criterion name
+     * @param[in] name the criterion name
+     * @param[in] logger the application main logger
      * @return raw pointer on the created criterion
      */
-    CSelectionCriterion* createInclusiveCriterion(const std::string& name,
-                                                  core::log::Logger& logger);
+    Criterion* createInclusiveCriterion(const std::string& name,
+                                        core::log::Logger& logger);
 
     /** Criterion Retrieval
      *
-     * @param[in] name, the criterion name
+     * @param[in] name the criterion name
      * @result pointer to the desired criterion object
      */
-    CSelectionCriterion* getSelectionCriterion(const std::string& name);
+    Criterion* getSelectionCriterion(const std::string& name);
 
     /** Const Criterion Retrieval
      *
-     * @param[in] name, the criterion name
+     * @param[in] name the criterion name
      * @result pointer to the desired const criterion object
      */
-    const CSelectionCriterion* getSelectionCriterion(const std::string& name) const;
+    const Criterion* getSelectionCriterion(const std::string& name) const;
 
-    // List available criteria
-    void listSelectionCriteria(std::list<std::string>& strResult, bool bWithTypeInfo, bool bHumanReadable) const;
+    /** List available criteria
+     *
+     * @param[out] results information container
+     * @param[in] withTypeInfo indicates if we want to retrieve criterion type information
+     * @param[in] humanReadable indicates the formatage we want to use
+     */
+    void listSelectionCriteria(std::list<std::string>& results,
+                               bool withTypeInfo,
+                               bool humanReadable) const;
 
-    // Reset the modified status of the children
+    /** Reset the modified status of criteria */
     void resetModifiedStatus();
 
     /** Xml Serialization method
      *
      * @param[out] xmlElement the current xml element to fill with data
-     * @param serializingContext context of the current serialization
+     * @param context context of the current serialization
      */
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement& xmlElement,CXmlSerializingContext& context) const override;
 
 private:
+    // @{
+    /** As Criteria owns some unique_ptr, the class is non copyable */
+    Criteria(const Criteria &criteria) = delete;
+    Criteria operator=(const Criteria &criteria) = delete;
+    Criteria(Criteria &&criteria) = default;
+    // @}
 
     /** Internally wrap criterion pointer to not have to handle destruction */
-    typedef std::unique_ptr<CSelectionCriterion> CriterionWrapper;
+    typedef std::unique_ptr<Criterion> CriterionWrapper;
 
     /** Criteria instance container type, map which use criterion name as key */
-    typedef std::map<std::string, CriterionWrapper> Criteria;
+    typedef std::map<std::string, CriterionWrapper> CriteriaMap;
 
     /** Confine exception use to smooth code transitions
      * Android is not supporting exceptions by default. Nevertheless some
@@ -105,8 +125,11 @@ private:
      * @param[in] name, name of the criterion to retrieve
      * @return pointer to the desired criterion
      */
-    CSelectionCriterion* getCriterionPointer(const std::string& name) const;
+    Criterion* getCriterionPointer(const std::string& name) const;
 
     /** Criteria instance container */
-    Criteria mCriteria;
+    CriteriaMap mCriteria;
 };
+
+} /** criterion namespace */
+} /** core namespace */

--- a/parameter/criterion/include/criterion/Criterion.h
+++ b/parameter/criterion/include/criterion/Criterion.h
@@ -29,27 +29,50 @@
  */
 #pragma once
 
+#include "client/CriterionInterface.h"
 #include "XmlSource.h"
-#include "SelectionCriterionInterface.h"
 #include <log/Logger.h>
 
 #include <map>
 #include <string>
 #include <functional>
 
+namespace core
+{
+namespace criterion
+{
+
 /** Criterion object used to apply rules based on system state */
-class CSelectionCriterion : public IXmlSource, public ISelectionCriterionInterface
+class Criterion : public IXmlSource, public CriterionInterface
 {
 public:
-    CSelectionCriterion(const std::string& name, core::log::Logger& logger);
+    /** @param[in] name the criterion name
+     *  @param[in] logger the main application logger
+     */
+    Criterion(const std::string& name, core::log::Logger& logger);
 
-    /// From ISelectionCriterionInterface
-    // State
-    virtual void setCriterionState(int iState);
-    virtual int getCriterionState() const;
-    // Name
-    virtual std::string getCriterionName() const;
-    // Modified status
+    // @{
+    /** @see CriterionInterface */
+    virtual void setCriterionState(int iState) override final;
+
+    virtual int getCriterionState() const override final;
+
+    virtual std::string getCriterionName() const override final;
+
+    virtual bool isInclusive() const override;
+
+    virtual bool addValuePair(int numericalValue,
+                              const std::string& literalValue,
+                              std::string& error) override;
+
+    bool getLiteralValue(int numericalValue, std::string& literalValue) const override final;
+
+    virtual bool getNumericalValue(const std::string& literalValue,
+                                   int& numericalValue) const override;
+
+    virtual std::string getFormattedState() const override;
+    // @}
+
     bool hasBeenModified() const;
     void resetModifiedStatus();
 
@@ -70,24 +93,7 @@ public:
      */
     bool isMatchMethodAvailable(const std::string& method) const;
 
-    /// User request
     std::string getFormattedDescription(bool bWithTypeInfo, bool bHumanReadable) const;
-
-    //@{
-    /** @see ISelectionCriterionInterface */
-    virtual bool isInclusive() const override;
-
-    virtual bool addValuePair(int numericalValue,
-                              const std::string& literalValue,
-                              std::string& error) override;
-
-    bool getLiteralValue(int numericalValue, std::string& literalValue) const override final;
-
-    virtual bool getNumericalValue(const std::string& literalValue,
-                                   int& numericalValue) const override;
-
-    virtual std::string getFormattedState() const override;
-    //@}
 
     /** List different values a criterion can have
      *
@@ -95,14 +101,12 @@ public:
      */
     std::string listPossibleValues() const;
 
-    /**
-      * Export to XML
-      *
-      * @param[in] xmlElement The XML element to export to
-      * @param[in] serializingContext The serializing context
-      *
-      */
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    /** Export to XML
+     *
+     * @param[in] xmlElement The XML element to export to
+     * @param[in] serializingContext The serializing context
+     */
+    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& context) const override;
 
 protected:
     /** Criterion Match callback type
@@ -111,7 +115,7 @@ protected:
      * and returns a boolean which indicates if the current state match the state given in
      * parameter.
      */
-    typedef std::function<bool(int)> MatchMethod;
+    typedef std::function<bool (int)> MatchMethod;
 
     /** Match method container, MatchMethod are indexed by their name */
     typedef std::map<std::string, MatchMethod> MatchMethods;
@@ -123,14 +127,15 @@ protected:
      * This Constructor initialize class members and should be called by derived class
      * in order to add functionalities
      *
-     * @param[in] name, the criterion name
+     * @param[in] name the criterion name
+     * @param[in] logger the main application logger
      * @param[in] derivedValuePairs initial value pairs of derived classes
      * @param[in] derivedMatchMethods match methods of derived classes
      */
-    CSelectionCriterion(const std::string& name,
-                        core::log::Logger& logger,
-                        const ValuePairs& derivedValuePairs,
-                        const MatchMethods& derivedMatchMethods);
+    Criterion(const std::string& name,
+              core::log::Logger& logger,
+              const ValuePairs& derivedValuePairs,
+              const MatchMethods& derivedMatchMethods);
 
     /** Set a "default formatted state" when no criterion state is set
      *
@@ -168,3 +173,5 @@ private:
     const std::string mName;
 };
 
+} /** criterion namespace */
+} /** core namespace */

--- a/parameter/criterion/include/criterion/InclusiveCriterion.h
+++ b/parameter/criterion/include/criterion/InclusiveCriterion.h
@@ -29,33 +29,38 @@
  */
 #pragma once
 
-#include "SelectionCriterion.h"
+#include "criterion/Criterion.h"
 
-/** Criterion we can take several state values at the same time */
-class InclusiveCriterion : public CSelectionCriterion
+namespace core
+{
+namespace criterion
 {
 
+/** Criterion we can take several state values at the same time */
+class InclusiveCriterion final : public Criterion
+{
 public:
-
     /** @param[in] name, the criterion name */
     InclusiveCriterion(const std::string& name, core::log::Logger& logger);
 
-    //@{
-    /** @see ISelectionCriterionInterface */
-    bool isInclusive() const override final;
+    // @{
+    /** @see CriterionInterface */
+    bool isInclusive() const override;
 
     bool addValuePair(int numericalValue,
                       const std::string& literalValue,
-                      std::string& error) override final;
+                      std::string& error) override;
 
     bool getNumericalValue(const std::string& literalValue,
-                           int& numericalValue) const override final;
+                           int& numericalValue) const override;
 
-    std::string getFormattedState() const override final;
-    //@}
+    std::string getFormattedState() const override;
+    // @}
 
 private:
-
     /** Inclusive criterion state delimiter. */
     static const std::string gDelimiter;
 };
+
+} /** criterion namespace */
+} /** core namespace */

--- a/parameter/criterion/include/criterion/client/CriterionInterface.h
+++ b/parameter/criterion/include/criterion/client/CriterionInterface.h
@@ -31,7 +31,15 @@
 
 #include <string>
 
-class ISelectionCriterionInterface
+namespace core
+{
+namespace criterion
+{
+
+/** Client criterion interface used for interacting with the system state
+ * Allows client to set or retrieve a Criterion state.
+ */
+class CriterionInterface
 {
 public:
     virtual void setCriterionState(int iState) = 0;
@@ -84,5 +92,8 @@ public:
     virtual bool isInclusive() const = 0;
 
 protected:
-    virtual ~ISelectionCriterionInterface() {}
+    virtual ~CriterionInterface() {}
 };
+
+} /** criterion namespace */
+} /** core namespace */

--- a/parameter/criterion/src/Criteria.cpp
+++ b/parameter/criterion/src/Criteria.cpp
@@ -27,16 +27,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "SelectionCriteria.h"
-#include "InclusiveCriterion.h"
+#include "criterion/Criteria.h"
+#include "criterion/InclusiveCriterion.h"
 
 #include <stdexcept>
 
-CSelectionCriteria::CSelectionCriteria() : mCriteria()
+namespace core
+{
+namespace criterion
+{
+
+Criteria::Criteria() : mCriteria()
 {
 }
 
-CSelectionCriterion* CSelectionCriteria::getCriterionPointer(const std::string& name) const
+Criterion* Criteria::getCriterionPointer(const std::string& name) const
 {
     // Bound exception aware code to criteria, others Pfw parts will check nullptr.
     try {
@@ -47,50 +52,46 @@ CSelectionCriterion* CSelectionCriteria::getCriterionPointer(const std::string& 
     }
 }
 
-CSelectionCriterion* CSelectionCriteria::createExclusiveCriterion(const std::string& name,
-                                                                  core::log::Logger& logger)
+Criterion* Criteria::createExclusiveCriterion(const std::string& name, core::log::Logger& logger)
 {
-    mCriteria.emplace(name, CriterionWrapper(new CSelectionCriterion(name, logger)));
+    mCriteria.emplace(name, CriterionWrapper(new Criterion(name, logger)));
     return getCriterionPointer(name);
 }
 
-CSelectionCriterion* CSelectionCriteria::createInclusiveCriterion(const std::string& name,
-                                                                  core::log::Logger& logger)
+Criterion* Criteria::createInclusiveCriterion(const std::string& name, core::log::Logger& logger)
 {
     mCriteria.emplace(name, CriterionWrapper(new InclusiveCriterion(name, logger)));
     return getCriterionPointer(name);
 }
 
-// Selection criterion retrieval
-CSelectionCriterion* CSelectionCriteria::getSelectionCriterion(const std::string& name)
+Criterion* Criteria::getSelectionCriterion(const std::string& name)
 {
     return getCriterionPointer(name);
 }
 
-const CSelectionCriterion* CSelectionCriteria::getSelectionCriterion(const std::string& name) const
+const Criterion* Criteria::getSelectionCriterion(const std::string& name) const
 {
     return getCriterionPointer(name);
 }
 
-// List available criteria
-void CSelectionCriteria::listSelectionCriteria(std::list<std::string>& lstrResult, bool bWithTypeInfo, bool bHumanReadable) const
+void Criteria::listSelectionCriteria(std::list<std::string>& results,
+                                     bool withTypeInfo,
+                                     bool humanReadable) const
 {
     for (auto& criterion : mCriteria) {
-        lstrResult.push_back(criterion.second->getFormattedDescription(bWithTypeInfo,
-                                                                       bHumanReadable));
+        results.push_back(criterion.second->getFormattedDescription(withTypeInfo, humanReadable));
     }
 }
 
-// Reset the modified status of the children
-void CSelectionCriteria::resetModifiedStatus()
+void Criteria::resetModifiedStatus()
 {
     for (auto& criterion : mCriteria) {
         criterion.second->resetModifiedStatus();
     }
 }
 
-void CSelectionCriteria::toXml(CXmlElement& xmlElement,
-                               CXmlSerializingContext& serializingContext) const
+void Criteria::toXml(CXmlElement& xmlElement,
+                     CXmlSerializingContext& serializingContext) const
 {
     for (auto& criterion : mCriteria) {
 
@@ -99,3 +100,6 @@ void CSelectionCriteria::toXml(CXmlElement& xmlElement,
         criterion.second->toXml(xmlChildElement, serializingContext);
     }
 }
+
+} /** criterion namespace */
+} /** core namespace */

--- a/parameter/criterion/src/Criterion.cpp
+++ b/parameter/criterion/src/Criterion.cpp
@@ -27,44 +27,47 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-#include "SelectionCriterion.h"
+#include "criterion/Criterion.h"
+#include <Utility.h>
 #include <log/Logger.h>
-#include "Utility.h"
 
 #include <stdexcept>
+#include <sstream>
 
-CSelectionCriterion::CSelectionCriterion(const std::string& name, core::log::Logger& logger) :
-    CSelectionCriterion(name, logger, {}, {})
+namespace core
+{
+namespace criterion
+{
+
+Criterion::Criterion(const std::string& name, core::log::Logger& logger)
+    : Criterion(name, logger, {}, {})
 {
 }
 
-CSelectionCriterion::CSelectionCriterion(const std::string& name,
-                                         core::log::Logger& logger,
-                                         const ValuePairs& derivedValuePairs,
-                                         const MatchMethods& derivedMatchMethods) :
-    mValuePairs(derivedValuePairs),
-    mMatchMethods(CUtility::merge(MatchMethods{
-                                    {"Is", [&](int state){ return mState == state; }},
-                                    {"IsNot", [&](int state){ return mState != state; }}},
-                                  derivedMatchMethods)),
-    mState(0), _uiNbModifications(0), _logger(logger), mName(name)
+Criterion::Criterion(const std::string& name,
+                     core::log::Logger& logger,
+                     const ValuePairs& derivedValuePairs,
+                     const MatchMethods& derivedMatchMethods)
+    : mValuePairs(derivedValuePairs),
+      mMatchMethods(CUtility::merge(MatchMethods{
+                                      {"Is", [&](int state){ return mState == state; }},
+                                      {"IsNot", [&](int state){ return mState != state; }}},
+                                    derivedMatchMethods)),
+      mState(0), _uiNbModifications(0), _logger(logger), mName(name)
 {
 }
 
-bool CSelectionCriterion::hasBeenModified() const
+bool Criterion::hasBeenModified() const
 {
     return _uiNbModifications != 0;
 }
 
-void CSelectionCriterion::resetModifiedStatus()
+void Criterion::resetModifiedStatus()
 {
     _uiNbModifications = 0;
 }
 
-/// From ISelectionCriterionInterface
-// State
-void CSelectionCriterion::setCriterionState(int iState)
+void Criterion::setCriterionState(int iState)
 {
     // Check for a change
     if (mState != iState) {
@@ -74,7 +77,8 @@ void CSelectionCriterion::setCriterionState(int iState)
         _logger.info() << "Selection criterion changed event: "
                        << getFormattedDescription(false, false);
 
-        // Check if the previous criterion value has been taken into account (i.e. at least one Configuration was applied
+        // Check if the previous criterion value has been taken into account
+        // (i.e. at least one Configuration was applied
         // since the last criterion change)
         if (_uiNbModifications != 0) {
 
@@ -88,19 +92,17 @@ void CSelectionCriterion::setCriterionState(int iState)
     }
 }
 
-int CSelectionCriterion::getCriterionState() const
+int Criterion::getCriterionState() const
 {
     return mState;
 }
 
-// Name
-std::string CSelectionCriterion::getCriterionName() const
+std::string Criterion::getCriterionName() const
 {
     return mName;
 }
 
-/// User request
-std::string CSelectionCriterion::getFormattedDescription(bool bWithTypeInfo, bool bHumanReadable) const
+std::string Criterion::getFormattedDescription(bool bWithTypeInfo, bool bHumanReadable) const
 {
     std::string strFormattedDescription;
 
@@ -144,7 +146,7 @@ std::string CSelectionCriterion::getFormattedDescription(bool bWithTypeInfo, boo
         // Current State
         strFormattedDescription += ", current state: " + getFormattedState();
 
-         if (bWithTypeInfo) {
+        if (bWithTypeInfo) {
             // States
             strFormattedDescription += ", states: " + listPossibleValues();
         }
@@ -152,15 +154,14 @@ std::string CSelectionCriterion::getFormattedDescription(bool bWithTypeInfo, boo
     return strFormattedDescription;
 }
 
-// XML export
-void CSelectionCriterion::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void Criterion::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
-    (void) serializingContext;
+    (void)serializingContext;
     xmlElement.setAttributeString("Value", getFormattedState());
     xmlElement.setAttributeString("Name", mName);
     xmlElement.setAttributeString("Kind", isInclusive() ? "Inclusive" : "Exclusive");
 
-    for (auto& valuePair: mValuePairs) {
+    for (auto& valuePair : mValuePairs) {
         CXmlElement childValuePairElement;
 
         xmlElement.createChild(childValuePairElement, "ValuePair");
@@ -169,14 +170,14 @@ void CSelectionCriterion::toXml(CXmlElement& xmlElement, CXmlSerializingContext&
     }
 }
 
-bool CSelectionCriterion::isInclusive() const
+bool Criterion::isInclusive() const
 {
     return false;
 }
 
-bool CSelectionCriterion::addValuePair(int numericalValue,
-                                       const std::string& literalValue,
-                                       std::string& error)
+bool Criterion::addValuePair(int numericalValue,
+                             const std::string& literalValue,
+                             std::string& error)
 {
     // Check already inserted
     if (mValuePairs.count(literalValue) == 1) {
@@ -194,8 +195,8 @@ bool CSelectionCriterion::addValuePair(int numericalValue,
     return true;
 }
 
-bool CSelectionCriterion::getNumericalValue(const std::string& literalValue,
-                                            int& numericalValue) const
+bool Criterion::getNumericalValue(const std::string& literalValue,
+                                  int& numericalValue) const
 {
     try {
         numericalValue = mValuePairs.at(literalValue);
@@ -206,9 +207,9 @@ bool CSelectionCriterion::getNumericalValue(const std::string& literalValue,
     }
 }
 
-bool CSelectionCriterion::getLiteralValue(int numericalValue, std::string& literalValue) const
+bool Criterion::getLiteralValue(int numericalValue, std::string& literalValue) const
 {
-    for (auto& value: mValuePairs) {
+    for (auto& value : mValuePairs) {
         if (value.second == numericalValue) {
             literalValue = value.first;
             return true;
@@ -217,21 +218,21 @@ bool CSelectionCriterion::getLiteralValue(int numericalValue, std::string& liter
     return false;
 }
 
-std::string CSelectionCriterion::getFormattedState() const
+std::string Criterion::getFormattedState() const
 {
     std::string formattedState;
     getLiteralValue(mState, formattedState);
 
-    return CSelectionCriterion::checkFormattedStateEmptyness(formattedState);
+    return Criterion::checkFormattedStateEmptyness(formattedState);
 }
 
-std::string CSelectionCriterion::listPossibleValues() const
+std::string Criterion::listPossibleValues() const
 {
     std::string possibleValues = "{";
 
     // Get comma separated list of values
     bool first = true;
-    for (auto& value: mValuePairs) {
+    for (auto& value : mValuePairs) {
 
         if (first) {
             first = false;
@@ -245,7 +246,7 @@ std::string CSelectionCriterion::listPossibleValues() const
     return possibleValues;
 }
 
-std::string& CSelectionCriterion::checkFormattedStateEmptyness(std::string& formattedState) const
+std::string& Criterion::checkFormattedStateEmptyness(std::string& formattedState) const
 {
     if (formattedState.empty()) {
         formattedState = "<none>";
@@ -253,12 +254,15 @@ std::string& CSelectionCriterion::checkFormattedStateEmptyness(std::string& form
     return formattedState;
 }
 
-bool CSelectionCriterion::match(const std::string& method, int32_t state) const
+bool Criterion::match(const std::string& method, int32_t state) const
 {
     return mMatchMethods.at(method)(state);
 }
 
-bool CSelectionCriterion::isMatchMethodAvailable(const std::string& method) const
+bool Criterion::isMatchMethodAvailable(const std::string& method) const
 {
     return mMatchMethods.count(method) == 1;
 }
+
+} /** criterion namespace */
+} /** core namespace */

--- a/parameter/criterion/src/InclusiveCriterion.cpp
+++ b/parameter/criterion/src/InclusiveCriterion.cpp
@@ -27,19 +27,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "InclusiveCriterion.h"
+#include "criterion/InclusiveCriterion.h"
 #include "Tokenizer.h"
 
 #include <sstream>
 
+namespace core
+{
+namespace criterion
+{
+
 const std::string InclusiveCriterion::gDelimiter = "|";
 
-InclusiveCriterion::InclusiveCriterion(const std::string& name,
-                                       core::log::Logger& logger)
-    : CSelectionCriterion(name, logger,
-                          {{"none", 0}},
-                          {{"Includes", [&](int state){ return (mState & state) == state; }},
-                           {"Excludes", [&](int state){ return (mState & state) == 0; }}})
+InclusiveCriterion::InclusiveCriterion(const std::string& name, core::log::Logger& logger)
+    : Criterion(name, logger,
+                {{"none", 0}},
+                {{"Includes", [&](int state){ return (mState & state) == state; }},
+                 {"Excludes", [&](int state){ return (mState & state) == 0; }}})
 {
 }
 
@@ -63,7 +67,7 @@ bool InclusiveCriterion::addValuePair(int numericalValue,
         return false;
     }
 
-    return CSelectionCriterion::addValuePair(numericalValue, literalValue, error);
+    return Criterion::addValuePair(numericalValue, literalValue, error);
 }
 
 bool InclusiveCriterion::getNumericalValue(const std::string& literalValue,
@@ -77,7 +81,7 @@ bool InclusiveCriterion::getNumericalValue(const std::string& literalValue,
     for (std::string atomicLiteral : literalValues) {
 
         int atomicNumerical = 0;
-        if (!CSelectionCriterion::getNumericalValue(atomicLiteral, atomicNumerical)) {
+        if (!Criterion::getNumericalValue(atomicLiteral, atomicNumerical)) {
             return false;
         }
         numericalValue |= atomicNumerical;
@@ -114,5 +118,8 @@ std::string InclusiveCriterion::getFormattedState() const
         formattedState += atomicState;
     }
 
-    return CSelectionCriterion::checkFormattedStateEmptyness(formattedState);
+    return Criterion::checkFormattedStateEmptyness(formattedState);
 }
+
+} /** criterion namespace */
+} /** core namespace */

--- a/parameter/include/ParameterMgrFullConnector.h
+++ b/parameter/include/ParameterMgrFullConnector.h
@@ -29,9 +29,9 @@
  */
 #pragma once
 
-#include "SelectionCriterionInterface.h"
 #include "ParameterHandle.h"
 #include "ParameterMgrLoggerForward.h"
+#include <criterion/client/CriterionInterface.h>
 
 #include <string>
 #include <list>
@@ -77,7 +77,8 @@ public:
      * @param[in] name, the criterion name
      * @return raw pointer on the criterion interface
      */
-    ISelectionCriterionInterface* createExclusiveCriterion(const std::string& name);
+    core::criterion::CriterionInterface*
+    createExclusiveCriterion(const std::string& name);
 
     /** Create a new Inclusive criterion
      * Beware returned objects shall not be deleted by client.
@@ -86,9 +87,11 @@ public:
      * @param[in] name, the criterion name
      * @return raw pointer on the criterion interface
      */
-    ISelectionCriterionInterface* createInclusiveCriterion(const std::string& name);
+    core::criterion::CriterionInterface*
+    createInclusiveCriterion(const std::string& name);
 
-    ISelectionCriterionInterface* getSelectionCriterion(const std::string& strName);
+    core::criterion::CriterionInterface*
+    getSelectionCriterion(const std::string& strName);
 
     /** Is the remote interface forcefully disabled ?
      */

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -29,9 +29,9 @@
  */
 #pragma once
 
-#include "SelectionCriterionInterface.h"
 #include "ParameterHandle.h"
 #include "ParameterMgrLoggerForward.h"
+#include <criterion/client/CriterionInterface.h>
 
 class CParameterMgr;
 
@@ -60,7 +60,8 @@ public:
      * @param[in] name, the criterion name
      * @return raw pointer on the criterion interface
      */
-    ISelectionCriterionInterface* createExclusiveCriterion(const std::string& name);
+    core::criterion::CriterionInterface*
+    createExclusiveCriterion(const std::string& name);
 
     /** Create a new Inclusive criterion
      * Beware returned objects shall not be deleted by client.
@@ -69,10 +70,12 @@ public:
      * @param[in] name, the criterion name
      * @return raw pointer on the criterion interface
      */
-    ISelectionCriterionInterface* createInclusiveCriterion(const std::string& name);
+    core::criterion::CriterionInterface*
+    createInclusiveCriterion(const std::string& name);
 
     // Selection criterion retrieval
-    ISelectionCriterionInterface* getSelectionCriterion(const std::string& strName) const;
+    core::criterion::CriterionInterface*
+    getSelectionCriterion(const std::string& strName) const;
 
     // Logging
     // Should be called before start

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -41,6 +41,7 @@
 #include "RemoteProcessorServer.h"
 
 using std::string;
+using core::criterion::CriterionInterface;
 
 class CParameterMgrPlatformConnectorLogger : public CParameterMgrPlatformConnector::ILogger
 {
@@ -293,7 +294,7 @@ bool CTestPlatform::createExclusiveCriterionFromStateList(const string& strName,
 
     assert(_pParameterMgrPlatformConnector != NULL);
 
-    ISelectionCriterionInterface* pCriterion =
+    CriterionInterface* pCriterion =
         _pParameterMgrPlatformConnector->createExclusiveCriterion(strName);
 
     assert(pCriterion!= NULL);
@@ -323,7 +324,7 @@ bool CTestPlatform::createInclusiveCriterionFromStateList(const string& strName,
 {
     assert(_pParameterMgrPlatformConnector != NULL);
 
-    ISelectionCriterionInterface* pCriterion =
+    CriterionInterface* pCriterion =
         _pParameterMgrPlatformConnector->createInclusiveCriterion(strName);
 
     assert(pCriterion != NULL);
@@ -359,7 +360,7 @@ bool CTestPlatform::createExclusiveCriterion(const string& strName,
                                              uint32_t uiNbStates,
                                              string& strResult)
 {
-    ISelectionCriterionInterface* pCriterion =
+    CriterionInterface* pCriterion =
         _pParameterMgrPlatformConnector->createExclusiveCriterion(strName);
 
     uint32_t uistate;
@@ -387,7 +388,7 @@ bool CTestPlatform::createInclusiveCriterion(const string& strName,
                                              uint32_t uiNbStates,
                                              string& strResult)
 {
-    ISelectionCriterionInterface* pCriterion =
+    CriterionInterface* pCriterion =
         _pParameterMgrPlatformConnector->createInclusiveCriterion(strName);
 
     if (uiNbStates > 32) {
@@ -420,7 +421,7 @@ bool CTestPlatform::createInclusiveCriterion(const string& strName,
 
 bool CTestPlatform::setCriterionState(const string& strName, uint32_t uiState, string& strResult)
 {
-    ISelectionCriterionInterface* pCriterion =
+    CriterionInterface* pCriterion =
         _pParameterMgrPlatformConnector->getSelectionCriterion(strName);
 
     if (!pCriterion) {
@@ -442,7 +443,7 @@ bool CTestPlatform::setCriterionStateByLexicalSpace(const IRemoteCommand& remote
     // Get criterion name
     std::string strCriterionName = remoteCommand.getArgument(0);
 
-    ISelectionCriterionInterface* pCriterion =
+    CriterionInterface* pCriterion =
         _pParameterMgrPlatformConnector->getSelectionCriterion(strCriterionName);
 
     if (!pCriterion) {
@@ -474,7 +475,7 @@ bool CTestPlatform::setCriterionStateByLexicalSpace(const IRemoteCommand& remote
          uiLexicalSubStateIndex <= uiNbSubStates;
          uiLexicalSubStateIndex++) {
         /*
-         * getNumericalValue method from ISelectionCriterionInterface strip his parameter
+         * getNumericalValue method from CriterionInterface strip his parameter
          * first parameter based on | sign. In case that the user uses multiple parameters
          * to set InclusiveCriterion value, we aggregate all desired values to be sure
          * they will be handled correctly.

--- a/test/test-platform/TestPlatform.h
+++ b/test/test-platform/TestPlatform.h
@@ -37,7 +37,6 @@
 
 class CParameterMgrPlatformConnectorLogger;
 class CRemoteProcessorServer;
-class ISelectionCriterionInterface;
 
 class CTestPlatform
 {
@@ -95,7 +94,7 @@ private:
     CommandReturn createInclusiveCriterion(const IRemoteCommand& remoteCommand,
                                            std::string& strResult);
 
-    /** Callback to set a criterion's value, see ISelectionCriterionInterface::setCriterionState.
+    /** Callback to set a criterion's value, see CriterionInterface::setCriterionState.
      * @see CCommandHandler::RemoteCommandParser for detail on each arguments and return
      *
      * @param[in] remoteCommand the first argument should be the name of the criterion to set.


### PR DESCRIPTION
Criteria interface has been enough reworked to introduce a separated
library. This library exposes a client interface to let the client dealt
with criteria and larger interface through Criteria class which allows
the parameter-framework to handle criteria.

Signed-off-by: Jules Clero <julesx.clero@intel.com>