### PR TITLE
Missing client APIs' doxygen

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -756,6 +756,7 @@ WARN_LOGFILE           =
 
 INPUT                  = @PROJECT_SOURCE_DIR@/bindings/c \
                          @PROJECT_SOURCE_DIR@/parameter \
+                         @PROJECT_SOURCE_DIR@/parameter/include \
                          @PROJECT_SOURCE_DIR@/remote-process \
                          @PROJECT_SOURCE_DIR@/remote-processor \
                          @PROJECT_SOURCE_DIR@/Schemas \

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -754,7 +754,8 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @PROJECT_SOURCE_DIR@/bindings/c \
+INPUT                  = @PROJECT_SOURCE_DIR@/README.md \
+                         @PROJECT_SOURCE_DIR@/bindings/c \
                          @PROJECT_SOURCE_DIR@/parameter \
                          @PROJECT_SOURCE_DIR@/parameter/include \
                          @PROJECT_SOURCE_DIR@/remote-process \


### PR DESCRIPTION
The folder containing client APIs (parameter/include) was missing and thus, their documentation was not generated.

Also, the main readme file wasn't used anymore to generate the documentation's index.html. Put it back in the input so that it will be used for this purpose.