### PR TITLE
Clarify XmlSerializingContext usage.

### DIFF
--- a/xmlserializer/XmlSerializingContext.cpp
+++ b/xmlserializer/XmlSerializingContext.cpp
@@ -53,11 +53,6 @@ void CXmlSerializingContext::appendLineToError(const std::string& strAppend)
     _strError += "\n" + strAppend;
 }
 
-const std::string& CXmlSerializingContext::getError() const
-{
-    return _strError;
-}
-
 void CXmlSerializingContext::genericErrorHandler(void* userData, const char* format, ...)
 {
     char *buffer = NULL;

--- a/xmlserializer/XmlSerializingContext.h
+++ b/xmlserializer/XmlSerializingContext.h
@@ -31,6 +31,16 @@
 
 #include <string>
 
+/** Class that gather errors during serialization.
+ *
+ * Provided with an initial empty buffer (strError), an instance of this class
+ * can describe an error.
+ *
+ * This error will be accessible formated in the aforementioned buffer
+ * _after_ destruction.
+ * Ie. the provided buffer (strError) is in an undefined state between
+ * construction and destruction and should not be accessed in between.
+ */
 class CXmlSerializingContext
 {
 public:
@@ -40,7 +50,6 @@ public:
     // Error
     void setError(const std::string& strError);
     void appendLineToError(const std::string& strAppend);
-    const std::string& getError() const;
     /** XML error handler
       *
       * @param[in] userData pointer to the serializing context


### PR DESCRIPTION
The XmlSerializingContext usage was not very clear.

Add a doxygen for the class XmlSerializingContext and remove an unused
function that contradict with the recommended usage.