### PR TITLE
Rework get/setAttribute

### DIFF
--- a/parameter/BitParameterBlockType.cpp
+++ b/parameter/BitParameterBlockType.cpp
@@ -59,7 +59,8 @@ uint32_t CBitParameterBlockType::getSize() const
 bool CBitParameterBlockType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Size
-    _uiSize = xmlElement.getAttributeInteger("Size") / 8;
+    xmlElement.getAttribute("Size", _uiSize);
+    _uiSize /= 8;
 
     // Base
     return base::fromXml(xmlElement, serializingContext);
@@ -75,7 +76,7 @@ CInstanceConfigurableElement* CBitParameterBlockType::doInstantiate() const
 void CBitParameterBlockType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Size
-    xmlElement.setAttributeString("Size", CUtility::toString(_uiSize * 8));
+    xmlElement.setAttribute("Size", _uiSize * 8);
 
     base::toXml(xmlElement, serializingContext);
 }

--- a/parameter/BitParameterType.cpp
+++ b/parameter/BitParameterType.cpp
@@ -74,10 +74,10 @@ void CBitParameterType::showProperties(string& strResult) const
 bool CBitParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Pos
-    _uiBitPos = xmlElement.getAttributeInteger("Pos");
+    xmlElement.getAttribute("Pos", _uiBitPos);
 
     // Size
-    _uiBitSize = xmlElement.getAttributeInteger("Size");
+    xmlElement.getAttribute("Size", _uiBitSize);
 
     // Validate bit pos and size still fit into parent type
     const CBitParameterBlockType* pBitParameterBlockType = static_cast<const CBitParameterBlockType*>(getParent());
