### PR TITLE
Check duplicate criterion values

### DIFF
--- a/parameter/SelectionCriterionType.cpp
+++ b/parameter/SelectionCriterionType.cpp
@@ -66,6 +66,14 @@ bool CSelectionCriterionType::addValuePair(int iValue, const std::string& strVal
 
         return false;
     }
+    for (NumToLitMapConstIt it = _numToLitMap.begin(); it != _numToLitMap.end(); ++it) {
+        if (it->second == iValue) {
+            log_warning("Rejecting value pair association (numerical already present): 0x%X - %s"
+                        " for Selection Criterion Type %s",
+                        iValue, strValue.c_str(), getName().c_str());
+            return false;
+        }
+    }
     _numToLitMap[strValue] = iValue;
 
     return true;

--- a/parameter/SelectionCriterionType.cpp
+++ b/parameter/SelectionCriterionType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2015, Intel Corporation
+ * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -30,8 +30,6 @@
 #include "SelectionCriterionType.h"
 #include "Tokenizer.h"
 
-#include <climits>
-
 #define base CElement
 
 const std::string CSelectionCriterionType::_strDelimiter = "|";
@@ -53,18 +51,6 @@ std::string CSelectionCriterionType::getKind() const
 // From ISelectionCriterionTypeInterface
 bool CSelectionCriterionType::addValuePair(int iValue, const std::string& strValue)
 {
-    // An inclusive criterion is implemented as a bitfield over an int and
-    // thus, can't have values larger than the number of bits in an int.
-    static const unsigned int inclusiveCriterionMaxValue = 1 << (sizeof(iValue) * CHAR_BIT - 1);
-
-    if (_bInclusive && (unsigned int)iValue > inclusiveCriterionMaxValue) {
-
-        log_warning("Rejecting value pair association: 0x%X - %s "
-                    "because an inclusive criterion can't have values larger than 0x%X",
-                    iValue, strValue.c_str(), inclusiveCriterionMaxValue);
-        return false;
-    }
-
     // Check 1 bit set only for inclusive types
     if (_bInclusive && (!iValue || (iValue & (iValue - 1)))) {
 

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2015, Intel Corporation
+ * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -333,6 +333,14 @@ bool CTestPlatform::createInclusiveSelectionCriterionFromStateList(
     assert(pCriterionType != NULL);
 
     uint32_t uiNbStates = remoteCommand.getArgumentCount() - 1;
+
+    if (uiNbStates > 32) {
+
+        strResult = "Maximum number of states for inclusive criterion is 32";
+
+        return false;
+    }
+
     uint32_t uiState;
 
     for (uiState = 0; uiState < uiNbStates; uiState++) {
@@ -388,6 +396,13 @@ bool CTestPlatform::createInclusiveSelectionCriterion(const string& strName,
 {
     ISelectionCriterionTypeInterface* pCriterionType =
         _pParameterMgrPlatformConnector->createSelectionCriterionType(true);
+
+    if (uiNbStates > 32) {
+
+        strResult = "Maximum number of states for inclusive criterion is 32";
+
+        return false;
+    }
 
     uint32_t uiState;
 

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -333,14 +333,6 @@ bool CTestPlatform::createInclusiveSelectionCriterionFromStateList(
     assert(pCriterionType != NULL);
 
     uint32_t uiNbStates = remoteCommand.getArgumentCount() - 1;
-
-    if (uiNbStates > 32) {
-
-        strResult = "Maximum number of states for inclusive criterion is 32";
-
-        return false;
-    }
-
     uint32_t uiState;
 
     for (uiState = 0; uiState < uiNbStates; uiState++) {
@@ -396,13 +388,6 @@ bool CTestPlatform::createInclusiveSelectionCriterion(const string& strName,
 {
     ISelectionCriterionTypeInterface* pCriterionType =
         _pParameterMgrPlatformConnector->createSelectionCriterionType(true);
-
-    if (uiNbStates > 32) {
-
-        strResult = "Maximum number of states for inclusive criterion is 32";
-
-        return false;
-    }
 
     uint32_t uiState;
 


### PR DESCRIPTION
- Revert the previously-merged patch for this issue: it wasn't fixing the root cause.
- Implement another solution that checks for and refuses duplicate criterion numerical values.