### PR TITLE
Android: Make libxmserializer dynamic

### DIFF
--- a/bindings/python/Android.mk
+++ b/bindings/python/Android.mk
@@ -44,8 +44,7 @@ LOCAL_CLANG := false
 # Android only provides a 32bit version of python.
 LOCAL_32_BIT_ONLY := true
 
-LOCAL_SHARED_LIBRARIES := libparameter_host
-LOCAL_STATIC_LIBRARIES := libxmlserializer_host
+LOCAL_SHARED_LIBRARIES := libxmlserializer_host libparameter_host
 
 # python is only available in 32bits for now, thus arch is forced to 32bits
 PYTHON_INSTALL_PATH := prebuilts/python/$(HOST_OS)-x86/2.7.5/

--- a/parameter/Android.mk
+++ b/parameter/Android.mk
@@ -130,10 +130,7 @@ common_cflags := \
 common_c_includes := \
     $(LOCAL_PATH)/include/ \
     $(LOCAL_PATH)/../utility/ \
-    $(LOCAL_PATH)/../xmlserializer/ \
     $(LOCAL_PATH)/../remote-processor/
-
-common_shared_libraries := libicuuc
 
 #############################
 # Target build
@@ -155,8 +152,8 @@ LOCAL_MODULE_TAGS := $(common_module_tags)
 
 LOCAL_C_INCLUDES := $(common_c_includes)
 
-LOCAL_SHARED_LIBRARIES := $(common_shared_libraries) libdl
-LOCAL_STATIC_LIBRARIES := libxmlserializer libpfw_utility libxml2
+LOCAL_SHARED_LIBRARIES := libxmlserializer libdl
+LOCAL_STATIC_LIBRARIES := libpfw_utility
 
 LOCAL_REQUIRED_MODULES := libremote-processor
 
@@ -184,8 +181,8 @@ LOCAL_MODULE_TAGS := $(common_module_tags)
 LOCAL_C_INCLUDES += \
     $(common_c_includes)
 
-LOCAL_SHARED_LIBRARIES := $(common_shared_libraries)-host
-LOCAL_STATIC_LIBRARIES := libxmlserializer_host libpfw_utility_host libxml2
+LOCAL_SHARED_LIBRARIES := libxmlserializer_host
+LOCAL_STATIC_LIBRARIES := libpfw_utility_host libxml2
 
 LOCAL_LDLIBS += -ldl
 

--- a/xmlserializer/Android.mk
+++ b/xmlserializer/Android.mk
@@ -79,7 +79,7 @@ LOCAL_STATIC_LIBRARIES := $(common_static_libraries)
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
 include external/stlport/libstlport.mk
-include $(BUILD_STATIC_LIBRARY)
+include $(BUILD_SHARED_LIBRARY)
 
 ##############################
 # Host build
@@ -103,5 +103,5 @@ LOCAL_STATIC_LIBRARIES := libxml2
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
-include $(BUILD_HOST_STATIC_LIBRARY)
+include $(BUILD_HOST_SHARED_LIBRARY)
 


### PR DESCRIPTION
The Parameter Framework has recently removed (this trick was not working on osx) its *_include libraries that were used to include headers without linking against the libraries in the android build system.

There are two ways to include library headers:
 - copy the headers (but that would be in contradiction with how the main pfw headers are included)
 - link against the library (chosen solution)

In order for the plugins to avoid linking against a static
libxmlserializer - ie add it and its dependency to all plugins -
the xmlserializer library is now dynamic.

The [alsa](https://github.com/01org/parameter-framework-plugins-alsa/pull/15) and [filesystem](https://github.com/01org/parameter-framework-plugins-filesystem/pull/8) plugins are also updated.