@@ -99,7 +99,7 @@ bool CBitParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingCo
     // Max
     if (xmlElement.hasAttribute("Max")) {
 
-        _uiMax = xmlElement.getAttributeInteger("Max");
+        xmlElement.getAttribute("Max", _uiMax);
 
         if (_uiMax > getMaxEncodableValue()) {
 
@@ -246,13 +246,13 @@ bool CBitParameterType::isEncodable(uint64_t uiData) const
 void CBitParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Position
-    xmlElement.setAttributeString("Pos", CUtility::toString(_uiBitPos));
+    xmlElement.setAttribute("Pos", _uiBitPos);
 
     // Size
-    xmlElement.setAttributeString("Size", CUtility::toString(_uiBitSize));
+    xmlElement.setAttribute("Size", _uiBitSize);
 
     // Maximum
-    xmlElement.setAttributeString("Max", CUtility::toString(_uiMax));
+    xmlElement.setAttribute("Max", _uiMax);
 
     base::toXml(xmlElement, serializingContext);
 

--- a/parameter/BitParameterType.cpp
+++ b/parameter/BitParameterType.cpp
@@ -97,24 +97,17 @@ bool CBitParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingCo
     }
 
     // Max
-    if (xmlElement.hasAttribute("Max")) {
+    _uiMax = getMaxEncodableValue();
+    if (xmlElement.getAttribute("Max", _uiMax) && (_uiMax > getMaxEncodableValue())) {
 
-        xmlElement.getAttribute("Max", _uiMax);
+        // Max value exceeded
+        std::ostringstream strStream;
 
-        if (_uiMax > getMaxEncodableValue()) {
+        strStream << "Max attribute inconsistent with maximum encodable size (" << getMaxEncodableValue() << ") for " + getKind();
 
-            // Max value exceeded
-	    std::ostringstream strStream;
+        serializingContext.setError(strStream.str());
 
-            strStream << "Max attribute inconsistent with maximum encodable size (" << getMaxEncodableValue() << ") for " + getKind();
-
-            serializingContext.setError(strStream.str());
-
-            return false;
-        }
-    } else {
-
-        _uiMax = getMaxEncodableValue();
+        return false;
     }
 
     // Base

--- a/parameter/ComponentInstance.cpp
+++ b/parameter/ComponentInstance.cpp
@@ -80,7 +80,8 @@ bool CComponentInstance::fromXml(const CXmlElement& xmlElement, CXmlSerializingC
 
     const CComponentLibrary* pComponentLibrary = parameterBuildContext.getComponentLibrary();
 
-    std::string strComponentType = xmlElement.getAttributeString("Type");
+    std::string strComponentType;
+    xmlElement.getAttribute("Type", strComponentType);
 
     _pComponentType = pComponentLibrary->getComponentType(strComponentType);
 

--- a/parameter/ComponentType.cpp
+++ b/parameter/ComponentType.cpp
@@ -89,7 +89,8 @@ bool CComponentType::fromXml(const CXmlElement& xmlElement, CXmlSerializingConte
     // Check for Extends attribute (extensions will be populated after and not before)
     if (xmlElement.hasAttribute("Extends")) {
 
-        std::string strExtendsType = xmlElement.getAttributeString("Extends");
+        std::string strExtendsType;
+        xmlElement.getAttribute("Extends", strExtendsType);
 
         _pExtendsComponentType = pComponentLibrary->getComponentType(strExtendsType);
 

--- a/parameter/CompoundRule.cpp
+++ b/parameter/CompoundRule.cpp
@@ -140,7 +140,7 @@ bool CCompoundRule::matches() const
 bool CCompoundRule::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Get type
-    _bTypeAll = xmlElement.getAttributeBoolean("Type", _apcTypes[true]);
+    _bTypeAll = xmlElement.getAttributeString("Type") == _apcTypes[true];
 
     // Base
     return base::fromXml(xmlElement, serializingContext);

--- a/parameter/CompoundRule.cpp
+++ b/parameter/CompoundRule.cpp
@@ -140,7 +140,9 @@ bool CCompoundRule::matches() const
 bool CCompoundRule::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Get type
-    _bTypeAll = xmlElement.getAttributeString("Type") == _apcTypes[true];
+    string strType;
+    xmlElement.getAttribute("Type", strType);
+    _bTypeAll = strType == _apcTypes[true];
 
     // Base
     return base::fromXml(xmlElement, serializingContext);
@@ -150,7 +152,7 @@ bool CCompoundRule::fromXml(const CXmlElement& xmlElement, CXmlSerializingContex
 void CCompoundRule::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Set type
-    xmlElement.setAttributeString("Type", _apcTypes[_bTypeAll]);
+    xmlElement.setAttribute("Type", _apcTypes[_bTypeAll]);
 
     // Base
     base::toXml(xmlElement, serializingContext);

--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -121,7 +121,7 @@ void CConfigurableDomain::toXml(CXmlElement& xmlElement, CXmlSerializingContext&
     base::toXml(xmlElement, serializingContext);
 
     // Sequence awareness
-    xmlElement.setAttributeBoolean("SequenceAware", _bSequenceAware);
+    xmlElement.setAttribute("SequenceAware", _bSequenceAware);
 }
 
 void CConfigurableDomain::childrenToXml(CXmlElement& xmlElement,
@@ -169,7 +169,7 @@ void CConfigurableDomain::composeConfigurableElements(CXmlElement& xmlElement) c
         xmlConfigurableElementsElement.createChild(xmlChildConfigurableElement, "ConfigurableElement");
 
         // Set Path attribute
-        xmlChildConfigurableElement.setAttributeString("Path", pConfigurableElement->getPath());
+        xmlChildConfigurableElement.setAttribute("Path", pConfigurableElement->getPath());
     }
 }
 
@@ -218,9 +218,13 @@ bool CConfigurableDomain::fromXml(const CXmlElement& xmlElement, CXmlSerializing
         static_cast<CXmlDomainImportContext&>(serializingContext);
 
     // Sequence awareness (optional)
-    _bSequenceAware = xmlElement.hasAttribute("SequenceAware") && xmlElement.getAttributeBoolean("SequenceAware");
+    if (!xmlElement.getAttribute("SequenceAware", _bSequenceAware)) {
+        _bSequenceAware = false;
+    }
 
-    setName(xmlElement.getAttributeString("Name"));
+    std::string name;
+    xmlElement.getAttribute("Name", name);
+    setName(name);
 
     // Local parsing. Do not dig
     if (!parseDomainConfigurations(xmlElement, xmlDomainImportContext) ||
@@ -274,7 +278,8 @@ bool CConfigurableDomain::parseConfigurableElements(const CXmlElement& xmlElemen
     while (it.next(xmlConfigurableElementElement)) {
 
         // Locate configurable element
-        string strConfigurableElementPath = xmlConfigurableElementElement.getAttributeString("Path");
+        string strConfigurableElementPath;
+        xmlConfigurableElementElement.getAttribute("Path", strConfigurableElementPath);
 
         CPathNavigator pathNavigator(strConfigurableElementPath);
         string strError;

--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -218,9 +218,7 @@ bool CConfigurableDomain::fromXml(const CXmlElement& xmlElement, CXmlSerializing
         static_cast<CXmlDomainImportContext&>(serializingContext);
 
     // Sequence awareness (optional)
-    if (!xmlElement.getAttribute("SequenceAware", _bSequenceAware)) {
-        _bSequenceAware = false;
-    }
+    xmlElement.getAttribute("SequenceAware", _bSequenceAware);
 
     std::string name;
     xmlElement.getAttribute("Name", name);

--- a/parameter/ConfigurableDomains.cpp
+++ b/parameter/ConfigurableDomains.cpp
@@ -102,7 +102,7 @@ void CConfigurableDomains::apply(CParameterBlackboard* pParameterBlackboard, CSy
 void CConfigurableDomains::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Set attribute
-    xmlElement.setAttributeString("SystemClassName", getName());
+    xmlElement.setAttribute("SystemClassName", getName());
 
     base::childrenToXml(xmlElement, serializingContext);
 }

--- a/parameter/DomainConfiguration.cpp
+++ b/parameter/DomainConfiguration.cpp
@@ -86,7 +86,8 @@ bool CDomainConfiguration::parseSettings(CXmlElement& xmlConfigurationSettingsEl
     while (it.next(xmlConfigurableElementSettingsElement)) {
 
         // Retrieve area configuration
-        string strConfigurableElementPath = xmlConfigurableElementSettingsElement.getAttributeString("Path");
+        string strConfigurableElementPath;
+        xmlConfigurableElementSettingsElement.getAttribute("Path", strConfigurableElementPath);
 
         CAreaConfiguration* pAreaConfiguration = findAreaConfiguration(strConfigurableElementPath);
 
@@ -131,7 +132,7 @@ void CDomainConfiguration::composeSettings(CXmlElement& xmlConfigurationSettings
         xmlConfigurationSettingsElement.createChild(xmlConfigurableElementSettingsElement, "ConfigurableElement");
 
         // Set Path attribute
-        xmlConfigurableElementSettingsElement.setAttributeString("Path", pConfigurableElement->getPath());
+        xmlConfigurableElementSettingsElement.setAttribute("Path", pConfigurableElement->getPath());
 
         // Delegate composing to area configuration
         ((CDomainConfiguration&)(*this)).serializeConfigurableElementSettings((CAreaConfiguration*)pAreaConfiguration, xmlConfigurableElementSettingsElement, serializingContext, true);

--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -221,7 +221,7 @@ void CElement::logValue(string& strValue, CErrorContext& errorContext) const
 // From IXmlSink
 bool CElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
-    setDescription(getXmlDescriptionAttribute(xmlElement));
+    xmlElement.getAttribute(gDescriptionPropertyName, _strDescription);
 
     // Propagate through children
     CXmlElement::CChildIterator childIterator(xmlElement);
@@ -298,13 +298,8 @@ void CElement::setXmlDescriptionAttribute(CXmlElement& xmlElement) const
 {
     const string &description = getDescription();
     if (!description.empty()) {
-        xmlElement.setAttributeString(gDescriptionPropertyName, description);
+        xmlElement.setAttribute(gDescriptionPropertyName, description);
     }
-}
-
-string CElement::getXmlDescriptionAttribute(const CXmlElement& xmlElement) const
-{
-    return xmlElement.getAttributeString(gDescriptionPropertyName);
 }
 
 void CElement::setXmlNameAttribute(CXmlElement& xmlElement) const

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -147,15 +147,6 @@ public:
     void setXmlDescriptionAttribute(CXmlElement& xmlElement) const;
 
     /**
-     * Extract the Description field from the Xml Element during XML decomposing.
-     *
-     * @param[in] xmlElement to extract the description from.
-     *
-     * @return description represented as a string, empty if not found
-     */
-    std::string getXmlDescriptionAttribute(const CXmlElement &xmlElement) const;
-
-    /**
      * Appends if found human readable description property.
      *
      * @param[out] strResult in which the description is wished to be appended.
@@ -179,6 +170,8 @@ protected:
      */
     CElement* createChild(const CXmlElement& childElement,
                           CXmlSerializingContext& elementSerializingContext);
+
+    static const std::string gDescriptionPropertyName;
 
 private:
     // Logging (done by root)
@@ -209,6 +202,4 @@ private:
     std::vector<CElement*> _childArray;
     // Parent
     CElement* _pParent;
-
-    static const std::string gDescriptionPropertyName;
 };

--- a/parameter/EnumParameterType.cpp
+++ b/parameter/EnumParameterType.cpp
@@ -82,7 +82,8 @@ void CEnumParameterType::showProperties(string& strResult) const
 bool CEnumParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Size in bits
-    uint32_t uiSizeInBits = xmlElement.getAttributeInteger("Size");
+    uint32_t uiSizeInBits;
+    xmlElement.getAttribute("Size", uiSizeInBits);
 
     // Size
     setSize(uiSizeInBits / 8);
@@ -345,7 +346,7 @@ bool CEnumParameterType::isValid(int iNumerical, CParameterAccessContext& parame
 void CEnumParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Size
-    xmlElement.setAttributeString("Size", CUtility::toString(getSize() * 8));
+    xmlElement.setAttribute("Size", getSize() * 8);
 
     base::toXml(xmlElement, serializingContext);
 }

--- a/parameter/EnumValuePair.cpp
+++ b/parameter/EnumValuePair.cpp
@@ -59,10 +59,12 @@ string CEnumValuePair::getNumericalAsString() const
 bool CEnumValuePair::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Literal
-    setName(xmlElement.getAttributeString("Literal"));
+    std::string name;
+    xmlElement.getAttribute("Literal", name);
+    setName(name);
 
     // Numerical
-    _iNumerical = xmlElement.getAttributeSignedInteger("Numerical");
+    xmlElement.getAttribute("Numerical", _iNumerical);
 
     // Base
     return base::fromXml(xmlElement, serializingContext);
@@ -80,10 +82,10 @@ void CEnumValuePair::logValue(string& strValue, CErrorContext& errorContext) con
 void CEnumValuePair::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Literal
-    xmlElement.setAttributeString("Literal", this->getName());
+    xmlElement.setAttribute("Literal", this->getName());
 
     // Numerical
-    xmlElement.setAttributeString("Numerical", getNumericalAsString());
+    xmlElement.setAttribute("Numerical", getNumericalAsString());
 
     base::toXml(xmlElement, serializingContext);
 }

--- a/parameter/FixedPointParameterType.cpp
+++ b/parameter/FixedPointParameterType.cpp
@@ -76,8 +76,9 @@ void CFixedPointParameterType::handleValueSpaceAttribute(CXmlElement& xmlConfigu
         // Get Value space from XML
         if (xmlConfigurableElementSettingsElement.hasAttribute("ValueSpace")) {
 
-            configurationAccessContext.setValueSpaceRaw(
-                    xmlConfigurableElementSettingsElement.getAttributeString("ValueSpace") == "Raw");
+            string strValueSpace;
+            xmlConfigurableElementSettingsElement.getAttribute("ValueSpace", strValueSpace);
+            configurationAccessContext.setValueSpaceRaw(strValueSpace == "Raw");
         } else {
 
             configurationAccessContext.setValueSpaceRaw(false);
@@ -86,7 +87,7 @@ void CFixedPointParameterType::handleValueSpaceAttribute(CXmlElement& xmlConfigu
         // Provide value space only if not the default one
         if (configurationAccessContext.valueSpaceIsRaw()) {
 
-            xmlConfigurableElementSettingsElement.setAttributeString("ValueSpace", "Raw");
+            xmlConfigurableElementSettingsElement.setAttribute("ValueSpace", "Raw");
         }
     }
 }
@@ -94,16 +95,22 @@ void CFixedPointParameterType::handleValueSpaceAttribute(CXmlElement& xmlConfigu
 bool CFixedPointParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Size
-    uint32_t uiSizeInBits = xmlElement.getAttributeInteger("Size");
+    uint32_t uiSizeInBits;
+    xmlElement.getAttribute("Size", uiSizeInBits);
 
     // Q notation
-    _uiIntegral = xmlElement.getAttributeInteger("Integral");
-    _uiFractional = xmlElement.getAttributeInteger("Fractional");
+    xmlElement.getAttribute("Integral", _uiIntegral);
+    xmlElement.getAttribute("Fractional", _uiFractional);
 
     // Size vs. Q notation integrity check
     if (uiSizeInBits < getUtilSizeInBits()) {
 
-        serializingContext.setError("Inconsistent Size vs. Q notation for " + getKind() + " " + xmlElement.getPath() + ": Summing (Integral + _uiFractional + 1) should not exceed given Size (" + xmlElement.getAttributeString("Size") + ")");
+        std::string size;
+        xmlElement.getAttribute("Size", size);
+        serializingContext.setError(
+                "Inconsistent Size vs. Q notation for " + getKind() + " " + xmlElement.getPath() +
+                ": Summing (Integral + _uiFractional + 1) should not exceed given Size (" +
+                size + ")");
 
         return false;
     }
@@ -365,13 +372,13 @@ double CFixedPointParameterType::binaryQnmToDouble(int32_t iValue) const
 void CFixedPointParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Size
-    xmlElement.setAttributeString("Size", CUtility::toString(getSize() * 8));
+    xmlElement.setAttribute("Size", getSize() * 8);
 
     // Integral
-    xmlElement.setAttributeString("Integral", CUtility::toString(_uiIntegral));
+    xmlElement.setAttribute("Integral", _uiIntegral);
 
     // Fractional
-    xmlElement.setAttributeString("Fractional", CUtility::toString(_uiFractional));
+    xmlElement.setAttribute("Fractional", _uiFractional);
 
     base::toXml(xmlElement, serializingContext);
 }

--- a/parameter/FixedPointParameterType.cpp
+++ b/parameter/FixedPointParameterType.cpp
@@ -76,7 +76,8 @@ void CFixedPointParameterType::handleValueSpaceAttribute(CXmlElement& xmlConfigu
         // Get Value space from XML
         if (xmlConfigurableElementSettingsElement.hasAttribute("ValueSpace")) {
 
-            configurationAccessContext.setValueSpaceRaw(xmlConfigurableElementSettingsElement.getAttributeBoolean("ValueSpace", "Raw"));
+            configurationAccessContext.setValueSpaceRaw(
+                    xmlConfigurableElementSettingsElement.getAttributeString("ValueSpace") == "Raw");
         } else {
 
             configurationAccessContext.setValueSpaceRaw(false);

--- a/parameter/FixedPointParameterType.cpp
+++ b/parameter/FixedPointParameterType.cpp
@@ -73,16 +73,9 @@ void CFixedPointParameterType::handleValueSpaceAttribute(CXmlElement& xmlConfigu
     // Direction?
     if (!configurationAccessContext.serializeOut()) {
 
-        // Get Value space from XML
-        if (xmlConfigurableElementSettingsElement.hasAttribute("ValueSpace")) {
-
-            string strValueSpace;
-            xmlConfigurableElementSettingsElement.getAttribute("ValueSpace", strValueSpace);
-            configurationAccessContext.setValueSpaceRaw(strValueSpace == "Raw");
-        } else {
-
-            configurationAccessContext.setValueSpaceRaw(false);
-        }
+        string strValueSpace;
+        xmlConfigurableElementSettingsElement.getAttribute("ValueSpace", strValueSpace);
+        configurationAccessContext.setValueSpaceRaw(strValueSpace == "Raw");
     } else {
         // Provide value space only if not the default one
         if (configurationAccessContext.valueSpaceIsRaw()) {

--- a/parameter/FrameworkConfigurationLocation.cpp
+++ b/parameter/FrameworkConfigurationLocation.cpp
@@ -39,7 +39,7 @@ CFrameworkConfigurationLocation::CFrameworkConfigurationLocation(const std::stri
 // From IXmlSink
 bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
-    _strPath = xmlElement.getAttributeString("Path");
+    xmlElement.getAttribute("Path", _strPath);
 
     if (_strPath.empty()) {
 

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -93,15 +93,17 @@ void CIntegerParameterType::showProperties(string& strResult) const
 bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Sign
-    _bSigned = xmlElement.getAttributeBoolean("Signed");
+    xmlElement.getAttribute("Signed", _bSigned);
 
     // Size in bits
-    uint32_t uiSizeInBits = xmlElement.getAttributeInteger("Size");
+    uint32_t uiSizeInBits = 0;
+    xmlElement.getAttribute("Size", uiSizeInBits);
 
     // Size
     setSize(uiSizeInBits / 8);
 
     // Min / Max
+    // TODO: Make IntegerParameter template
     if (_bSigned) {
 
         // Signed means we have one less util bit
@@ -109,7 +111,7 @@ bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializi
 
         if (xmlElement.hasAttribute("Min")) {
 
-            _uiMin = (uint32_t)xmlElement.getAttributeSignedInteger("Min");
+            xmlElement.getAttribute("Min", (int32_t &)_uiMin);
         } else {
 
             _uiMin = 1UL << uiSizeInBits;
@@ -119,7 +121,7 @@ bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializi
 
         if (xmlElement.hasAttribute("Max")) {
 
-            _uiMax = (uint32_t)xmlElement.getAttributeSignedInteger("Max");
+            xmlElement.getAttribute("Max", (int32_t &)_uiMax);
 
             signExtend((int32_t&)_uiMax);
         } else {
@@ -127,17 +129,12 @@ bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializi
             _uiMax = (1UL << uiSizeInBits) - 1;
         }
     } else {
-        if (xmlElement.hasAttribute("Min")) {
-
-            _uiMin = xmlElement.getAttributeInteger("Min");
-        } else {
+        if (!xmlElement.getAttribute("Min", _uiMin)) {
 
             _uiMin = 0;
         }
-        if (xmlElement.hasAttribute("Max")) {
 
-            _uiMax = xmlElement.getAttributeInteger("Max");
-        } else {
+        if (!xmlElement.getAttribute("Max", _uiMax)) {
 
             _uiMax = (uint32_t)-1L >> (8 * sizeof(uint32_t) - uiSizeInBits);
         }
@@ -435,27 +432,27 @@ const CParameterAdaptation* CIntegerParameterType::getParameterAdaptation() cons
 void CIntegerParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Sign
-    xmlElement.setAttributeBoolean("Signed", _bSigned);
+    xmlElement.setAttribute("Signed", _bSigned);
 
     if (_bSigned) {
 
         // Mininmum
-        xmlElement.setAttributeString("Min", CUtility::toString((int32_t)_uiMin));
+        xmlElement.setAttribute("Min", (int32_t)_uiMin);
 
         // Maximum
-        xmlElement.setAttributeString("Max", CUtility::toString((int32_t)_uiMax));
+        xmlElement.setAttribute("Max", (int32_t)_uiMax);
 
     } else {
 
         // Minimum
-        xmlElement.setAttributeString("Min", CUtility::toString(_uiMin));
+        xmlElement.setAttribute("Min", _uiMin);
 
         // Maximum
-        xmlElement.setAttributeString("Max", CUtility::toString(_uiMax));
+        xmlElement.setAttribute("Max", _uiMax);
     }
 
     // Size
-    xmlElement.setAttributeString("Size", CUtility::toString(getSize() * 8));
+    xmlElement.setAttribute("Size", getSize() * 8);
 
     base::toXml(xmlElement, serializingContext);
 

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -109,25 +109,17 @@ bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializi
         // Signed means we have one less util bit
         uiSizeInBits--;
 
-        if (xmlElement.hasAttribute("Min")) {
-
-            xmlElement.getAttribute("Min", (int32_t &)_uiMin);
-        } else {
+        if (!xmlElement.getAttribute("Min", (int32_t &)_uiMin)) {
 
             _uiMin = 1UL << uiSizeInBits;
-
         }
-        signExtend((int32_t&)_uiMin);
 
-        if (xmlElement.hasAttribute("Max")) {
-
-            xmlElement.getAttribute("Max", (int32_t &)_uiMax);
-
-            signExtend((int32_t&)_uiMax);
-        } else {
+        if (!xmlElement.getAttribute("Max", (int32_t &)_uiMax)) {
 
             _uiMax = (1UL << uiSizeInBits) - 1;
         }
+        signExtend((int32_t&)_uiMin);
+        signExtend((int32_t&)_uiMax);
     } else {
         if (!xmlElement.getAttribute("Min", _uiMin)) {
 

--- a/parameter/LinearParameterAdaptation.cpp
+++ b/parameter/LinearParameterAdaptation.cpp
@@ -65,7 +65,7 @@ bool CLinearParameterAdaptation::fromXml(const CXmlElement& xmlElement, CXmlSeri
     // Get SlopeNumerator
     if (xmlElement.hasAttribute("SlopeNumerator")) {
 
-        _dSlopeNumerator = xmlElement.getAttributeDouble("SlopeNumerator");
+       xmlElement.getAttribute("SlopeNumerator", _dSlopeNumerator);
 
     } else {
         // Default
@@ -74,7 +74,7 @@ bool CLinearParameterAdaptation::fromXml(const CXmlElement& xmlElement, CXmlSeri
     // Get SlopeDenominator
     if (xmlElement.hasAttribute("SlopeDenominator")) {
 
-        _dSlopeDenominator = xmlElement.getAttributeDouble("SlopeDenominator");
+        xmlElement.getAttribute("SlopeDenominator", _dSlopeDenominator);
 
         // Avoid by 0 division errors
         if (_dSlopeDenominator == 0) {

--- a/parameter/LinearParameterAdaptation.cpp
+++ b/parameter/LinearParameterAdaptation.cpp
@@ -63,30 +63,15 @@ void CLinearParameterAdaptation::showProperties(string& strResult) const
 bool CLinearParameterAdaptation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Get SlopeNumerator
-    if (xmlElement.hasAttribute("SlopeNumerator")) {
+    xmlElement.getAttribute("SlopeNumerator", _dSlopeNumerator);
 
-       xmlElement.getAttribute("SlopeNumerator", _dSlopeNumerator);
-
-    } else {
-        // Default
-        _dSlopeNumerator = 1;
-    }
     // Get SlopeDenominator
-    if (xmlElement.hasAttribute("SlopeDenominator")) {
-
-        xmlElement.getAttribute("SlopeDenominator", _dSlopeDenominator);
+    if (xmlElement.getAttribute("SlopeDenominator", _dSlopeDenominator)
+        && (_dSlopeDenominator == 0)) {
 
         // Avoid by 0 division errors
-        if (_dSlopeDenominator == 0) {
-
-            serializingContext.setError("SlopeDenominator attribute can't be 0 on element" + xmlElement.getPath());
-
-            return false;
-        }
-
-    } else {
-        // Default
-        _dSlopeDenominator = 1;
+        serializingContext.setError("SlopeDenominator attribute can't be 0 on element" + xmlElement.getPath());
+        return false;
     }
 
     // Base

--- a/parameter/LogarithmicParameterAdaptation.cpp
+++ b/parameter/LogarithmicParameterAdaptation.cpp
@@ -59,7 +59,7 @@ bool CLogarithmicParameterAdaptation::fromXml(const CXmlElement& xmlElement,
 
     if (xmlElement.hasAttribute("LogarithmBase")) {
 
-        _dLogarithmBase = xmlElement.getAttributeDouble("LogarithmBase");
+        xmlElement.getAttribute("LogarithmBase", _dLogarithmBase);
 
         // Avoid negative and 1 values
         if (_dLogarithmBase <= 0 || _dLogarithmBase == 1) {
@@ -71,7 +71,7 @@ bool CLogarithmicParameterAdaptation::fromXml(const CXmlElement& xmlElement,
     }
 
     if (xmlElement.hasAttribute("FloorValue")) {
-        _dFloorValue = xmlElement.getAttributeDouble("FloorValue");
+        xmlElement.getAttribute("FloorValue", _dFloorValue);
     }
     // Base
     return base::fromXml(xmlElement, serializingContext);

--- a/parameter/LogarithmicParameterAdaptation.cpp
+++ b/parameter/LogarithmicParameterAdaptation.cpp
@@ -56,23 +56,17 @@ void CLogarithmicParameterAdaptation::showProperties(std::string& strResult) con
 bool CLogarithmicParameterAdaptation::fromXml(const CXmlElement& xmlElement,
                                             CXmlSerializingContext& serializingContext)
 {
-
-    if (xmlElement.hasAttribute("LogarithmBase")) {
-
-        xmlElement.getAttribute("LogarithmBase", _dLogarithmBase);
-
+    if (xmlElement.getAttribute("LogarithmBase", _dLogarithmBase)
+        && (_dLogarithmBase <= 0 || _dLogarithmBase == 1)) {
         // Avoid negative and 1 values
-        if (_dLogarithmBase <= 0 || _dLogarithmBase == 1) {
-            serializingContext.setError("LogarithmBase attribute cannot be negative or 1 on element"
-                                        + xmlElement.getPath());
+        serializingContext.setError("LogarithmBase attribute cannot be negative or 1 on element"
+                                    + xmlElement.getPath());
 
-            return false;
-        }
+        return false;
     }
 
-    if (xmlElement.hasAttribute("FloorValue")) {
-        xmlElement.getAttribute("FloorValue", _dFloorValue);
-    }
+    xmlElement.getAttribute("FloorValue", _dFloorValue);
+
     // Base
     return base::fromXml(xmlElement, serializingContext);
 }

--- a/parameter/ParameterAdaptation.cpp
+++ b/parameter/ParameterAdaptation.cpp
@@ -66,12 +66,7 @@ void CParameterAdaptation::showProperties(string& strResult) const
 // From IXmlSink
 bool CParameterAdaptation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
-    // Get offset
-    if (xmlElement.hasAttribute("Offset")) {
-
-        _iOffset = xmlElement.getAttributeSignedInteger("Offset");
-
-    } else {
+    if (!xmlElement.getAttribute("Offset", _iOffset)) {
         // Default
         _iOffset = 0;
     }

--- a/parameter/ParameterAdaptation.cpp
+++ b/parameter/ParameterAdaptation.cpp
@@ -66,10 +66,7 @@ void CParameterAdaptation::showProperties(string& strResult) const
 // From IXmlSink
 bool CParameterAdaptation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
-    if (!xmlElement.getAttribute("Offset", _iOffset)) {
-        // Default
-        _iOffset = 0;
-    }
+    xmlElement.getAttribute("Offset", _iOffset);
 
     // Base
     return base::fromXml(xmlElement, serializingContext);

--- a/parameter/ParameterFrameworkConfiguration.cpp
+++ b/parameter/ParameterFrameworkConfiguration.cpp
@@ -68,13 +68,13 @@ uint16_t CParameterFrameworkConfiguration::getServerPort() const
 bool CParameterFrameworkConfiguration::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // System class name
-    _strSystemClassName = xmlElement.getAttributeString("SystemClassName");
+    xmlElement.getAttribute("SystemClassName", _strSystemClassName);
 
     // Tuning allowed
-    _bTuningAllowed = xmlElement.getAttributeBoolean("TuningAllowed");
+    xmlElement.getAttribute("TuningAllowed", _bTuningAllowed);
 
     // Server port
-    _uiServerPort = (uint16_t)xmlElement.getAttributeInteger("ServerPort");
+    xmlElement.getAttribute("ServerPort", _uiServerPort);
 
     // Base
     return base::fromXml(xmlElement, serializingContext);

--- a/parameter/ParameterType.cpp
+++ b/parameter/ParameterType.cpp
@@ -79,7 +79,7 @@ void CParameterType::setUnit(const std::string& strUnit)
 // From IXmlSink
 bool CParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
-    setUnit(xmlElement.getAttributeString(gUnitPropertyName));
+    xmlElement.getAttribute(gUnitPropertyName, _strUnit);
     return base::fromXml(xmlElement, serializingContext);
 }
 
@@ -94,7 +94,7 @@ void CParameterType::setXmlUnitAttribute(CXmlElement& xmlElement) const
 {
     const string& unit = getUnit();
     if (!unit.empty()) {
-        xmlElement.setAttributeString(gUnitPropertyName, unit);
+        xmlElement.setAttribute(gUnitPropertyName, unit);
     }
 }
 

--- a/parameter/PluginLocation.cpp
+++ b/parameter/PluginLocation.cpp
@@ -51,7 +51,7 @@ bool CPluginLocation::fromXml(const CXmlElement &xmlElement, CXmlSerializingCont
     (void) serializingContext;
 
     // Retrieve folder
-    _strFolder = xmlElement.getAttributeString("Folder");
+    xmlElement.getAttribute("Folder", _strFolder);
 
     // Get Info from children
     CXmlElement::CChildIterator childIterator(xmlElement);
@@ -61,7 +61,7 @@ bool CPluginLocation::fromXml(const CXmlElement &xmlElement, CXmlSerializingCont
     while (childIterator.next(xmlPluginElement)) {
 
         // Fill Plugin List
-        _pluginList.push_back(xmlPluginElement.getAttributeString("Name"));
+        _pluginList.push_back(xmlPluginElement.getNameAttribute());
     }
 
     // Don't dig

--- a/parameter/SelectionCriterion.cpp
+++ b/parameter/SelectionCriterion.cpp
@@ -175,7 +175,7 @@ std::string CSelectionCriterion::getFormattedDescription(bool bWithTypeInfo, boo
 void CSelectionCriterion::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Current Value
-    xmlElement.setAttributeString("Value", _pType->getFormattedState(_iState));
+    xmlElement.setAttribute("Value", _pType->getFormattedState(_iState));
 
     // Serialize Type node
     _pType->toXml(xmlElement, serializingContext);

--- a/parameter/SelectionCriterionRule.cpp
+++ b/parameter/SelectionCriterionRule.cpp
@@ -157,7 +157,8 @@ bool CSelectionCriterionRule::fromXml(const CXmlElement& xmlElement, CXmlSeriali
     CXmlDomainImportContext& xmlDomainImportContext = static_cast<CXmlDomainImportContext&>(serializingContext);
 
     // Get selection criterion
-    string strSelectionCriterion = xmlElement.getAttributeString("SelectionCriterion");
+    string strSelectionCriterion;
+    xmlElement.getAttribute("SelectionCriterion", strSelectionCriterion);
 
     _pSelectionCriterion = xmlDomainImportContext.getSelectionCriteriaDefinition()->getSelectionCriterion(strSelectionCriterion);
 
@@ -170,7 +171,8 @@ bool CSelectionCriterionRule::fromXml(const CXmlElement& xmlElement, CXmlSeriali
     }
 
     // Get MatchesWhen
-    string strMatchesWhen = xmlElement.getAttributeString("MatchesWhen");
+    string strMatchesWhen;
+    xmlElement.getAttribute("MatchesWhen", strMatchesWhen);
     string strError;
 
     if (!setMatchesWhen(strMatchesWhen, strError)) {
@@ -181,7 +183,8 @@ bool CSelectionCriterionRule::fromXml(const CXmlElement& xmlElement, CXmlSeriali
     }
 
     // Get Value
-    string strValue = xmlElement.getAttributeString("Value");
+    string strValue;
+    xmlElement.getAttribute("Value", strValue);
 
     if (!_pSelectionCriterion->getCriterionType()->getNumericalValue(strValue, _iMatchValue)) {
 
@@ -202,17 +205,17 @@ void CSelectionCriterionRule::toXml(CXmlElement& xmlElement, CXmlSerializingCont
     assert(_pSelectionCriterion);
 
     // Set selection criterion
-    xmlElement.setAttributeString("SelectionCriterion", _pSelectionCriterion->getName());
+    xmlElement.setAttribute("SelectionCriterion", _pSelectionCriterion->getName());
 
     // Set MatchesWhen
-    xmlElement.setAttributeString("MatchesWhen", _astMatchesWhen[_eMatchesWhen].pcMatchesWhen);
+    xmlElement.setAttribute("MatchesWhen", _astMatchesWhen[_eMatchesWhen].pcMatchesWhen);
 
     // Set Value
     string strValue;
 
      _pSelectionCriterion->getCriterionType()->getLiteralValue(_iMatchValue, strValue);
 
-    xmlElement.setAttributeString("Value", strValue);
+    xmlElement.setAttribute("Value", strValue);
 }
 
 // XML MatchesWhen attribute parsing

--- a/parameter/SelectionCriterionType.cpp
+++ b/parameter/SelectionCriterionType.cpp
@@ -220,7 +220,7 @@ std::string CSelectionCriterionType::getFormattedState(int iValue) const
 void CSelectionCriterionType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
 {
     // Type Kind
-    xmlElement.setAttributeString("Kind", isTypeInclusive() ? "Inclusive" : "Exclusive");
+    xmlElement.setAttribute("Kind", isTypeInclusive() ? "Inclusive" : "Exclusive");
 
     // Value pairs as children
     NumToLitMapConstIt it;
@@ -231,9 +231,9 @@ void CSelectionCriterionType::toXml(CXmlElement& xmlElement, CXmlSerializingCont
 
         xmlElement.createChild(childValuePairElement, "ValuePair");
         // Literal
-        childValuePairElement.setAttributeString("Literal", it->first);
+        childValuePairElement.setAttribute("Literal", it->first);
         // Numerical
-        childValuePairElement.setAttributeSignedInteger("Numerical", it->second);
+        childValuePairElement.setAttribute("Numerical", it->second);
     }
 
     base::toXml(xmlElement, serializingContext);

--- a/parameter/StringParameterType.cpp
+++ b/parameter/StringParameterType.cpp
@@ -60,7 +60,7 @@ void CStringParameterType::showProperties(string& strResult) const
 bool CStringParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // MaxLength
-    _uiMaxLength = xmlElement.getAttributeInteger("MaxLength");
+    xmlElement.getAttribute("MaxLength", _uiMaxLength);
 
     // Base
     return base::fromXml(xmlElement, serializingContext);
@@ -81,7 +81,7 @@ uint32_t CStringParameterType::getMaxLength() const
 void CStringParameterType::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
 {
     // MaxLength
-    xmlElement.setAttributeInteger("MaxLength", _uiMaxLength);
+    xmlElement.setAttribute("MaxLength", _uiMaxLength);
 
     base::toXml(xmlElement, serializingContext);
 }

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -159,7 +159,7 @@ bool CSubsystem::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& 
     }
 
     // Endianness
-    _bBigEndian = xmlElement.getAttributeBoolean("Endianness", "Big");
+    _bBigEndian = xmlElement.getAttributeString("Endianness") == "Big";
 
     return true;
 }

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -107,7 +107,9 @@ bool CSubsystem::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& 
 {
     // Subsystem class does not rely on generic fromXml algorithm of Element class.
     // So, setting here the description if found as XML attribute.
-    setDescription(getXmlDescriptionAttribute(xmlElement));
+    string description;
+    xmlElement.getAttribute(gDescriptionPropertyName, description);
+    setDescription(description);
 
     // Context
     CXmlParameterSerializingContext& parameterBuildContext = static_cast<CXmlParameterSerializingContext&>(serializingContext);
@@ -118,7 +120,8 @@ bool CSubsystem::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& 
     CXmlElement childElement;
 
     // Manage mapping attribute
-    std::string rawMapping = xmlElement.getAttributeString("Mapping");
+    string rawMapping;
+    xmlElement.getAttribute("Mapping", rawMapping);
     if (!rawMapping.empty()) {
 
         std::string error;
@@ -159,7 +162,9 @@ bool CSubsystem::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& 
     }
 
     // Endianness
-    _bBigEndian = xmlElement.getAttributeString("Endianness") == "Big";
+    string strEndianness;
+    xmlElement.getAttribute("Endianness", strEndianness);
+    _bBigEndian = strEndianness == "Big";
 
     return true;
 }

--- a/parameter/SubsystemLibrary.h
+++ b/parameter/SubsystemLibrary.h
@@ -42,6 +42,8 @@ private:
     virtual std::string getBuilderType(const CXmlElement& xmlElement) const
     {
         // Xml element's name attribute
-        return xmlElement.getAttributeString("Type");
+        std::string type;
+        xmlElement.getAttribute("Type", type);
+        return type;
     }
 };

--- a/parameter/TypeElement.cpp
+++ b/parameter/TypeElement.cpp
@@ -105,12 +105,13 @@ bool CTypeElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext
     // Array Length attribute
     if (xmlElement.hasAttribute("ArrayLength")) {
 
-        _uiArrayLength = xmlElement.getAttributeInteger("ArrayLength");
+        xmlElement.getAttribute("ArrayLength", _uiArrayLength);
     } else {
         _uiArrayLength = 0; // Scalar
     }
     // Manage mapping attribute
-    std::string rawMapping = xmlElement.getAttributeString("Mapping");
+    std::string rawMapping;
+    xmlElement.getAttribute("Mapping", rawMapping);
     if (!rawMapping.empty()) {
 
         std::string error;
@@ -157,7 +158,7 @@ void CTypeElement::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serial
 {
     if (!isScalar()) {
 
-        xmlElement.setAttributeInteger("ArrayLength", getArrayLength());
+        xmlElement.setAttribute("ArrayLength", getArrayLength());
     }
 
     base::toXml(xmlElement, serializingContext);

--- a/parameter/TypeElement.cpp
+++ b/parameter/TypeElement.cpp
@@ -103,16 +103,10 @@ void CTypeElement::populate(CElement* pElement) const
 bool CTypeElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Array Length attribute
-    if (xmlElement.hasAttribute("ArrayLength")) {
-
-        xmlElement.getAttribute("ArrayLength", _uiArrayLength);
-    } else {
-        _uiArrayLength = 0; // Scalar
-    }
+    xmlElement.getAttribute("ArrayLength", _uiArrayLength);
     // Manage mapping attribute
     std::string rawMapping;
-    xmlElement.getAttribute("Mapping", rawMapping);
-    if (!rawMapping.empty()) {
+    if (xmlElement.getAttribute("Mapping", rawMapping) && !rawMapping.empty()) {
 
         std::string error;
         if (!getMappingData()->init(rawMapping, error)) {

--- a/parameter/XmlFileIncluderElement.cpp
+++ b/parameter/XmlFileIncluderElement.cpp
@@ -51,7 +51,8 @@ bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSeriali
     CXmlElementSerializingContext& elementSerializingContext = static_cast<CXmlElementSerializingContext&>(serializingContext);
 
     // Parse included document
-    std::string strPath = xmlElement.getAttributeString("Path");
+    std::string strPath;
+    xmlElement.getAttribute("Path", strPath);
 
     // Relative path?
     if (strPath[0] != '/') {

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -34,3 +34,8 @@ add_library(pfw_utility STATIC
 
 # '-fPIC' needed for linking against shared libraries (e.g. libparameter)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+
+install(FILES
+    Utility.h
+    convert.hpp
+    DESTINATION "include/utility")

--- a/xmlserializer/CMakeLists.txt
+++ b/xmlserializer/CMakeLists.txt
@@ -51,7 +51,10 @@ else(NOT LIBXML2_FOUND)
     endif(NOT XML2_XINCLUDE_SUPPORT)
 endif(NOT LIBXML2_FOUND)
 
-include_directories(${LIBXML2_INCLUDE_DIR})
+include_directories(
+    ${LIBXML2_INCLUDE_DIR}
+    "${PROJECT_SOURCE_DIR}/utility")
+
 target_link_libraries(xmlserializer ${LIBXML2_LIBRARIES})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LIBXML2_DEFINITIONS}")
 

--- a/xmlserializer/XmlDocSource.cpp
+++ b/xmlserializer/XmlDocSource.cpp
@@ -92,7 +92,9 @@ string CXmlDocSource::getRootElementAttributeString(const string& strAttributeNa
 {
     CXmlElement topMostElement(_pRootNode);
 
-    return topMostElement.getAttributeString(strAttributeName);
+    string attribute;
+    topMostElement.getAttribute(strAttributeName, attribute);
+    return attribute;
 }
 
 _xmlDoc* CXmlDocSource::getDoc() const

--- a/xmlserializer/XmlElement.cpp
+++ b/xmlserializer/XmlElement.cpp
@@ -100,11 +100,6 @@ string CXmlElement::getAttributeString(const string &strAttributeName) const
     return strValue;
 }
 
-bool CXmlElement::getAttributeBoolean(const string& strAttributeName, const string& strTrueValue) const
-{
-    return getAttributeString(strAttributeName) == strTrueValue;
-}
-
 bool CXmlElement::getAttributeBoolean(const string& strAttributeName) const
 {
     string strAttributeValue(getAttributeString(strAttributeName));

--- a/xmlserializer/XmlElement.cpp
+++ b/xmlserializer/XmlElement.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -29,11 +29,11 @@
  */
 #include "XmlElement.h"
 #include <libxml/tree.h>
+#include "convert.hpp"
+#include "Utility.h"
 #include <stdlib.h>
-#include <sstream>
 
 using std::string;
-using std::ostringstream;
 
 CXmlElement::CXmlElement(_xmlNode* pXmlElement) : _pXmlElement(pXmlElement)
 {
@@ -72,60 +72,54 @@ string CXmlElement::getPath() const
     return strPathElement;
 }
 
-string CXmlElement::getNameAttribute() const
-{
-    return getAttributeString("Name");
-}
-
 bool CXmlElement::hasAttribute(const string& strAttributeName) const
 {
     return xmlHasProp(_pXmlElement, (const xmlChar*)strAttributeName.c_str()) != NULL;
 }
 
-string CXmlElement::getAttributeString(const string &strAttributeName) const
+template <>
+bool CXmlElement::getAttribute<std::string>(const string &name, string &value) const
 {
-    if (!hasAttribute(strAttributeName)) {
-
-        return "";
+    if (!hasAttribute(name)) {
+        return false;
     }
-    xmlChar* pucXmlValue = xmlGetProp((xmlNode*)_pXmlElement, (const xmlChar*)strAttributeName.c_str());
+
+    string backup = value;
+    xmlChar* pucXmlValue = xmlGetProp((xmlNode*)_pXmlElement, (const xmlChar*)name.c_str());
     if (pucXmlValue == NULL) {
-        return "";
+        value = backup;
+        return false;
     }
 
-    string strValue((const char*)pucXmlValue);
+    value = (const char*)pucXmlValue;
 
     xmlFree(pucXmlValue);
 
-    return strValue;
+    return true;
 }
 
-bool CXmlElement::getAttributeBoolean(const string& strAttributeName) const
+template <typename T>
+bool CXmlElement::getAttribute(const std::string &name, T &value) const
 {
-    string strAttributeValue(getAttributeString(strAttributeName));
+    std::string rawValue;
+    if (!getAttribute(name, rawValue)) {
+        return false;
+    }
 
-    return strAttributeValue == "true" || strAttributeValue == "1";
+    T backup = value;
+    if (!convertTo<T>(rawValue, value)) {
+        value = backup;
+        return false;
+    }
+
+    return true;
 }
 
-uint32_t CXmlElement::getAttributeInteger(const string &strAttributeName) const
+string CXmlElement::getNameAttribute() const
 {
-    string strAttributeValue(getAttributeString(strAttributeName));
-
-    return strtoul(strAttributeValue.c_str(), NULL, 0);
-}
-
-int32_t CXmlElement::getAttributeSignedInteger(const string &strAttributeName) const
-{
-    string strAttributeValue(getAttributeString(strAttributeName));
-
-    return strtol(strAttributeValue.c_str(), NULL, 0);
-}
-
-double CXmlElement::getAttributeDouble(const string &strAttributeName) const
-{
-    string strAttributeValue(getAttributeString(strAttributeName));
-
-    return strtod(strAttributeValue.c_str(), NULL);
+    string attribute;
+    getAttribute("Name", attribute);
+    return attribute;
 }
 
 string CXmlElement::getTextContent() const
@@ -197,35 +191,37 @@ bool CXmlElement::getParentElement(CXmlElement& parentElement) const
     return false;
 }
 
-// Setters
-void CXmlElement::setAttributeBoolean(const string& strAttributeName, bool bValue)
+template <>
+void CXmlElement::setAttribute<bool>(const string& name, const bool &value)
 {
-    setAttributeString(strAttributeName, bValue ? "true" : "false");
+    setAttribute(name, value ? "true" : "false");
 }
 
-
-void CXmlElement::setAttributeString(const string& strAttributeName, const string& strValue)
+template <>
+void CXmlElement::setAttribute<std::string>(const string &name, const string &value)
 {
-    xmlNewProp(_pXmlElement, BAD_CAST strAttributeName.c_str(), BAD_CAST strValue.c_str());
+    setAttribute(name, value.c_str());
 }
 
-void CXmlElement::setAttributeInteger(const string& strAttributeName, uint32_t uiValue)
+// This method exists for 2 reasons:
+//  - at link time, all calls to setAttribute(const string&, const char [N])
+//    for any value of N will all resolve to this method; this prevents the
+//    need for one template instance per value of N.
+//  - the libxml2 API takes a C-style string anyway.
+void CXmlElement::setAttribute(const string &name, const char *value)
 {
-   ostringstream strStream;
-   strStream << uiValue;
-   setAttributeString(strAttributeName, strStream.str());
+    xmlNewProp(_pXmlElement, BAD_CAST name.c_str(), BAD_CAST value);
 }
 
-void CXmlElement::setAttributeSignedInteger(const string& strAttributeName, int32_t iValue)
+template <typename T>
+void CXmlElement::setAttribute(const std::string& name, const T &value)
 {
-   ostringstream strStream;
-   strStream << iValue;
-   setAttributeString(strAttributeName, strStream.str());
+    setAttribute(name, CUtility::toString(value).c_str());
 }
 
 void CXmlElement::setNameAttribute(const string& strValue)
 {
-    setAttributeString("Name", strValue);
+    setAttribute("Name", strValue);
 }
 
 void CXmlElement::setTextContent(const string& strContent)
@@ -266,3 +262,18 @@ bool CXmlElement::CChildIterator::next(CXmlElement& xmlChildElement)
     return false;
 }
 
+template bool CXmlElement::getAttribute(const std::string &name, std::string &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, uint16_t &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, uint32_t &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, int32_t &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, uint64_t &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, bool &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, double &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, float &value) const;
+
+template void CXmlElement::setAttribute(const std::string& name, const std::string &value);
+template void CXmlElement::setAttribute(const std::string& name, const bool &value);
+template void CXmlElement::setAttribute(const std::string& name, const int32_t &value);
+template void CXmlElement::setAttribute(const std::string& name, const uint32_t &value);
+template void CXmlElement::setAttribute(const std::string& name, const uint64_t &value);
+template void CXmlElement::setAttribute(const std::string& name, const float &value);

--- a/xmlserializer/XmlElement.h
+++ b/xmlserializer/XmlElement.h
@@ -50,7 +50,6 @@ public:
     std::string getPath() const;
     std::string getNameAttribute() const;
     bool hasAttribute(const std::string& strAttributeName) const;
-    bool getAttributeBoolean(const std::string& strAttributeName, const std::string& strTrueValue) const;
     bool getAttributeBoolean(const std::string& strAttributeName) const;
     std::string getAttributeString(const std::string& strAttributeName) const;
     uint32_t getAttributeInteger(const std::string& strAttributeName) const;

--- a/xmlserializer/XmlElement.h
+++ b/xmlserializer/XmlElement.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -50,11 +50,24 @@ public:
     std::string getPath() const;
     std::string getNameAttribute() const;
     bool hasAttribute(const std::string& strAttributeName) const;
-    bool getAttributeBoolean(const std::string& strAttributeName) const;
-    std::string getAttributeString(const std::string& strAttributeName) const;
-    uint32_t getAttributeInteger(const std::string& strAttributeName) const;
-    int32_t getAttributeSignedInteger(const std::string& strAttributeName) const;
-    double getAttributeDouble(const std::string& strAttributeName) const;
+
+     /** Get attribute
+      *
+      * If the attribute does not exists or there is a libxml2 error while
+      * reading it or conversion from string to T fails, false is returned. In
+      * case of failure, the content of value is the same as before calling
+      * this method.
+      *
+      * Note: if T==string, no conversion takes place.
+      *
+      * @tparam T the type of the value to retrieve
+      * @param[in] name The attribute name
+      * @param[out] value The attribute value
+      * @return true if success, false otherwise
+      */
+    template <typename T>
+    bool getAttribute(const std::string &name, T &value) const;
+
     std::string getTextContent() const;
 
     // Navigation
@@ -63,20 +76,23 @@ public:
     size_t getNbChildElements() const;
     bool getParentElement(CXmlElement& parentElement) const;
 
-    // Setters
-    void setAttributeBoolean(const std::string& strAttributeName, bool bValue);
-    void setAttributeString(const std::string& strAttributeName, const std::string& strValue);
+     /** Set attribute
+      *
+      * @tparam T the type of the value to retrieve
+      * @param[in] name The attribute name
+      * @param[in] value The attribute value
+      */
+    template <typename T>
+    void setAttribute(const std::string& name, const T &value);
+     /** Set attribute - special case for C-style strings
+      *
+      * @param[in] name The attribute name
+      * @param[in] value The attribute value
+      */
+    void setAttribute(const std::string& name, const char *value);
+
     void setNameAttribute(const std::string& strValue);
     void setTextContent(const std::string& strContent);
-    void setAttributeInteger(const std::string& strAttributeName, uint32_t uiValue);
-    /**
-      * Set attribute with signed integer
-      *
-      * @param[in] strAttributeName The attribute name
-      * @param[in] iValue The attribute value
-      *
-      */
-    void setAttributeSignedInteger(const std::string& strAttributeName, int32_t iValue);
 
     // Child creation
     void createChild(CXmlElement& childElement, const std::string& strType);
@@ -96,4 +112,3 @@ public:
 private:
     _xmlNode* _pXmlElement;
 };
-

--- a/xmlserializer/XmlMemoryDocSource.cpp
+++ b/xmlserializer/XmlMemoryDocSource.cpp
@@ -74,10 +74,10 @@ bool CXmlMemoryDocSource::populate(CXmlSerializingContext& serializingContext)
     if (!_strXmlSchemaFile.empty()) {
 
         // Schema namespace
-        docElement.setAttributeString("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
+        docElement.setAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
 
         // Schema location
-        docElement.setAttributeString("xsi:noNamespaceSchemaLocation", _strXmlSchemaFile);
+        docElement.setAttribute("xsi:noNamespaceSchemaLocation", _strXmlSchemaFile);
     }
 
     // Compose the xml document


### PR DESCRIPTION
getAttribute API forces the user to call a specific API for each call
getAttributeString etc..  This patch replaces this API by a template one.  The
success of of the action can now be checked.  It can be useful one to check
that a conversion succeed.

Same for setAttribute* methods.