### PR TITLE
Add check for inclusive criterion overflow

### DIFF
--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -333,14 +333,6 @@ bool CTestPlatform::createInclusiveSelectionCriterionFromStateList(
     assert(pCriterionType != NULL);
 
     uint32_t uiNbStates = remoteCommand.getArgumentCount() - 1;
-
-    if (uiNbStates > 32) {
-
-        strResult = "Maximum number of states for inclusive criterion is 32";
-
-        return false;
-    }
-
     uint32_t uiState;
 
     for (uiState = 0; uiState < uiNbStates; uiState++) {
@@ -396,13 +388,6 @@ bool CTestPlatform::createInclusiveSelectionCriterion(const string& strName,
 {
     ISelectionCriterionTypeInterface* pCriterionType =
         _pParameterMgrPlatformConnector->createSelectionCriterionType(true);
-
-    if (uiNbStates > 32) {
-
-        strResult = "Maximum number of states for inclusive criterion is 32";
-
-        return false;
-    }
 
     uint32_t uiState;
 


### PR DESCRIPTION
Inclusive criteria have a limited value number due to their internal state
representation. Currently, the only check made for this is at test-platform
level.

This patch adds a new check to make addValuePair API fail if too many values
are added to an inclusive criterion type.  A log has also been added to warn
the client.  The check at test-platform level has been removed.

Change-Id: Ie9c9ec8fb8561f949bb62adbab127bc900aa254b
Signed-off-by: Jules Clero <julesx.clero@intel.com>