### PR TITLE
travis: exclude 'install' directory from coverage PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ after_success:
           --exclude "build_debug/bindings/python"
           --exclude "build_debug/CMakeFiles"
           --exclude "build"
+          --exclude "install"
           --exclude "skeleton-subsystem"
           --exclude "test/test-subsystem"
           --exclude "bindings/c/Test.cpp"


### PR DESCRIPTION
The directory used to install the PF was covered. Thus,
include files were covered twice.
This patch removes this directory from the coverage PATH.

Signed-off-by: Jules Clero <julesx.clero@intel.com>