### PR TITLE
Some coveralls fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ after_success:
           --exclude "build_debug/bindings/python"
           --exclude "build_debug/CMakeFiles"
           --exclude "build"
+          --exclude "install"
           --exclude "skeleton-subsystem"
           --exclude "test/test-subsystem"
           --exclude "test/functional-tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ after_success:
           --exclude "build"
           --exclude "skeleton-subsystem"
           --exclude "test/test-subsystem"
+          --exclude "test/functional-tests"
           --exclude "bindings/c/Test.cpp"
           --exclude "test/tokenizer"
           --gcov /usr/bin/gcov-4.8


### PR DESCRIPTION
- Ignore the functional tests suite's source code
- Simpify the coveralls exclusion rules and correctly exclude the installed headers