### PR TITLE
doc: some directories were missing from doxygen's list

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -754,12 +754,11 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @PROJECT_SOURCE_DIR@ \
-                         @PROJECT_SOURCE_DIR@/bindings \
+INPUT                  = @PROJECT_SOURCE_DIR@/bindings/c \
                          @PROJECT_SOURCE_DIR@/parameter \
                          @PROJECT_SOURCE_DIR@/remote-process \
                          @PROJECT_SOURCE_DIR@/remote-processor \
-                         @PROJECT_SOURCE_DIR@/Schemas
+                         @PROJECT_SOURCE_DIR@/Schemas \
                          @PROJECT_SOURCE_DIR@/test/test-platform \
                          @PROJECT_SOURCE_DIR@/utility \
                          @PROJECT_SOURCE_DIR@/xmlserializer \
@@ -788,7 +787,7 @@ FILE_PATTERNS          =
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a


### PR DESCRIPTION
A line ending in the INPUT variable (in Doxyfile.in) was not correctly escaped,
which resulted in several directories to be ignored. Let's add them and also
activate the RECURSIVE option in order to parse subdirectories.

Signed-off-by: David Wagner <david.wagner@intel.com>