### PR TITLE
Forward libxml2 error messages

### DIFF
--- a/bindings/python/sample.py
+++ b/bindings/python/sample.py
@@ -59,6 +59,6 @@ mood = pfw.createSelectionCriterion("Mood", moodType)
 
 ok, error = pfw.start()
 if not ok:
-    print("Error while starting the pfw: {}".format(error))
+    print("Error while starting the pfw: '{}'".format(error))
 
 raw_input("[Press enter to exit]")

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -535,7 +535,7 @@ bool CParameterMgr::loadFrameworkConfiguration(string& strError)
     // Parse Structure XML file
     CXmlElementSerializingContext elementSerializingContext(strError);
 
-    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(_strXmlConfigurationFilePath, true, true, strError);
+    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(_strXmlConfigurationFilePath, true, true, elementSerializingContext);
     if (doc == NULL) {
         return false;
     }
@@ -593,7 +593,7 @@ bool CParameterMgr::loadStructure(string& strError)
 
     CAutoLog autolog(pSystemClass, "Importing system structure from file " + strXmlStructureFilePath);
 
-    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strXmlStructureFilePath, true, true, strError);
+    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strXmlStructureFilePath, true, true, parameterBuildContext);
     if (doc == NULL) {
         return false;
     }
@@ -687,7 +687,7 @@ bool CParameterMgr::loadSettingsFromConfigFile(string& strError)
 
     log_info("Importing configurable domains from file %s %s settings", strXmlConfigurationDomainsFilePath.c_str(), pBinarySettingsFileLocation ? "without" : "with");
 
-    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strXmlConfigurationDomainsFilePath, true, true, strError);
+    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strXmlConfigurationDomainsFilePath, true, true, xmlDomainImportContext);
     if (doc == NULL) {
         return false;
     }
@@ -2275,7 +2275,7 @@ bool CParameterMgr::wrapLegacyXmlImport(const string& xmlSource, bool fromFile,
 
     // It doesn't make sense to resolve XIncludes on an imported file because
     // we can't reliably decide of a "base url"
-    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(xmlSource, fromFile, false, errorMsg);
+    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(xmlSource, fromFile, false, xmlDomainImportContext);
     if (doc == NULL) {
         return false;
     }

--- a/parameter/XmlFileIncluderElement.cpp
+++ b/parameter/XmlFileIncluderElement.cpp
@@ -69,12 +69,7 @@ bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSeriali
         std::string strPathToXsdFile = elementSerializingContext.getXmlSchemaPathFolder() + "/" +
                                strIncludedElementType + ".xsd";
 
-        std::string xmlErrorMsg;
-        _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strPath, true, true, xmlErrorMsg);
-        if (doc == NULL) {
-            elementSerializingContext.setError(xmlErrorMsg);
-            return false;
-        }
+        _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strPath, true, true, elementSerializingContext);
 
         CXmlDocSource docSource(doc, _bValidateSchemasOnStart,
                                 strPathToXsdFile,

--- a/xmlserializer/XmlDocSource.cpp
+++ b/xmlserializer/XmlDocSource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -33,7 +33,6 @@
 #include <libxml/xmlschemas.h>
 #include <libxml/parser.h>
 #include <libxml/xinclude.h>
-#include <libxml/xmlerror.h>
 #include <stdlib.h>
 
 using std::string;
@@ -209,8 +208,6 @@ bool CXmlDocSource::isInstanceDocumentValid()
         return false;
     }
 
-    xmlSetStructuredErrorFunc(this, schemaValidityStructuredErrorFunc);
-
     bool isDocValid = xmlSchemaValidateDoc(pValidationCtxt, _pDoc) == 0;
 
     xmlSchemaFreeValidCtxt(pValidationCtxt);
@@ -221,16 +218,6 @@ bool CXmlDocSource::isInstanceDocumentValid()
     return isDocValid;
 #else
     return true;
-#endif
-}
-
-void CXmlDocSource::schemaValidityStructuredErrorFunc(void* pUserData, _xmlError* pError)
-{
-    (void)pUserData;
-
-#ifdef LIBXML_SCHEMAS_ENABLED
-    // Display message
-    puts(pError->message);
 #endif
 }
 

--- a/xmlserializer/XmlDocSource.cpp
+++ b/xmlserializer/XmlDocSource.cpp
@@ -221,7 +221,7 @@ bool CXmlDocSource::isInstanceDocumentValid()
 #endif
 }
 
