### PR TITLE
Fix ILogger::operator<< when called on list<string>

### DIFF
--- a/skeleton-subsystem/CMakeLists.txt
+++ b/skeleton-subsystem/CMakeLists.txt
@@ -31,7 +31,7 @@ cmake_minimum_required(VERSION 2.8)
 
 project(parameter-framework-plugins-skeleton)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -std=c++11")
 
 #
 # Find PFW libraries and include directories


### PR DESCRIPTION
Calling info() << someList should be identical to calling info() << element on
each element of someList.

This was not the case because when used on a list, the string was concatenated
with \n and the logging callback called once. Instead, the logging callback
is now called for each line.

Fixes #125.

Signed-off-by: David Wagner <david.wagner@intel.com>