### PR TITLE
Fix default builder leak and make a warning non fatal in criterion's test.

### DIFF
--- a/parameter/DefaultElementLibrary.h
+++ b/parameter/DefaultElementLibrary.h
@@ -34,6 +34,8 @@
 
 #include <map>
 #include <string>
+#include <memory>
+#include <utility>
 
 /** Factory that creates an element given an xml element. If no matching builder is found, it uses
   * the default builder.
@@ -46,7 +48,6 @@ class CDefaultElementLibrary: public CElementLibrary
 {
 public:
 
-    CDefaultElementLibrary() : _defaultBuilder(NULL) {}
     virtual ~CDefaultElementLibrary() {}
 
     /** Set the default builder used in fallback mechanism.
@@ -54,9 +55,9 @@ public:
       *
       * @param[in] defaultBuilder if NULL default builder mechanism, else provided builder is used.
       */
-    void setDefaultBuilder(CDefaultElementBuilder* defaultBuilder)
+    void setDefaultBuilder(std::unique_ptr<CDefaultElementBuilder> defaultBuilder)
     {
-        _defaultBuilder = defaultBuilder;
+        _defaultBuilder = std::move(defaultBuilder);
     }
 
 
@@ -73,7 +74,7 @@ public:
     CElement* createElement(const CXmlElement& xmlElement) const;
 
 private:
-    CDefaultElementBuilder* _defaultBuilder;
+    std::unique_ptr<CDefaultElementBuilder> _defaultBuilder;
 };
 
 template<class CDefaultElementBuilder>

--- a/parameter/SystemClass.cpp
+++ b/parameter/SystemClass.cpp
@@ -38,6 +38,7 @@
 #include <assert.h>
 #include "PluginLocation.h"
 #include "Utility.h"
+#include "Memory.hpp"
 
 #define base CConfigurableElement
 
@@ -109,7 +110,7 @@ bool CSystemClass::loadSubsystems(string& strError,
     _pSubsystemLibrary->addElementBuilder("Virtual", new VirtualSubsystemBuilder(_logger));
     // Set virtual subsytem as builder fallback if required
     if (bVirtualSubsystemFallback) {
-        _pSubsystemLibrary->setDefaultBuilder(new VirtualSubsystemBuilder(_logger));
+        _pSubsystemLibrary->setDefaultBuilder(make_unique<VirtualSubsystemBuilder>(_logger));
     }
 
     // Add subsystem defined in shared libraries

--- a/parameter/criterion/CMakeLists.txt
+++ b/parameter/criterion/CMakeLists.txt
@@ -56,6 +56,8 @@ if(BUILD_TESTING)
     # Add unit test
     add_executable(criterionUnitTest test/CriterionUnitTest.cpp)
 
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=parentheses")
+
     target_link_libraries(criterionUnitTest criterion)
     add_test(NAME criterionUnitTest
              COMMAND criterionUnitTest)

--- a/utility/Memory.hpp
+++ b/utility/Memory.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2011-2014, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+/** Implementation of C++14's std::make_unique.
+ *
+ * TODO: Specialisation for array types is not implemented.
+ */
+template<class T, class... Args>
+std::unique_ptr<T> make_unique(Args &&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+


### PR DESCRIPTION
Catch parses expression to detect operators at build time by overloading operators. This leaded gcc to warn that some expression might be ambiguous after macro extension.

Port C++14's make_unique.

Manage default builders with unique_ptr to guard again leaks at compile time.