-_xmlDoc* CXmlDocSource::mkXmlDoc(const string& source, bool fromFile, bool xincludes, string& errorMsg)
+_xmlDoc* CXmlDocSource::mkXmlDoc(const string& source, bool fromFile, bool xincludes, CXmlSerializingContext& serializingContext)
 {
     _xmlDoc* doc = NULL;
     if (fromFile) {
@@ -231,25 +231,17 @@ _xmlDoc* CXmlDocSource::mkXmlDoc(const string& source, bool fromFile, bool xincl
     }
 
     if (doc == NULL) {
-        errorMsg = "libxml failed to read";
+        string errorMsg = "libxml failed to read";
         if (fromFile) {
             errorMsg += " \"" + source + "\"";
         }
-
-        xmlError* details = xmlGetLastError();
-        if (details != NULL) {
-            errorMsg += ": " + string(details->message);
-        }
+        serializingContext.appendLineToError(errorMsg);
 
         return NULL;
     }
 
     if (xincludes and (xmlXIncludeProcess(doc) < 0)) {
-        errorMsg = "libxml failed to resolve XIncludes";
-        xmlError* details = xmlGetLastError();
-        if (details != NULL) {
-            errorMsg += ": " + string(details->message);
-        }
+        serializingContext.appendLineToError("libxml failed to resolve XIncludes");
 
         xmlFreeDoc(doc);
         doc = NULL;

--- a/xmlserializer/XmlDocSource.cpp
+++ b/xmlserializer/XmlDocSource.cpp
@@ -109,12 +109,6 @@ bool CXmlDocSource::isParsable() const
 
 bool CXmlDocSource::populate(CXmlSerializingContext& serializingContext)
 {
-    return validate(serializingContext);
-
-}
-
-bool CXmlDocSource::validate(CXmlSerializingContext& serializingContext)
-{
     // Check that the doc has been created
     if (!_pDoc) {
 

--- a/xmlserializer/XmlDocSource.h
+++ b/xmlserializer/XmlDocSource.h
@@ -120,15 +120,6 @@ public:
     _xmlDoc* getDoc() const;
 
     /**
-      * Method that validates the Xml doc contained in pDoc
-      *
-      * @param[out] serializingContext is used as error output
-      *
-      * @return false if any error occurs
-      */
-    virtual bool validate(CXmlSerializingContext& serializingContext);
-
-    /**
     * Method that checks that the xml document has been correctly parsed.
     *
     * @return false if any error occurs during the parsing

--- a/xmlserializer/XmlDocSource.h
+++ b/xmlserializer/XmlDocSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -167,13 +167,6 @@ private:
       * @return true if document is valid, false if any error occures
       */
     bool isInstanceDocumentValid();
-
-    /** Validity error display method
-      *
-      * @param[in] pUserData pointer to the data to validate
-      * @param[out] pError is the xml error output
-      */
-    static void schemaValidityStructuredErrorFunc(void* pUserData, _xmlError* pError);
 
     /**
       * Schema file

--- a/xmlserializer/XmlDocSource.h
+++ b/xmlserializer/XmlDocSource.h
@@ -134,9 +134,9 @@ public:
      * @param[in] fromFile true if source is a filename, false if source is an xml
      *            represents an xml document
      * @param[in] xincludes if true, process xincludes tags
-     * @param[out] errorMsg used as error output
+     * @param[in] serializingContext will receive any serialization error
      */
-    static _xmlDoc* mkXmlDoc(const std::string& source, bool fromFile, bool xincludes, std::string& errorMsg);
+    static _xmlDoc* mkXmlDoc(const std::string& source, bool fromFile, bool xincludes, CXmlSerializingContext& serializingContext);
 
 protected:
 

--- a/xmlserializer/XmlSerializingContext.h
+++ b/xmlserializer/XmlSerializingContext.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -35,12 +35,21 @@ class CXmlSerializingContext
 {
 public:
     CXmlSerializingContext(std::string& strError);
+    ~CXmlSerializingContext();
 
     // Error
     void setError(const std::string& strError);
     void appendLineToError(const std::string& strAppend);
     const std::string& getError() const;
+    /** XML error handler
+      *
+      * @param[in] userData pointer to the serializing context
+      * @param[in] format is the xml error output format
+      *
+      */
+    static void genericErrorHandler(void* userData, const char* format, ...);
 
 private:
     std::string& _strError;
+    std::string _strXmlError;
 };


### PR DESCRIPTION
Most error messages from libxml2 are missed or dropped. These changes makes the CXmlSerializingContext automatically gather them so that they will be logged or returned to the client.