### PR TITLE
Remove mappingdata xmlsink inheritance

### DIFF
--- a/parameter/MappingData.cpp
+++ b/parameter/MappingData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -36,13 +36,9 @@ CMappingData::CMappingData()
 {
 }
 
-bool CMappingData::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CMappingData::init(const std::string &rawMapping, std::string &error)
 {
-    assert(xmlElement.hasAttribute("Mapping"));
-
-    std::string strMapping = xmlElement.getAttributeString("Mapping");
-
-    Tokenizer mappingTok(strMapping, ",");
+    Tokenizer mappingTok(rawMapping, ",");
 
     std::string strMappingElement;
 
@@ -71,7 +67,8 @@ bool CMappingData::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext
 
         if (!addValue(strKey, strValue)) {
 
-            serializingContext.setError("Duplicate Mapping data: Unable to process Mapping element key = " + strKey + ", value = " + strValue + " from XML element " + xmlElement.getPath());
+            error = "Unable to process Mapping element key = " + strKey + ", value = " + strValue +
+                    ": Duplicate Mapping data";
 
             return false;
         }

--- a/parameter/MappingData.h
+++ b/parameter/MappingData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,18 +29,23 @@
  */
 #pragma once
 
-#include "XmlSink.h"
 #include <string>
 #include <map>
 
-class CMappingData : public IXmlSink
+class CMappingData
 {
     typedef std::map<std::string, std::string>::const_iterator KeyToValueMapConstIterator;
 public:
     CMappingData();
 
-    // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    /** Initialize mapping data through a raw value
+     *
+     * @param[in] rawMapping the raw mapping data which has to be parsed.
+     *            This raw value is a succession of pair "key:value" separated with comma.
+     * @param[out] error description of the error if there is one, empty otherwise
+     * @return true on success, false otherwise
+     */
+    bool init(const std::string &rawMapping, std::string &error);
 
     // Query
     bool getValue(const std::string& strkey, const std::string*& pStrValue) const;

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -115,8 +115,7 @@ using std::ifstream;
 // Used for remote processor server creation
 typedef IRemoteProcessorServerInterface* (*CreateRemoteProcessorServer)(uint16_t uiPort, IRemoteCommandHandler* pCommandHandler);
 
-// Global configuration file name (fixed)
-const char* gacParameterFrameworkConfigurationFileName = "ParameterFrameworkConfiguration.xml";
+// Global Schemas folder (fixed)
 const char* gacSystemSchemasSubFolder = "Schemas";
 
 // Config File System looks normally like this:

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -51,7 +51,6 @@ class CSubsystemLibrary;
 class CSystemClass;
 class CSelectionCriteria;
 class CParameterFrameworkConfiguration;
-class CSystemClassConfiguration;
 class CParameterBlackboard;
 class CConfigurableDomains;
 class IRemoteProcessorServerInterface;

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -118,11 +118,15 @@ bool CSubsystem::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& 
     CXmlElement childElement;
 
     // Manage mapping attribute
-    if (xmlElement.hasAttribute("Mapping")) {
+    std::string rawMapping = xmlElement.getAttributeString("Mapping");
+    if (!rawMapping.empty()) {
 
+        std::string error;
         _pMappingData = new CMappingData;
-        if (!_pMappingData->fromXml(xmlElement, serializingContext)) {
+        if (!_pMappingData->init(rawMapping, error)) {
 
+            serializingContext.setError("Invalid Mapping data from XML element '" +
+                                        xmlElement.getPath() + "': " + error);
             return false;
         }
     }

--- a/parameter/TypeElement.cpp
+++ b/parameter/TypeElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -110,10 +110,14 @@ bool CTypeElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext
         _uiArrayLength = 0; // Scalar
     }
     // Manage mapping attribute
-    if (xmlElement.hasAttribute("Mapping")) {
+    std::string rawMapping = xmlElement.getAttributeString("Mapping");
+    if (!rawMapping.empty()) {
 
-        if (!getMappingData()->fromXml(xmlElement, serializingContext)) {
+        std::string error;
+        if (!getMappingData()->init(rawMapping, error)) {
 
+            serializingContext.setError("Invalid Mapping data from XML element '" +
+                                        xmlElement.getPath() + "': " + error);
             return false;
         }
     }


### PR DESCRIPTION
The MappingData inheritance from XmlSink can be avoided at no cost.