### PR TITLE
Write Parameter Framework requirements

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -31,6 +31,10 @@ option(DOXYGEN
        "Enable doxygen generation (you still have to run 'make doc')"
        OFF)
 
+option(REQUIREMENTS
+       "Generate the html version of the 'requirements' documentation"
+       OFF)
+
 include(CMakeDependentOption)
 # Only present DOXYGEN_GRAPHS if DOXYGEN is ON and if so, default to ON.
 # Else, set to OFF.
@@ -57,4 +61,29 @@ if(DOXYGEN)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating documentation with Doxygen"
         VERBATIM)
+endif()
+
+if(REQUIREMENTS)
+    find_program(PANDOC pandoc)
+
+    if(NOT PANDOC)
+        message(SEND_ERROR
+                "'pandoc' executable has not been found."
+                " Please install it to be able to generate the html version of"
+                " the 'requirements' documentation.")
+    endif()
+
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc.css
+        ${CMAKE_CURRENT_BINARY_DIR}/doc.css
+        COPYONLY)
+    add_custom_target(requirements-doc
+        ${PANDOC} --output ${CMAKE_CURRENT_BINARY_DIR}/requirements/index.html
+                  --from markdown --to html5
+                  --number-sections --table-of-contents
+                  --smart # typographic dashes
+                  --variable pagetitle:'Parameter Framework Requirements'
+                  --id-prefix 'doc-' # avoid tag name conflicts
+                  --css ../doc.css # this path is relative to the html doc
+                  --css http://sindresorhus.com/github-markdown-css/github-markdown.css
+                  ${CMAKE_CURRENT_SOURCE_DIR}/requirements/Requirements.md)
 endif()

--- a/doc/doc.css
+++ b/doc/doc.css
@@ -1,0 +1,44 @@
+.markdown-body {
+    min-width: 200px;
+    max-width: 920px;
+    margin: 0 auto;
+    padding: 30px;
+}
+
+nb::before,ko::before {
+    content: "Note: ";
+    font-style: normal;
+}
+
+ko::before {
+    color: red;
+}
+
+why::before {
+    content: "Why: ";
+    font-style: normal;
+}
+
+nb, ko, why {
+    font-style: italic;
+    display: block;
+    color: grey;
+}
+
+#doc-TOC {
+    display: block;
+    float: left;
+    height: 100%;
+    padding: 5px;
+
+    overflow: hidden;
+    font-family: "Helvetica Neue",Helvetica,"Segoe UI",Arial,freesans,sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    word-wrap: break-word;
+}
+
+nav>ul {
+    list-style: none;
+    padding-left: 0;
+}

--- a/doc/requirements/APIs.md
+++ b/doc/requirements/APIs.md
@@ -1,0 +1,232 @@
+<article class="markdown-body">
+
+Link from APIs to requirements
+==============================
+
+# `ParameterMgrPlatformConnector`
+
+This class is the main client interface.
+
+See
+<http://01org.github.io/parameter-framework/doc/classCParameterMgrPlatformConnector.html>
+for the complete documentation of each API.
+
+## `createSelectionCriterionType` and `createSelectionCriterion`
+
+Implement the **Selection Criterion** creation requirements. See section **5.4**
+of the requirements documentation.
+
+## `getSelectionCriterion`
+
+**???**
+
+## `setLogger`
+
+**???**
+
+There is no logging requirements in the documentation; it might be a miss.
+
+## `start` and `isStarted`
+
+**???**
+
+There is no "two-step-creation" requirement. This is an implementation detail.
+
+## `applyConfigurations`
+
+Deffered application requirement; see section **5.4.2.** See also the Selection
+Criterion APIs below.
+
+## `createParameterHandle`
+
+Introspection and direct parameter read/write access; see section **7.2**. See
+also the Parameter Handle APIs below.
+
+## `setForceNoRemoteInterface` and `getForceNoRemoteInterface`
+
+Tuning capability activation control; see section **8.2**.
+
+## `setFailureOnMissingSubsystem` and `getFailureOnMissingSubsystem`
+
+**???**
+
+Currently only used for XML generation.
+
+## `setFailureOnFailedSettingsLoad` and `getFailureOnFailedSettingsLoad`
+
+**???**
+
+Currently only used for XML generaton.
+
+## `setSchemaFolderLocation` and `getSchemaFolderLocation`; `setValidateSchemasOnStart` and `getValidateSchemasOnStart`
+
+**???**
+
+Currently only used for XML generation.
+
+# `ParameterMgrFullConnector`
+
+This is another client interface that covers the same purposes and APIs than
+`ParameterMgrPlatformConnector` and extands them. See this class' description.
+Added APIs are described in this chapter.
+
+## `setTuningMode` and `isTuningModeOn`
+
+Tuning capability activation control; see section **8.2**. It adds another
+level of flexibility over `setForceNoRemoteInterface`. The semantic of these
+two APIs overlap but **neither one fully contains the other**.
+
+**TODO**: fix the semantics.
+
+## `setValueSpace` and `isValueSpaceRaw`; `setOutputRawFormat` and `isOutputRawFormatHex`
+
+Serialization control (FIXME: what about deserialization ?). Seems **UNUSED**.
+
+## `setAutoSync`, `isAutoSyncOn` and `sync`
+
+Synchronization on client request; see section **4.4**.
+
+## `accessParameterValue`
+
+Parameter value direct access. **This overlaps with ParameterHandle.**
+
+## `getParameterMapping`
+
+Part of the Introspection requirements. See section **7**.
+
+## Tuning APIs
+
+All of the following APIs implement the Tuning requirement; see section **8**
+
+- `accessConfigurationValue`
+
+- `createDomain`
+- `deleteDomain`
+- `renameDomain`
+- `deleteAllDomains`
+
+- `setSequenceAwareness`
+- `getSequenceAwareness`
+- `setElementSequence`
+
+- `createConfiguration`
+- `deleteConfiguration`
+- `renameConfiguration`
+- `restoreConfiguration`
+- `saveConfiguration`
+
+- `addConfigurableElementToDomain`
+- `removeConfigurableElementFromDomain`
+- `split`
+
+- `setApplicationRule`
+- `getApplicationRule`
+- `clearApplicationRule`
+
+## Persistance APIs
+
+### `exportDomainsXml`
+
+Exports the "Domains" (aka "Settings") which is the inference engine's data.
+See section **6.3**.
+
+### `importDomainsXml`
+
+Imports previously-exported data into the inference engine. See section
+**6.3**.
+
+### `exportSingleDomainXml`
+
+Exports a given part of the inference engine data. See section **6.3**.
+
+### `importSingleDomainXml`
+
+Imports a partial inference engine data as previously exported. See section
+**6.3**.
+
+# `ISelectionCriterionTypeInterface`
+
+Plays a part in implementing the selection criterion requirements.
+
+## `addValuePair`
+
+Used to implement some requirements in section **5.4**.
+
+## `getNumericalValue`
+
+**???**
+
+## `getLiteralValue`
+
+**???**
+
+## `isTypeInclusive`
+
+**???**
+
+## `getFormattedState`
+
+**???**
+
+# `ISelectionCriterionInterface`
+
+## `setCriterionState` and `getCriterionState`
+
+See section **5.4** and **5.4.2**.
+
+## `getCriterionName`
+
+**???**
+
+## `getCriterionType`
+
+**???**
+
+# `CParameterHandle`
+
+This class implements the requirements related to direct read/write access to
+parameters.
+
+## `isRogue`
+
+Relative to setting rogue parameters; see section **7.2**.
+
+## `isArray`
+
+**???**
+
+## `getArrayLength`
+
+## `getPath` and `getKind`
+
+For introspection purposes; see section **7.2**.
+
+## Setters and getters
+
+The following APIs allow reading/writing parameters:
+
+- `setAsBoolean` 
+- `getAsBoolean` 
+- `setAsBooleanArray` 
+- `getAsBooleanArray` 
+- 
+- `setAsInteger` 
+- `getAsInteger` 
+- `setAsIntegerArray` 
+- `getAsIntegerArray` 
+- `setAsSignedInteger` 
+- `getAsSignedInteger` 
+- `setAsSignedIntegerArray` 
+- `getAsSignedIntegerArray` 
+- 
+- `setAsDouble` 
+- `getAsDouble` 
+- `setAsDoubleArray` 
+- `getAsDoubleArray` 
+- 
+- `setAsString` 
+- `getAsString` 
+- `setAsStringArray` 
+- `getAsStringArray` 
+
+</article>

--- a/doc/requirements/Requirements.md
+++ b/doc/requirements/Requirements.md
@@ -1,3 +1,5 @@
+<article class="markdown-body">
+
 High level requirements
 =======================
 
@@ -681,3 +683,4 @@ The PF host API **SHOULD** expose parameter values with the same API syncer use.
 <why>The current reference implementation abstracts the memory layout of
 parameters. This memory layout is specified in the parameter structure thus
 TODO</why>
+</article>

--- a/doc/requirements/Requirements.md
+++ b/doc/requirements/Requirements.md
@@ -1,0 +1,629 @@
+High level requirements
+=======================
+
+(Note: some requirements are only motivated by the fact that the reference
+       implementation implements them. Search for "reference implementation".)
+
+# Introduction
+The PF MUST be a library.
+(Why: To be reused in different components.)
+
+PF instances MUST not share any mutable data.
+(Why: to guarantee that different PF instances will not impact each others.)
+
+# Parameters
+
+A PF MUST be able to handle parameters.
+(Why: because the PF aims to abstract hardware and model it by parameters.)
+
+## Definitions
+
+Hardware: system controlled by the PF. Not necessary material system. This
+term was chosen because:
+ - historically the PF reference implementation was used to abstract hardware
+ - the subsystem term would arguably fit best is already used.
+(FIXME: choose subsystem instead, it is not used in fact.)
+
+## Value
+
+A parameter MUST have a value.
+(Why: because a parameter without value would not abstract any hardware.)
+
+A PF MUST support mutable parameters.
+(Why: To control the underlined hardware.)
+
+A PF MAY support immutable parameters, i.e. parameters which value is
+determined on start then read only.
+(Why: To permit hardware read only value reflection.)
+(Note: This is not implemented in the PF reference implementation.)
+
+This value MUST be gettable and settable (except if immutable).
+(Why: A parameter that can not be accessed is of no use.)
+
+A value MUST be convertible to a string.
+(Why: To display a parameter value to the human user for debugging purpose.)
+
+A bijective conversion string <-> value SHOULD exist.
+(Why: To support serialization and deserialization of the parameter values.
+      It is not a MUST because a PF implementation could offer serialization to
+      custom -not string based- format.)
+
+### Data type
+
+#### Definition
+All parameters have a data type.
+A data type designates parameter invariants.
+A data type is the meaning of the data and the way values of that type can be
+stored.
+
+
+#### Philosophy
+
+A data type defines the value properties:
+ - memory layout
+ - value constrains
+
+A value type is mostly used to:
+ - pretty display parameter values (not just a as an array of bits)
+ - check for user error when setting it (out of bound, invalid...)
+ - offer a type safe API
+
+#### Requirements
+
+A PF SHOULD support the following types.
+If a type is chosen to be supported, it MUST respect all MUST clause,
+SHOULD respect all SHOULD clause, MAY respect all MAY clause of the type.
+(Why: All type are not necessary to use the PF. For example any parameter could
+      be represented as an array of char (string). But this would not permit to
+      check parameter validity (invariants) nor a pretty display of the values.)
+
+Implementation MAY add another API to access a parameter value.
+(Why: For example a C++ implementation may give access to a string as an
+      std::string object.)
+
+##### Integers
+PF SHOULD support signed and unsigned integer parameters
+(Why: The reference implementation supports it.)
+
+PF MUST support integer with invariant size.
+(Why: It is common in C API to expect numbers to have a fixed maximum size.)
+
+The API to access it MUST respect C integer ABI.
+(Why: For easy access from C code.)
+
+Supported integer size SHOULD be at least 8, 16 and 32 bits.
+(Why: The reference implementation supports it.)
+
+PF MAY support constraining the parameter minimum and maximum value.
+(Why: To catch user out of valid range errors when changing the parameter
+      value.)
+
+##### String
+PF SHOULD support array of characters.
+(Why: Everything that a computer can store fits in an array of characters.
+      It can be used as a fallback type if no other matches the parameter.)
+
+The array maximum size MAY be invariant (immutable).
+(Note: This is what the reference implementation does.)
+
+The API to access the string value SHOULD support null terminated character
+array. As it is commonly done in C.
+(Why: For easy access from C code.)
+
+##### Fix point parameter
+PF SHOULD support fix point parameters. I.e. integers divided by a fixed power
+of two.
+(Why: The reference implementation supports it.)
+
+The API to access the values SHOULD respect the Qm.n and UQm.n standards.
+(Why: It is the main standard for fix point parameters.)
+
+PF SHOULD support at least `0 <= m + n <= 31` for a Signed Qm.n and
+`0 <= m + n <= 32` for an Unsigned Qm.n (or "UQm.n").
+(Why: The reference implementation supports it.)
+(Note: The reference implementation only supports Signed Qn.m)
+
+PF MAY support constraining the parameter minimum and maximum value.
+(Why: To catch user out of valid range errors when changing the parameter
+      value.)
+(Note: The reference implementation does not support it)
+
+##### Floating point
+PF SHOULD support floating point parameters .
+(Why: The reference implementation supports it.)
+
+The API to access the values SHOULD respect the IEEE 754 standard.
+
+PF SHOULD support at least 32 and 64 bit size floats.
+(Why: The reference implementation supports it.)
+(Note: The reference implementation only supports 32bits)
+
+PF MAY support constraining the parameter minimum and maximum value.
+(Why: To catch user out of valid range errors when changing the parameter
+      value.)
+
+##### Bit field following the C ABI
+PF SHOULD support 1 or more bit sized integers.
+(Why: The reference implementation supports it.)
+
+Such parameters called are regrouped in a so called bit parameter block.
+The API to access a bit parameter block SHOULD give access to a packed bit
+field.
+(Why: The reference implementation supports it.)
+
+### Parameter adaptation
+
+#### Philosophy
+Parameters exposed by hardware sometimes need to transform a parameter value.
+For example an hardware integer parameter could have a range 64-128 but it might
+be necessary for upper layer to access in a range 0-100.
+
+This transformation (called parameter adaptation in the rest of the document)
+could be done by the syncer. Nevertheless syncers are supposed to contain only
+business logic and should not be impacted by upper layer needs.
+
+#### Definition
+Parameter adaptation is a bijective pure function converting a parameter value
+between the syncer and other parameter reader/writer (including the inference
+engine).
+
+(Why: It must be bijective in order to a) scale the user value to the hardware
+      value and b) convert the hardware value to the user's value space.)
+
+#### Requirements
+The following parameter adaptation SHOULD be supported
+
+ - Affine adaptation: `affAd(value) = slope * value + offset` where slope and
+   offset and user-defined constants
+(Why: The reference implementation supports it.)
+
+ - Logarithm adaptation: `logAd(base, value) = ln(value) / ln(base)` where
+   `ln` is the natural logarithm and base is a user-defined constant.
+(Why: The reference application supports it.)
+(Note: The reference implementation also supports passing a floor value to
+       be applied after conversion.)
+
+A PF MAY offer Parameter adaptation composition. I.e. combine multiple parameter
+adaptation
+E.g.: composing the affine and logarithm adaptation to
+`compAd(value) = slope * logAd(base, value) + offset`.
+(Why: To avoid combination explosion of parameter adaptations.
+      The idea is to builtin basic function and let the user compose them to
+      meet its need.)
+(Note: The reference application supports in a tricky way: the logarithm
+ adaptation is always combined with the affine adaptation)
+
+## Identifiers
+Every parameter MUST have an identifier that uniquely identifies it.
+(Why: to identify a parameter outside the framework)
+
+This identifier SHOULD be a string.
+(Why: so that the (human) user can identify a parameter with ease.)
+
+Two PF instances with the same parameters MUST have the same identifier for
+those parameters.
+I.e. this identifier should be the same across all instances with the same
+configuration.
+(Why: Persistence of parameter identifier across PF instances with the same
+      configuration. To identify parameters independently of the host machine
+      and PF instance)
+
+### Parameter tree
+A parameter MUST be structured in a tree. Each parameter being a distinct tree
+leaf.
+(Why: Tree is a simple data structure that can be easily represented and is
+      enough to map underlined layers.)
+
+Each node of the tree SHOULD have its own identifier with the same
+characteristics (type, independence...) than a parameter.
+(Why: To represent the tree without treating the leaf nodes specifically.)
+
+The identifier of each node of the tree SHOULD be a combination of its parents.
+More specifically, if the identifier is a string it should be formated the same
+way as a file system path. E.g. the parameter named `/root/child1/4/parameter1`.
+(Why: Usual syntax to address trees.)
+
+
+# Syncer
+
+The PF philosophy is to map the hardware characteristics to parameters.
+
+A syncer MUST be mapped to one or more parameters.
+(Why: The hardware minimal access may be bigger than one parameter.)
+
+One parameter MUST NOT be mapped to two or more syncer.
+(Why: Which syncer should be responsible to retrieve the initial parameter
+      value if they are multiple per parameter?)
+
+A syncer MUST support retrieving the mapped parameters value from the mapped
+hardware.
+(Why: to retrieve a parameter value at the start of the PF.)
+
+A syncer MUST support setting the mapped parameters value to the mapped
+hardware.
+(Why: to synchronise hardware on parameter change.)
+
+Syncers MUST retrieve and set the parameters value from the PF core.
+(Why: to be able to synchronise with hardware.)
+
+This API MAY be a packed parameter structure, following the C ABI without
+padding.
+(Note: This is what the reference implementation does.)
+(Why: ???)
+
+## Introspection
+The syncer API SHOULD allow introspection of the mapped parameters.
+(Why: the parameter structure may be useful for the syncer to
+      communicate with the hardware.)
+
+## Plugins
+The PF MUST be able to create syncers.
+(Why: to bind on the corresponding parameters.)
+
+### Definition
+The PF creates syncer using syncer builder.
+
+### Identifier
+All syncers mapping to the same hardware SHOULD have their builders regrouped in
+a syncer library.
+(Why: to be able to link a group of parameters and a given hardware.)
+
+A syncer builder MUST have a unique identifier in its containing syncer library.
+(Why: To uniquely identify the syncer that should bind on parameters.
+      Given that the syncer library has already been specified.)
+
+A syncer library MUST have a unique identifier in the host system.
+(Why: To identify the library associated to parameters.)
+
+Syncer build and syncer library identifiers SHOULD be strings.
+(Why: The reference application does so.)
+
+### Loading
+Syncer library or/and builder MAY be loaded from dynamically linked libraries
+(called syncer plugins).
+(Why: The reference implementation supports it.)
+
+Such syncer plugins SHOULD have an unique entry point that -when called- should
+register its payload (syncer library/builder) in the provided gatherer.
+(Note: This permit to merge multiple syncer libraries in one shared library.)
+(Why: The reference implementation supports it.)
+
+Multiple syncer plugins, may depend on each other. The PF should appropriately
+handle the case and not fail.
+(Why: The reference implementation supports it.)
+
+## Mapping
+### Definition
+A parameter not bound to a syncer is called a "virtual parameter".
+(Todo: remove if not used in the requirements.)
+
+### Requirements
+**TODO**:
+ - Plugins
+ - association builder <-> parameters
+
+## Sync
+
+Syncer SHOULD synchronise the mapped hardware on parameter change.
+(Why: To always keep synchronise the underlined hardware and the PF parameters.)
+
+Syncer SHOULD retrieve parameter value from the hardware if no value has be set
+since the PF start.
+(Note: This is usually implemented on PF start, initialize the parameter
+       values with the mapped hardware current state.)
+(Why: To allow introspection of the hardware.)
+
+A mode with synchronisation on client request MAY be supported.
+(Why: The reference implementation supports it.)
+
+Syncers MAY report an 'out-of-sync' condition indicating that the hardware
+parameter values are not (or no longer) reflecting the last values set by the
+Parameter Framework.
+(Why: This can happen when the underlying hardware subsystem
+      crashes/reboots/...)
+
+When a syncer reports an out-of-sync condition, the PF MUST try to resync the
+hardware values.
+
+# Rule based dynamic abstraction
+
+## Philosophy
+
+The PF offers parameters mapped on hardware. This is a good but weak
+abstraction. There is often a 1/1 relation between a parameter and the hardware
+it maps.
+
+A PF offers a mechanism to abstract the parameters to more high level concept.
+
+The goal is to hide numerous parameters and their dynamic value behind simple
+and human friendly API.
+
+It works by regrouping parameters with similar management and defining
+configurations for each "scenario". These "scenario" are then given a priority
+and a detection predicate. Configuration are applied when their associated
+"scenario" is detected.
+
+"Scenario" are detected through arbitrary criterion provided by the PF host
+(see below).
+
+## Definition
+
+Configurations: set of values for different parameters. A configuration MUST not
+contain 2 values of the same parameters.
+
+For example, given a PF with 3 integer parameters A,B,C, a configuration can
+contain
+ - 1 value for (A), (B) or (C)
+ - 2 value for (A,B), (A,C) or (B,C)
+ - 3 value for (A,B,C)
+
+## Configuration
+
+A PF MUST offer configurations as described in the Definition chapter.
+(Note: rule based parameter engine does not manipulate directly values,
+      it applies configuration on the parameters.)
+(Why: This is what the reference implementation does.)
+
+Each configuration MUST be associated with a predicate that condition its
+eligibility. A configuration with a predicate that evaluates to `true` is called
+an "eligible configuration"
+(Why: This is what the reference implementation does.)
+
+It SHOULD be possible to express a predicate to always evaluates to `true`.
+(Why: in order to have parameters set to constant values or have a fallback
+      configuration in a domain - see below.)
+
+The predicate SHOULD be a "selection criterion rule". See next chapter for a
+definition.
+(Why: The reference implementation uses a boolean expression based engine.)
+
+## Selection criterion
+
+A selection criterion MUST have one, and only one, state at a given time.
+
+A selection criterion MUST know at construction all possible states.
+(Why: To be able to validate:
+       - rules on start
+       - state changes)
+
+The selection criterion possible states MUST be specifiable by:
+ - Directly a state set (Input -> states == identity)
+   (Note: called exclusive criterion)
+   (Note: An empty set is not allowed as the criterion could not have a state.)
+   (Why: any criterion can be crated with this one.)
+
+The selection criterion possible states SHOULD be specifiable by:
+ - A combination of values
+   (Note: combination in the mathematical sense `"ab" -> ["", "a", "b", "ab"]`)
+   (Note: called inclusive criterion)
+   (Note: An empty value set is allowed as its combination -a set
+          containing the empty set- would not be empty. The empty set would be
+          the only possible criteria state.)
+   (Why: The reference implementation supports it.)
+
+The PF MUST not limit the number of criteria.
+
+The PF MUST not limit the number of states of any given criterion
+(Note: The reference implementation only supports 32 values for an inclusive
+       criterion and 2^32 values for an exclusive criterion)
+
+### Definitions
+ - Selection criterion rule: function (in the mathematical sense) that MUST
+   given selection criteria return a Boolean.
+
+ - Rule: an Boolean expression of Selection criterion rules
+   (Note: implementation only allows AND and OR combination)
+
+### Criterion change
+
+The API to change criterion values MUST allow atomicity regarding configuration
+application. I.e. it MUST be possible to change multiple criterion values
+without triggering a configuration application.
+(Why: Two criterion might have an excluding state.
+      If configuration application was triggered after each)
+
+### Rules
+
+It MUST always be able to express a selection criterion rule from a given
+selection criterion
+I.e.: a criteria MUST always have a state that can be matched by a rule.
+(Why: if no rules can be formulated from a criterion, it is useless)
+
+Parameter values change SHOULD be selected by Rules.
+(Why: A rule based inference engine has been chosen based on implementation and
+configuration ease)
+
+It MUST be possible to express a Rule that is always True.
+(Why: In order to make a configuration "always applicable"
+
+## Domains
+
+### Definition
+Domain: ordered set of configuration, all of which contain the values for the
+same parameters.
+
+### Requirement
+
+Each configuration SHOULD be in a "domain" (see Definition chapter).
+(Why: Domains are mostly a way to define the priority of "Scenarios" for some
+      parameters. It is not a MUST because this goal could also be achieve with
+      (for example) global configurations and per parameter priority. It is not
+      a MAY because the reference implementation uses domains.)
+
+If multiple configuration are eligible, the first one MUST be applied.
+(Why: If multiple configuration are eligible)
+
+If no configuration is eligible, no configuration MUST be applied.
+(Note: It means that if none of the configurations is eligible, none is applied.
+       This also mean that no function can be defined between criteria and
+       states.
+       I.e.: parameter values MAY depend on previous selection criterion states.
+(Why: This is what the reference implementation does.)
+
+TODO sequence aware domains
+
+# (de)serialization
+
+## Philosophy
+Serialization and deserialization are meant to support destruction recovery and
+configuration deployment.
+
+These are the same requirements than for a database, it needs to be able to save
+its state and restore for backup, deployment, reboot...
+
+## Definition
+PF data includes:
+- parameters tree
+- configurations:
+  - selection rule
+  - parameter/value couples
+- domain:
+  - list of associated configurations
+  - order of priority
+
+## Requirement
+The PF data MUST be deserializable.
+(Why: Otherwise a PF instance could only be created empty and then be filled
+      by the tuning interface.
+      The reference implementation supports it.)
+
+The PF data SHOULD be deserializable from a config file.
+(Why: This is usually how program configuration are stored.
+      The reference implementation supports it.)
+
+The PF data SHOULD be serializable.
+(Why: In order to save a PF instance state and restore it later.
+      This achieve destruction recovery.
+      The reference implementation supports it.)
+
+**TODO**: XML ?
+
+# Introspection
+## Philosophy
+In order to debug
+
+## Requirements
+User SHOULD be able to inspect PF data. Including:
+ - listing
+    - domains
+    - configurations of a domains
+    - parameters
+    - a domain's associated parameters
+ - displaying their properties. Including:
+    - parameters values, min, max, size...
+(Why: To offer run time debugging.)
+
+PF MAY offer pretty print of data. Including:
+ - printing parameter value in decimal
+(Why: For human readability)
+ - pretty print parameter tree (such as the Unix tree command for files)
+(Why: In order to ease runtime debug.)
+
+
+# Tuning
+## Philosophy
+Tuning is the ability to modify the PF data structure at runtime.
+
+As the PF might model a complex system with its dynamic parameter value engine
+(rule based in the default implementation), its behaviour might be hard to
+understand and should be easily modified not correct.
+
+To address this need, a fast modify-update-test cycle should be possible.
+
+## Requirements
+Users SHOULD be able to modify the PF inference engine behaviour (rules,
+configuration...) with minimal effort.
+This usually mean avoiding:
+ - recompiling
+ - restarting the host process/service
+(Note: No requirement is made on the persistence of those changes,
+       they may or may not disappear on PF restart.
+       This could be implemented in several way, for example:
+        - exposed in the PF API
+        - changing a config file and sending a signal to the PF
+        - providing a IPC
+        - directly modifying the memory)
+(Why: To enable a fast modify-update-test cycle during tuning.)
+
+Tuning SHOULD be possible from the PF native API.
+Why: In order to let the host system implement its own tuning mechanism.)
+
+Users MAY be able to modify the parameters (types, identifiers, tree...) with
+minimal effort (see previous requirement).
+(Note: The reference implementation does not support it.)
+(Why: To enable a fast modify-update-test cycle on PF configuration.)
+
+Users SHOULD be able to modify the parameter values at any time.
+This change SHOULD not be overwritten without a user action.
+(Note: user overwritten user action could be a log out, leaving some tuning
+       mode, forcing an inference engine update...)
+(Why: Even if a parameter is managed by the inference engine,
+      it often is useful (test, debugging) to overwrite its value temporally.).
+
+A PF tuning capability MAY be disabled in a context where no tuning is needed.
+(Why: The reference implementation does so (phone end users can not change the
+      tuning).)
+
+# Command line interface
+
+The PF MAY offer a command line interface that binds to its IPC.
+(Why: to have a reference way to interact with a PF without implementing its IPC
+      protocol.)
+
+This command line interface SHOULD support all tuning and introspection ability.
+(Why: In order to be used in scripting and live tuning/debugging on an embedded
+      system.)
+
+This command line interface MAY offer argument auto completion.
+(Why: Is more user friendly.)
+
+# Bindings
+The PF SHOULD expose its API in C.
+(Why: The PF aims to be a hardware abstraction thus middle ware which is often
+      written in C or a language compatible with C.
+      Virtually all programing language support C Foreign Procedure Call,
+      having a C API ease integration whichever the host language is.)
+
+The PF MAY expose its API to multiple programing language.
+(Why: The reference implementation has python bindings.)
+
+# Performance
+
+The reference Parameter Framework implementation is mainly intended for use in
+consumer electronics such as smartphones and tablets. Such platforms are often
+referred to as "embedded" platforms but their capacity today is so huge in
+terms of both computing and memory that can can be considered as small personal
+computers.
+
+Moreover, since one of the Parameter Framework's primary feature is to
+implement storage of a) a hardware description and b) settings, its memory
+footprint largely depends on how many such items are stored.
+
+For those reasons, there are no performance requirements imposed on the
+architecture. Performance considerations are left to the implementation of the
+Parameter Framework and/or the client and/or the build chain.
+
+# Next
+The following requirements are not implemented in the reference implementation
+and are to be considered draft.
+
+PF MAY support at least:
+    - Linux (and Android)
+    - Windows
+    - Mac OSX
+(Why: As the reference PF implementation leaves its original Android
+      environment, needs emerge to use it on other platform.)
+
+The PF host API SHOULD be structured.
+I.e.: the PF, when requested for a list of domains, should return a list of
+structured object, each containing configuration objects, containing their
+values.
+(Why: The reference implementation has a string oriented API.
+      E.g/: The list of domains is returned as a concatenation of domains name
+      in one big string.
+      This leads to hard an hard to use API from C and C++ code.)
+
+The PF host API SHOULD expose parameter values with the same API syncer use.
+(Why: The current reference implementation abstracts the memory layout of
+      parameters. This memory layout is specified in the parameter structure
+      thus TODO)

--- a/doc/requirements/Requirements.md
+++ b/doc/requirements/Requirements.md
@@ -1,155 +1,169 @@
 High level requirements
 =======================
 
-(Note: some requirements are only motivated by the fact that the reference
-       implementation implements them. Search for "reference implementation".)
+<nb>Some requirements are only motivated by the fact that the reference
+implementation implements them. Search for "reference implementation".</nb>
 
 # Introduction
-The PF MUST be a library.
-(Why: To be reused in different components.)
+The PF **MUST** be a library.
+<why>To be reused in different components.</why>
 
-PF instances MUST not share any mutable data.
-(Why: to guarantee that different PF instances will not impact each others.)
+PF instances **MUST NOT** share any mutable data.
+<why>to guarantee that different PF instances will not impact each others.</why>
 
 # Parameters
 
-A PF MUST be able to handle parameters.
-(Why: because the PF aims to abstract hardware and model it by parameters.)
+A PF **MUST** be able to handle parameters.
+<why>because the PF aims to abstract hardware and model it by parameters.</why>
 
 ## Definitions
 
-Hardware: system controlled by the PF. Not necessary material system. This
-term was chosen because:
+<dl>
+<dt>Hardware</dt>
+<dd>System controlled by the PF. Not necessary material system. This term was
+chosen because:
+
  - historically the PF reference implementation was used to abstract hardware
  - the subsystem term would arguably fit best is already used.
+
 (FIXME: choose subsystem instead, it is not used in fact.)
+</dd>
+</dl>
 
 ## Value
 
-A parameter MUST have a value.
-(Why: because a parameter without value would not abstract any hardware.)
+A parameter **MUST** have a value.
+<why>because a parameter without value would not abstract any hardware.</why>
 
-A PF MUST support mutable parameters.
-(Why: To control the underlined hardware.)
+A PF **MUST** support mutable parameters.
+<why>To control the underlined hardware.</why>
 
-A PF MAY support immutable parameters, i.e. parameters which value is
-determined on start then read only.
-(Why: To permit hardware read only value reflection.)
-(Note: This is not implemented in the PF reference implementation.)
+A PF **MAY** support immutable parameters, i.e. parameters which value is determined
+on start then read only.
+<why>To permit hardware read only value reflection.</why>
+<ko>This is not implemented in the PF reference implementation.</ko>
 
-This value MUST be gettable and settable (except if immutable).
-(Why: A parameter that can not be accessed is of no use.)
+This value **MUST** be gettable and settable (except if immutable).
+<why>A parameter that can not be accessed is of no use.</why>
 
-A value MUST be convertible to a string.
-(Why: To display a parameter value to the human user for debugging purpose.)
+A value **MUST** be convertible to a string.
+<why>To display a parameter value to the human user for debugging purpose.</why>
 
-A bijective conversion string <-> value SHOULD exist.
-(Why: To support serialization and deserialization of the parameter values.
-      It is not a MUST because a PF implementation could offer serialization to
-      custom -not string based- format.)
+A bijective conversion string <-> value **SHOULD** exist.
+<why>To support serialization and deserialization of the parameter values. It is
+not a MUST because a PF implementation could offer serialization to custom --
+not string based -- format.</why>
 
 ### Data type
 
 #### Definition
-All parameters have a data type.
-A data type designates parameter invariants.
+
+<dl>
+<dt>Data type</dt>
+<dd>
+All parameters have a data type. A data type designates parameter invariants.
+
 A data type is the meaning of the data and the way values of that type can be
 stored.
+</dd>
+</dl>
 
 
 #### Philosophy
 
 A data type defines the value properties:
+
  - memory layout
  - value constrains
 
 A value type is mostly used to:
+
  - pretty display parameter values (not just a as an array of bits)
  - check for user error when setting it (out of bound, invalid...)
  - offer a type safe API
 
 #### Requirements
 
-A PF SHOULD support the following types.
-If a type is chosen to be supported, it MUST respect all MUST clause,
-SHOULD respect all SHOULD clause, MAY respect all MAY clause of the type.
-(Why: All type are not necessary to use the PF. For example any parameter could
-      be represented as an array of char (string). But this would not permit to
-      check parameter validity (invariants) nor a pretty display of the values.)
+A PF **SHOULD** support the following types.
+If a type is chosen to be supported, it **MUST** respect all MUST clause,
+**SHOULD** respect all SHOULD clause, **MAY** respect all MAY clause of the type.
+<why>All type are not necessary to use the PF. For example any parameter could
+be represented as an array of char (string). But this would not permit to
+check parameter validity (invariants) nor a pretty display of the values.</why>
 
-Implementation MAY add another API to access a parameter value.
-(Why: For example a C++ implementation may give access to a string as an
-      std::string object.)
+Implementation **MAY** add another API to access a parameter value.
+<why>For example a C++ implementation may give access to a string as an
+std::string object.</why>
 
 ##### Integers
-PF SHOULD support signed and unsigned integer parameters
-(Why: The reference implementation supports it.)
+PF **SHOULD** support signed and unsigned integer parameters
+<why>The reference implementation supports it.</why>
 
-PF MUST support integer with invariant size.
-(Why: It is common in C API to expect numbers to have a fixed maximum size.)
+PF **MUST** support integer with invariant size.
+<why>It is common in C API to expect numbers to have a fixed maximum size.</why>
 
-The API to access it MUST respect C integer ABI.
-(Why: For easy access from C code.)
+The API to access it **MUST** respect C integer ABI.
+<why>For easy access from C code.</why>
 
-Supported integer size SHOULD be at least 8, 16 and 32 bits.
-(Why: The reference implementation supports it.)
+Supported integer size **SHOULD** be at least 8, 16 and 32 bits.
+<why>The reference implementation supports it.</why>
 
-PF MAY support constraining the parameter minimum and maximum value.
-(Why: To catch user out of valid range errors when changing the parameter
-      value.)
+PF **MAY** support constraining the parameter minimum and maximum value.
+<why>To catch user out of valid range errors when changing the parameter
+value.</why>
 
 ##### String
-PF SHOULD support array of characters.
-(Why: Everything that a computer can store fits in an array of characters.
-      It can be used as a fallback type if no other matches the parameter.)
+PF **SHOULD** support array of characters.
+<why>Everything that a computer can store fits in an array of characters. It can
+be used as a fallback type if no other matches the parameter.</why>
 
-The array maximum size MAY be invariant (immutable).
-(Note: This is what the reference implementation does.)
+The array maximum size **MAY** be invariant (immutable).
+<nb>This is what the reference implementation does.</nb>
 
-The API to access the string value SHOULD support null terminated character
+The API to access the string value **SHOULD** support null terminated character
 array. As it is commonly done in C.
-(Why: For easy access from C code.)
+<why>For easy access from C code.</why>
 
 ##### Fix point parameter
-PF SHOULD support fix point parameters. I.e. integers divided by a fixed power
+PF **SHOULD** support fix point parameters. I.e. integers divided by a fixed power
 of two.
-(Why: The reference implementation supports it.)
+<why>The reference implementation supports it.</why>
 
-The API to access the values SHOULD respect the Qm.n and UQm.n standards.
-(Why: It is the main standard for fix point parameters.)
+The API to access the values **SHOULD** respect the Qm.n and UQm.n standards.
+<why>It is the main standard for fix point parameters.</why>
 
-PF SHOULD support at least `0 <= m + n <= 31` for a Signed Qm.n and
+PF **SHOULD** support at least `0 <= m + n <= 31` for a Signed Qm.n and
 `0 <= m + n <= 32` for an Unsigned Qm.n (or "UQm.n").
-(Why: The reference implementation supports it.)
-(Note: The reference implementation only supports Signed Qn.m)
+<why>The reference implementation supports it.</why>
+<ko>The reference implementation only supports Signed Qn.m</ko>
 
-PF MAY support constraining the parameter minimum and maximum value.
-(Why: To catch user out of valid range errors when changing the parameter
-      value.)
-(Note: The reference implementation does not support it)
+PF **MAY** support constraining the parameter minimum and maximum value.
+<why>To catch user out of valid range errors when changing the parameter
+value.</why>
+<ko>The reference implementation does not support it</ko>
 
 ##### Floating point
-PF SHOULD support floating point parameters .
-(Why: The reference implementation supports it.)
+PF **SHOULD** support floating point parameters .
+<why>The reference implementation supports it.</why>
 
-The API to access the values SHOULD respect the IEEE 754 standard.
+The API to access the values **SHOULD** respect the IEEE 754 standard.
 
-PF SHOULD support at least 32 and 64 bit size floats.
-(Why: The reference implementation supports it.)
-(Note: The reference implementation only supports 32bits)
+PF **SHOULD** support at least 32 and 64 bit size floats.
+<why>The reference implementation supports it.</why>
+<ko>The reference implementation only supports 32bits</ko>
 
-PF MAY support constraining the parameter minimum and maximum value.
-(Why: To catch user out of valid range errors when changing the parameter
-      value.)
+PF **MAY** support constraining the parameter minimum and maximum value.
+<why>To catch user out of valid range errors when changing the parameter
+value.</why>
 
 ##### Bit field following the C ABI
-PF SHOULD support 1 or more bit sized integers.
-(Why: The reference implementation supports it.)
+PF **SHOULD** support 1 or more bit sized integers.
+<why>The reference implementation supports it.</why>
 
 Such parameters called are regrouped in a so called bit parameter block.
-The API to access a bit parameter block SHOULD give access to a packed bit
+The API to access a bit parameter block **SHOULD** give access to a packed bit
 field.
-(Why: The reference implementation supports it.)
+<why>The reference implementation supports it.</why>
 
 ### Parameter adaptation
 
@@ -163,139 +177,151 @@ could be done by the syncer. Nevertheless syncers are supposed to contain only
 business logic and should not be impacted by upper layer needs.
 
 #### Definition
-Parameter adaptation is a bijective pure function converting a parameter value
-between the syncer and other parameter reader/writer (including the inference
-engine).
+<dl>
+<dt>Parameter adaptation<dt>
+<dd>
+A bijective pure function converting a parameter value between the syncer
+and other parameter reader/writer (including the inference engine).
 
-(Why: It must be bijective in order to a) scale the user value to the hardware
-      value and b) convert the hardware value to the user's value space.)
+<why>It must be bijective in order to a) scale the user value to the hardware
+value and b) convert the hardware value to the user's value space.)</why>
+</dd>
+</dl>
 
 #### Requirements
-The following parameter adaptation SHOULD be supported
+The following parameter adaptation **SHOULD** be supported
 
  - Affine adaptation: `affAd(value) = slope * value + offset` where slope and
    offset and user-defined constants
-(Why: The reference implementation supports it.)
+   <why>The reference implementation supports it.</why>
 
  - Logarithm adaptation: `logAd(base, value) = ln(value) / ln(base)` where
    `ln` is the natural logarithm and base is a user-defined constant.
-(Why: The reference application supports it.)
-(Note: The reference implementation also supports passing a floor value to
-       be applied after conversion.)
+   <why>The reference application supports it.</why>
+   <nb>The reference implementation also supports passing a floor value to be
+   applied after conversion.</nb>
 
-A PF MAY offer Parameter adaptation composition. I.e. combine multiple parameter
+A PF **MAY** offer Parameter adaptation composition. I.e. combine multiple parameter
 adaptation
-E.g.: composing the affine and logarithm adaptation to
-`compAd(value) = slope * logAd(base, value) + offset`.
-(Why: To avoid combination explosion of parameter adaptations.
-      The idea is to builtin basic function and let the user compose them to
-      meet its need.)
-(Note: The reference application supports in a tricky way: the logarithm
- adaptation is always combined with the affine adaptation)
+<nb>E.g.: composing the affine and logarithm adaptation to
+`compAd(value) = slope * logAd(base, value) + offset`.</nb>
+<why>To avoid combination explosion of parameter adaptations. The idea is to
+builtin basic function and let the user compose them to meet its need.</why>
+<ko>The reference application supports in a tricky way: the logarithm
+adaptation is always combined with the affine adaptation</ko>
 
 ## Identifiers
-Every parameter MUST have an identifier that uniquely identifies it.
-(Why: to identify a parameter outside the framework)
+Every parameter **MUST** have an identifier that uniquely identifies it.
+<why>to identify a parameter outside the framework</why>
 
-This identifier SHOULD be a string.
-(Why: so that the (human) user can identify a parameter with ease.)
+This identifier **SHOULD** be a string.
+<why>so that the (human</why> user can identify a parameter with ease.)
 
-Two PF instances with the same parameters MUST have the same identifier for
+Two PF instances with the same parameters **MUST** have the same identifier for
 those parameters.
 I.e. this identifier should be the same across all instances with the same
 configuration.
-(Why: Persistence of parameter identifier across PF instances with the same
-      configuration. To identify parameters independently of the host machine
-      and PF instance)
+<why>Persistence of parameter identifier across PF instances with the same
+configuration. To identify parameters independently of the host machine and PF
+instance</why>
 
 ### Parameter tree
-A parameter MUST be structured in a tree. Each parameter being a distinct tree
-leaf.
-(Why: Tree is a simple data structure that can be easily represented and is
-      enough to map underlined layers.)
+A parameter **MUST** be structured in a tree. Each parameter being a distinct
+tree leaf.
+<why>Tree is a simple data structure that can be easily represented and is
+enough to map underlined layers.</why>
 
-Each node of the tree SHOULD have its own identifier with the same
+Each node of the tree **SHOULD** have its own identifier with the same
 characteristics (type, independence...) than a parameter.
-(Why: To represent the tree without treating the leaf nodes specifically.)
+<why>To represent the tree without treating the leaf nodes specifically.</why>
 
-The identifier of each node of the tree SHOULD be a combination of its parents.
-More specifically, if the identifier is a string it should be formated the same
-way as a file system path. E.g. the parameter named `/root/child1/4/parameter1`.
-(Why: Usual syntax to address trees.)
+The identifier of each node of the tree **SHOULD** be a combination of its
+parents. More specifically, if the identifier is a string it should be
+formated the same way as a file system path. E.g. the parameter named
+`/root/child1/4/parameter1`.
+<why>Usual syntax to address trees.</why>
 
 
 # Syncer
 
 The PF philosophy is to map the hardware characteristics to parameters.
 
-A syncer MUST be mapped to one or more parameters.
-(Why: The hardware minimal access may be bigger than one parameter.)
+A syncer **MUST** be mapped to one or more parameters.
+<why>The hardware minimal access may be bigger than one parameter.</why>
 
-One parameter MUST NOT be mapped to two or more syncer.
-(Why: Which syncer should be responsible to retrieve the initial parameter
-      value if they are multiple per parameter?)
+One parameter **MUST NOT** be mapped to two or more syncer.
+<why>Which syncer should be responsible to retrieve the initial parameter value
+if they are multiple per parameter?</why>
 
-A syncer MUST support retrieving the mapped parameters value from the mapped
+A syncer **MUST** support retrieving the mapped parameters value from the mapped
 hardware.
-(Why: to retrieve a parameter value at the start of the PF.)
+<why>to retrieve a parameter value at the start of the PF.</why>
 
-A syncer MUST support setting the mapped parameters value to the mapped
+A syncer **MUST** support setting the mapped parameters value to the mapped
 hardware.
-(Why: to synchronise hardware on parameter change.)
+<why>to synchronise hardware on parameter change.</why>
 
-Syncers MUST retrieve and set the parameters value from the PF core.
-(Why: to be able to synchronise with hardware.)
+Syncers **MUST** retrieve and set the parameters value from the PF core.
+<why>to be able to synchronise with hardware.</why>
 
-This API MAY be a packed parameter structure, following the C ABI without
+This API **MAY** be a packed parameter structure, following the C ABI without
 padding.
-(Note: This is what the reference implementation does.)
-(Why: ???)
+<nb>This is what the reference implementation does.</nb>
+<why>???</why>
 
 ## Introspection
-The syncer API SHOULD allow introspection of the mapped parameters.
-(Why: the parameter structure may be useful for the syncer to
-      communicate with the hardware.)
+The syncer API **SHOULD** allow introspection of the mapped parameters.
+<why>the parameter structure may be useful for the syncer to communicate with
+the hardware.</why>
 
 ## Plugins
-The PF MUST be able to create syncers.
-(Why: to bind on the corresponding parameters.)
+The PF **MUST** be able to create syncers.
+<why>to bind on the corresponding parameters.</why>
 
 ### Definition
 The PF creates syncer using syncer builder.
 
 ### Identifier
-All syncers mapping to the same hardware SHOULD have their builders regrouped in
-a syncer library.
-(Why: to be able to link a group of parameters and a given hardware.)
+All syncers mapping to the same hardware **SHOULD** have their builders regrouped
+in a syncer library.
+<why>to be able to link a group of parameters and a given hardware.</why>
 
-A syncer builder MUST have a unique identifier in its containing syncer library.
-(Why: To uniquely identify the syncer that should bind on parameters.
-      Given that the syncer library has already been specified.)
+A syncer builder **MUST** have a unique identifier in its containing syncer
+library.
+<why>To uniquely identify the syncer that should bind on parameters. Given that
+the syncer library has already been specified.</why>
 
-A syncer library MUST have a unique identifier in the host system.
-(Why: To identify the library associated to parameters.)
+A syncer library **MUST** have a unique identifier in the host system.
+<why>To identify the library associated to parameters.</why>
 
-Syncer build and syncer library identifiers SHOULD be strings.
-(Why: The reference application does so.)
+Syncer build and syncer library identifiers **SHOULD** be strings.
+<why>The reference application does so.</why>
 
 ### Loading
-Syncer library or/and builder MAY be loaded from dynamically linked libraries
+Syncer library or/and builder **MAY** be loaded from dynamically linked libraries
 (called syncer plugins).
-(Why: The reference implementation supports it.)
+<why>The reference implementation supports it.</why>
 
-Such syncer plugins SHOULD have an unique entry point that -when called- should
-register its payload (syncer library/builder) in the provided gatherer.
-(Note: This permit to merge multiple syncer libraries in one shared library.)
-(Why: The reference implementation supports it.)
+Such syncer plugins **SHOULD** have an unique entry point that -- when called --
+should register its payload (syncer library/builder) in the provided gatherer.
+<nb>This permit to merge multiple syncer libraries in one shared
+library.</nb>
+<why>The reference implementation supports it.</why>
 
 Multiple syncer plugins, may depend on each other. The PF should appropriately
 handle the case and not fail.
-(Why: The reference implementation supports it.)
+<why>The reference implementation supports it.</why>
 
 ## Mapping
 ### Definition
-A parameter not bound to a syncer is called a "virtual parameter".
+
+<dl>
+<dt>Virtual Parameter</dt>
+<dd>
+A parameter not bound to a syncer.
 (Todo: remove if not used in the requirements.)
+</dd>
+</dl>
 
 ### Requirements
 **TODO**:
@@ -304,26 +330,27 @@ A parameter not bound to a syncer is called a "virtual parameter".
 
 ## Sync
 
-Syncer SHOULD synchronise the mapped hardware on parameter change.
-(Why: To always keep synchronise the underlined hardware and the PF parameters.)
+Syncer **SHOULD** synchronise the mapped hardware on parameter change.
+<why>To always keep synchronise the underlined hardware and the PF
+parameters.</why>
 
-Syncer SHOULD retrieve parameter value from the hardware if no value has be set
-since the PF start.
-(Note: This is usually implemented on PF start, initialize the parameter
-       values with the mapped hardware current state.)
-(Why: To allow introspection of the hardware.)
+Syncer **SHOULD** retrieve parameter value from the hardware if no value has be
+set since the PF start.
+<nb>This is usually implemented on PF start, initialize the parameter values
+with the mapped hardware current state.</nb>
+<why>To allow introspection of the hardware.</why>
 
-A mode with synchronisation on client request MAY be supported.
-(Why: The reference implementation supports it.)
+A mode with synchronisation on client request **MAY** be supported.
+<why>The reference implementation supports it.</why>
 
-Syncers MAY report an 'out-of-sync' condition indicating that the hardware
+Syncers **MAY** report an 'out-of-sync' condition indicating that the hardware
 parameter values are not (or no longer) reflecting the last values set by the
 Parameter Framework.
-(Why: This can happen when the underlying hardware subsystem
-      crashes/reboots/...)
+<why>This can happen when the underlying hardware subsystem
+crashes/reboots/...</why>
 
-When a syncer reports an out-of-sync condition, the PF MUST try to resync the
-hardware values.
+When a syncer reports an out-of-sync condition, the PF **MUST** try to resync
+the hardware values.
 
 # Rule based dynamic abstraction
 
@@ -348,117 +375,133 @@ and a detection predicate. Configuration are applied when their associated
 
 ## Definition
 
-Configurations: set of values for different parameters. A configuration MUST not
-contain 2 values of the same parameters.
+<dl>
+<dt>Configuration</dt>
+<dd>
+Set of values for different parameters. A configuration **MUST NOT** contain 2
+values of the same parameters.
 
 For example, given a PF with 3 integer parameters A,B,C, a configuration can
-contain
- - 1 value for (A), (B) or (C)
- - 2 value for (A,B), (A,C) or (B,C)
- - 3 value for (A,B,C)
+contain:
+
+ - 1 value: (A) or (B) or (C); or
+ - 2 values: (A,B) or (A,C) or (B,C); or
+ - 3 values: (A,B,C).
+</dd>
+</dl>
 
 ## Configuration
 
-A PF MUST offer configurations as described in the Definition chapter.
-(Note: rule based parameter engine does not manipulate directly values,
-      it applies configuration on the parameters.)
-(Why: This is what the reference implementation does.)
+A PF **MUST** offer configurations as described in the Definition chapter.
+<nb>rule based parameter engine does not manipulate directly values, it
+applies configuration on the parameters.</nb>
+<why>This is what the reference implementation does.</why>
 
-Each configuration MUST be associated with a predicate that condition its
+Each configuration **MUST** be associated with a predicate that condition its
 eligibility. A configuration with a predicate that evaluates to `true` is called
 an "eligible configuration"
-(Why: This is what the reference implementation does.)
+<why>This is what the reference implementation does.</why>
 
-It SHOULD be possible to express a predicate to always evaluates to `true`.
-(Why: in order to have parameters set to constant values or have a fallback
-      configuration in a domain - see below.)
+It **SHOULD** be possible to express a predicate to always evaluates to `true`.
+<why>in order to have parameters set to constant values or have a fallback
+configuration in a domain -- see below.</why>
 
-The predicate SHOULD be a "selection criterion rule". See next chapter for a
+The predicate **SHOULD** be a "selection criterion rule". See next chapter for a
 definition.
-(Why: The reference implementation uses a boolean expression based engine.)
+<why>The reference implementation uses a boolean expression based engine.</why>
 
 ## Selection criterion
 
-A selection criterion MUST have one, and only one, state at a given time.
+A selection criterion **MUST** have one, and only one, state at a given time.
 
-A selection criterion MUST know at construction all possible states.
-(Why: To be able to validate:
-       - rules on start
-       - state changes)
+A selection criterion **MUST** know at construction all possible states.
+<why>To be able to validate: -- rules on start -- state changes</why>
 
-The selection criterion possible states MUST be specifiable by:
- - Directly a state set (Input -> states == identity)
-   (Note: called exclusive criterion)
-   (Note: An empty set is not allowed as the criterion could not have a state.)
-   (Why: any criterion can be crated with this one.)
+The selection criterion possible states **MUST** be specifiable by directly a
+state set (`Input -> states == identity`)
+<nb>called **exclusive criterion**</nb>
+<nb>An empty set is not allowed as the criterion could not have a state.</nb>
+<why>any criterion can be crated with this one.</why>
 
-The selection criterion possible states SHOULD be specifiable by:
- - A combination of values
-   (Note: combination in the mathematical sense `"ab" -> ["", "a", "b", "ab"]`)
-   (Note: called inclusive criterion)
-   (Note: An empty value set is allowed as its combination -a set
-          containing the empty set- would not be empty. The empty set would be
-          the only possible criteria state.)
-   (Why: The reference implementation supports it.)
+The selection criterion possible states **SHOULD** be specifiable by a combination
+of values
+<nb>combination in the mathematical sense `"ab" -> ["", "a", "b", "ab"]`</nb>
+<nb>called **inclusive criterion**</nb>
+<nb>An empty value set is allowed as its combination -- a set containing the
+empty set -- would not be empty. The empty set would be the only possible
+criteria state.</nb>
+<why>The reference implementation supports it.</why>
 
-The PF MUST not limit the number of criteria.
+The PF **MUST NOT** limit the number of criteria.
 
-The PF MUST not limit the number of states of any given criterion
-(Note: The reference implementation only supports 32 values for an inclusive
-       criterion and 2^32 values for an exclusive criterion)
+The PF **MUST NOT** limit the number of states of any given criterion
+<ko>The reference implementation only supports 32 values for an inclusive
+criterion and 2^32 values for an exclusive criterion</ko>
 
 ### Definitions
- - Selection criterion rule: function (in the mathematical sense) that MUST
-   given selection criteria return a Boolean.
+<dl>
+<dt>Selection criterion rule</dt>
+<dd>
+Function (in the mathematical sense) that **MUST** given selection criteria
+return a Boolean.
+</dd>
 
- - Rule: an Boolean expression of Selection criterion rules
-   (Note: implementation only allows AND and OR combination)
+<dt>Rule</dt>
+<dd>
+A Boolean expression of Selection criterion rules.
+<nb>implementation only allows AND and OR combination</nb>
+<dd>
+</dl>
 
 ### Criterion change
 
-The API to change criterion values MUST allow atomicity regarding configuration
-application. I.e. it MUST be possible to change multiple criterion values
-without triggering a configuration application.
-(Why: Two criterion might have an excluding state.
-      If configuration application was triggered after each)
+The API to change criterion values **MUST** allow atomicity regarding
+configuration application. I.e. it **MUST** be possible to change multiple
+criterion values without triggering a configuration application.
+<why>Two criterion might have an excluding state. If configuration application
+was triggered after each</why>
 
 ### Rules
 
-It MUST always be able to express a selection criterion rule from a given
+It **MUST** always be able to express a selection criterion rule from a given
 selection criterion
-I.e.: a criteria MUST always have a state that can be matched by a rule.
-(Why: if no rules can be formulated from a criterion, it is useless)
+I.e.: a criteria **MUST** always have a state that can be matched by a rule.
+<why>if no rules can be formulated from a criterion, it is useless</why>
 
-Parameter values change SHOULD be selected by Rules.
-(Why: A rule based inference engine has been chosen based on implementation and
-configuration ease)
+Parameter values change **SHOULD** be selected by Rules.
+<why>A rule based inference engine has been chosen based on implementation and
+configuration ease</why>
 
-It MUST be possible to express a Rule that is always True.
-(Why: In order to make a configuration "always applicable"
+It **MUST** be possible to express a Rule that is always True.
+<why>In order to make a configuration "always applicable"</why>
 
 ## Domains
 
 ### Definition
-Domain: ordered set of configuration, all of which contain the values for the
+<dl>
+<dt>Domain</dt>
+<dd>
+Ordered set of configuration, all of which contain the values for the
 same parameters.
+</dd>
+</dl>
 
 ### Requirement
 
-Each configuration SHOULD be in a "domain" (see Definition chapter).
-(Why: Domains are mostly a way to define the priority of "Scenarios" for some
-      parameters. It is not a MUST because this goal could also be achieve with
-      (for example) global configurations and per parameter priority. It is not
-      a MAY because the reference implementation uses domains.)
+Each configuration **SHOULD** be in a "domain" (see Definition chapter).
+<why>Domains are mostly a way to define the priority of "Scenarios" for some
+parameters. It is not a MUST because this goal could also be achieve with (for
+example) global configurations and per parameter priority. It is not a MAY
+because the reference implementation uses domains.</why>
 
-If multiple configuration are eligible, the first one MUST be applied.
-(Why: If multiple configuration are eligible)
+If multiple configuration are eligible, the first one **MUST** be applied.
+<why>If multiple configuration are eligible</why>
 
-If no configuration is eligible, no configuration MUST be applied.
-(Note: It means that if none of the configurations is eligible, none is applied.
-       This also mean that no function can be defined between criteria and
-       states.
-       I.e.: parameter values MAY depend on previous selection criterion states.
-(Why: This is what the reference implementation does.)
+If no configuration is eligible, no configuration **MUST** be applied.
+<nb>It means that if none of the configurations is eligible, none is applied.
+This also mean that no function can be defined between criteria and states.
+I.e.: parameter values MAY depend on previous selection criterion states.</nb>
+<why>This is what the reference implementation does.</why>
 
 TODO sequence aware domains
 
@@ -473,28 +516,27 @@ its state and restore for backup, deployment, reboot...
 
 ## Definition
 PF data includes:
+
 - parameters tree
 - configurations:
-  - selection rule
-  - parameter/value couples
+    - selection rule
+    - parameter/value couples
 - domain:
-  - list of associated configurations
-  - order of priority
+    - list of associated configurations
+    - order of priority
 
 ## Requirement
-The PF data MUST be deserializable.
-(Why: Otherwise a PF instance could only be created empty and then be filled
-      by the tuning interface.
-      The reference implementation supports it.)
+The PF data **MUST** be deserializable.
+<why>Otherwise a PF instance could only be created empty and then be filled by
+the tuning interface. The reference implementation supports it.</why>
 
-The PF data SHOULD be deserializable from a config file.
-(Why: This is usually how program configuration are stored.
-      The reference implementation supports it.)
+The PF data **SHOULD** be deserializable from a config file.
+<why>This is usually how program configuration are stored. The reference
+implementation supports it.</why>
 
-The PF data SHOULD be serializable.
-(Why: In order to save a PF instance state and restore it later.
-      This achieve destruction recovery.
-      The reference implementation supports it.)
+The PF data **SHOULD** be serializable.
+<why>In order to save a PF instance state and restore it later. This achieve
+destruction recovery. The reference implementation supports it.</why>
 
 **TODO**: XML ?
 
@@ -503,21 +545,24 @@ The PF data SHOULD be serializable.
 In order to debug
 
 ## Requirements
-User SHOULD be able to inspect PF data. Including:
- - listing
+User **SHOULD** be able to inspect PF data.
+<why>To offer run time debugging.</why>
+This includes:
+
+- listing
     - domains
     - configurations of a domains
     - parameters
     - a domain's associated parameters
- - displaying their properties. Including:
+- displaying their properties. Including:
     - parameters values, min, max, size...
-(Why: To offer run time debugging.)
 
-PF MAY offer pretty print of data. Including:
- - printing parameter value in decimal
-(Why: For human readability)
- - pretty print parameter tree (such as the Unix tree command for files)
-(Why: In order to ease runtime debug.)
+PF **MAY** offer pretty print of data. Including:
+
+- printing parameter value in decimal
+    <why>For human readability</why>
+- pretty print parameter tree (such as the Unix tree command for files)
+    <why>In order to ease runtime debug.</why>
 
 
 # Tuning
@@ -531,99 +576,108 @@ understand and should be easily modified not correct.
 To address this need, a fast modify-update-test cycle should be possible.
 
 ## Requirements
-Users SHOULD be able to modify the PF inference engine behaviour (rules,
+Users **SHOULD** be able to modify the PF inference engine behaviour (rules,
 configuration...) with minimal effort.
+<why>To enable a fast modify-update-test cycle during tuning.</why>
 This usually mean avoiding:
- - recompiling
- - restarting the host process/service
-(Note: No requirement is made on the persistence of those changes,
-       they may or may not disappear on PF restart.
-       This could be implemented in several way, for example:
-        - exposed in the PF API
-        - changing a config file and sending a signal to the PF
-        - providing a IPC
-        - directly modifying the memory)
-(Why: To enable a fast modify-update-test cycle during tuning.)
 
-Tuning SHOULD be possible from the PF native API.
-Why: In order to let the host system implement its own tuning mechanism.)
+- recompiling
+- restarting the host process/service
 
-Users MAY be able to modify the parameters (types, identifiers, tree...) with
+<nb>
+No requirement is made on the persistence of those changes, they may or
+may not disappear on PF restart. This could be implemented in several way, for
+example:
+
+- exposed in the PF API
+- changing a config file and sending a signal to the PF
+- providing a IPC
+- directly modifying the memory
+</nb>
+
+Tuning **SHOULD** be possible from the PF native API.
+<why>In order to let the host system implement its own tuning mechanism.</why>
+
+Users **MAY** be able to modify the parameters (types, identifiers, tree...) with
 minimal effort (see previous requirement).
-(Note: The reference implementation does not support it.)
-(Why: To enable a fast modify-update-test cycle on PF configuration.)
+<ko>The reference implementation does not support it.</ko>
+<why>To enable a fast modify-update-test cycle on PF configuration.</why>
 
-Users SHOULD be able to modify the parameter values at any time.
-This change SHOULD not be overwritten without a user action.
-(Note: user overwritten user action could be a log out, leaving some tuning
-       mode, forcing an inference engine update...)
-(Why: Even if a parameter is managed by the inference engine,
-      it often is useful (test, debugging) to overwrite its value temporally.).
+Users **SHOULD** be able to modify the parameter values at any time.
+This change **SHOULD NOT** be overwritten without a user action.
+<nb>user overwritten user action could be a log out, leaving some tuning mode,
+forcing an inference engine update...</nb>
+<why>Even if a parameter is managed by the inference engine, it often is useful
+(test, debugging) to overwrite its value temporally.</why>
 
-A PF tuning capability MAY be disabled in a context where no tuning is needed.
-(Why: The reference implementation does so (phone end users can not change the
-      tuning).)
+A PF tuning capability **MAY** be disabled in a context where no tuning is needed.
+<why>The reference implementation does so (phone end users can not change the
+tuning).</why>
 
 # Command line interface
 
-The PF MAY offer a command line interface that binds to its IPC.
-(Why: to have a reference way to interact with a PF without implementing its IPC
-      protocol.)
+The PF **MAY** offer a command line interface that binds to its IPC.
+<why>to have a reference way to interact with a PF without implementing its IPC
+protocol.</why>
 
-This command line interface SHOULD support all tuning and introspection ability.
-(Why: In order to be used in scripting and live tuning/debugging on an embedded
-      system.)
+This command line interface **SHOULD** support all tuning and introspection
+ability.
+<why>In order to be used in scripting and live tuning/debugging on an embedded
+system.</why>
 
-This command line interface MAY offer argument auto completion.
-(Why: Is more user friendly.)
+This command line interface **MAY** offer argument auto completion.
+<why>Is more user friendly.</why>
 
 # Bindings
-The PF SHOULD expose its API in C.
-(Why: The PF aims to be a hardware abstraction thus middle ware which is often
-      written in C or a language compatible with C.
-      Virtually all programing language support C Foreign Procedure Call,
-      having a C API ease integration whichever the host language is.)
+The PF **SHOULD** expose its API in C.
+<why>The PF aims to be a hardware abstraction thus middle ware which is often
+written in C or a language compatible with C. Virtually all programing language
+support C Foreign Procedure Call, having a C API ease integration whichever the
+host language is.</why>
 
-The PF MAY expose its API to multiple programing language.
-(Why: The reference implementation has python bindings.)
+The PF **MAY** expose its API to multiple programing language.
+<why>The reference implementation has python bindings.</why>
 
 # Performance
 
-The reference Parameter Framework implementation is mainly intended for use in
-consumer electronics such as smartphones and tablets. Such platforms are often
-referred to as "embedded" platforms but their capacity today is so huge in
-terms of both computing and memory that can can be considered as small personal
+The reference Parameter Framework implementation is mainly intended for use
+in consumer electronics such as smartphones and tablets. Such platforms are
+often referred to as "embedded" platforms but their capacity today is so huge in
+terms of both computing and memory that they can be considered as small personal
 computers.
 
-Moreover, since one of the Parameter Framework's primary feature is to
-implement storage of a) a hardware description and b) settings, its memory
-footprint largely depends on how many such items are stored.
+Moreover, since one of the Parameter Framework's primary feature is to implement
+storage of a) a hardware description and b) settings, its memory footprint
+largely depends on how many such items are stored.
 
 For those reasons, there are no performance requirements imposed on the
 architecture. Performance considerations are left to the implementation of the
 Parameter Framework and/or the client and/or the build chain.
 
 # Next
+<ko>
 The following requirements are not implemented in the reference implementation
 and are to be considered draft.
+</ko>
 
-PF MAY support at least:
-    - Linux (and Android)
-    - Windows
-    - Mac OSX
-(Why: As the reference PF implementation leaves its original Android
-      environment, needs emerge to use it on other platform.)
+PF **MAY** support at least:
 
-The PF host API SHOULD be structured.
+ - Linux (and Android)
+ - Windows
+ - Mac OSX
+
+<why>As the reference PF implementation leaves its original Android environment,
+needs emerge to use it on other platform.</why>
+
+The PF host API **SHOULD** be structured.
 I.e.: the PF, when requested for a list of domains, should return a list of
 structured object, each containing configuration objects, containing their
 values.
-(Why: The reference implementation has a string oriented API.
-      E.g/: The list of domains is returned as a concatenation of domains name
-      in one big string.
-      This leads to hard an hard to use API from C and C++ code.)
+<why>The reference implementation has a string oriented API. E.g/: The list of
+domains is returned as a concatenation of domains name in one big string. This
+leads to hard an hard to use API from C and C++ code.</why>
 
-The PF host API SHOULD expose parameter values with the same API syncer use.
-(Why: The current reference implementation abstracts the memory layout of
-      parameters. This memory layout is specified in the parameter structure
-      thus TODO)
+The PF host API **SHOULD** expose parameter values with the same API syncer use.
+<why>The current reference implementation abstracts the memory layout of
+parameters. This memory layout is specified in the parameter structure thus
+TODO</why>

--- a/doc/requirements/Requirements.md
+++ b/doc/requirements/Requirements.md
@@ -342,8 +342,10 @@ set since the PF start.
 with the mapped hardware current state.</nb>
 <why>To allow introspection of the hardware.</why>
 
-A mode with synchronisation on client request **MAY** be supported.
-<why>The reference implementation supports it.</why>
+A mode with synchronisation on client request **SHOULD** be supported.
+<why>The user may want to group the synchronization of multiple parameters --
+for instance if a syncer contains more than 1 parameter -- in order to avoid
+undesired intermediary states.</why>
 
 Syncers **MAY** report an 'out-of-sync' condition indicating that the hardware
 parameter values are not (or no longer) reflecting the last values set by the
@@ -390,6 +392,11 @@ contain:
  - 2 values: (A,B) or (A,C) or (B,C); or
  - 3 values: (A,B,C).
 </dd>
+
+<dt>Rogue Parameter</dt>
+<dd>
+A Parameter that is not contained by any configuration.
+<dd>
 </dl>
 
 ## Configuration
@@ -540,7 +547,13 @@ The PF data **SHOULD** be serializable.
 <why>In order to save a PF instance state and restore it later. This achieve
 destruction recovery. The reference implementation supports it.</why>
 
+The PF data **SHOULD** be serializable/deserializable by parts. <why>For easier
+configuration management: for versioning; for selecting only wanted parts of a
+complete configuration.</why>
+
 **TODO**: XML ?
+
+**TODO**: get the binary content of an element.
 
 # Introspection
 ## Philosophy
@@ -556,7 +569,7 @@ This includes:
     - configurations of a domains
     - parameters
     - a domain's associated parameters
-- displaying their properties. Including:
+- getting their properties. Including:
     - parameters values, min, max, size...
 
 PF **MAY** offer pretty print of data. Including:
@@ -566,6 +579,11 @@ PF **MAY** offer pretty print of data. Including:
 - pretty print parameter tree (such as the Unix tree command for files)
     <why>In order to ease runtime debug.</why>
 
+Users **SHOULD** be able to modify rogue parameters through the native API at
+all time.
+<why>Otherwise, a rogue parameter is of no use.</why>
+<ko>In the reference implementation, under certain conditions, this is not
+possible (tuning mode)</ko>
 
 # Tuning
 ## Philosophy


### PR DESCRIPTION
Establishing the requirements is a Work In Progress, of which this commit is
the first step.

Signed-off-by: Kevin Rocard <kevin.rocard@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/156%23issuecomment-127899290%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23issuecomment-128331451%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23issuecomment-128335435%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23issuecomment-130577204%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36403950%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36405812%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36405886%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36405918%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406016%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406153%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406240%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406306%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406455%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406476%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406793%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408338%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408400%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408428%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408520%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408571%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408611%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409384%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409495%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409575%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409730%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409788%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409874%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409966%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409985%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410209%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410225%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410392%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410423%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410460%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410689%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410753%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410938%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411040%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411118%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411168%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411265%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411422%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411700%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411711%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411765%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411834%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411932%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411960%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412161%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412213%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412296%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412419%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412548%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412567%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412733%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36413289%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419015%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419086%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419297%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419357%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419486%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419699%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419858%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36420877%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36426234%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36624695%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36759519%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36760449%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36895969%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36896363%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36901629%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36901831%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36902036%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36902881%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36903087%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36903210%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36951849%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36969209%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37103131%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37165687%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37165791%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37166351%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37166433%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37167991%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37168285%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37168694%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37171780%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37171873%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37171897%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37171977%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37172013%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37172109%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37172507%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37172574%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37172609%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37172713%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37173141%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37173746%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37182325%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37182557%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37182729%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37182922%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37183051%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37183125%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37183148%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37192712%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37194880%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195090%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195091%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195094%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195095%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195098%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195102%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195103%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195104%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195106%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195107%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37195154%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37196836%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37202737%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37276114%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37276733%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37277068%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37277414%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37277435%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37278899%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37279525%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r37280124%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406455%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22quite%20strange%20requirement...%20I%20presonnally%20dislike%20libs%20that%20log%20stuff.%20I%20just%20want%20the%20lib%20to%20work%2C%20I%20don%27t%20want%20to%20debug%20it.%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A07%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20isn%27t%20specifically%20linked%20to%20logging%3A%20it%20is%20used%20for%20introspection%20too%20%28see%20%5C%22Introspection%5C%22%20chapter%29.%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A11%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20done%20added%20debugging%2C%20logging%2C%20display%22%2C%20%22created_at%22%3A%20%222015-08-12T19%3A31%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406016%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20is%20a%20parameter%3F%20Is%20there%20a%20link%20between%20this%20req%20and%20any%20description%20of%20the%20aim%20of%20the%20PFW%3F%20%28what%20problem%20is%20the%20PFW%20supposed%20to%20solve%3F%29%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A00%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Add%20a%20philosophy%20paragraph%20giving%20what%20problems%20the%20PF%20aims%20to%20solve.%5Cr%5Cn%5Cr%5CnDone%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-11T15%3A35%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406476%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22idem%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A07%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20how%20is%20%28de%29serialization%20to%20string%20bijection%20any%20close%20to%20logging%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T19%3A32%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36405886%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22the%20%5C%22why%5C%22%20should%20be%20the%20requirement%2C%20the%20rest%20is%20implementation%22%2C%20%22created_at%22%3A%20%222015-08-06T11%3A58%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-12T18%3A31%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36405812%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22IMHO%20implementation%20detail%2C%20even%20if%20relevant%22%2C%20%22created_at%22%3A%20%222015-08-06T11%3A57%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-12T18%3A28%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406153%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20this%20mean%20that%20the%20PFW%20manipulates%20%7Bparameter%2C%20value%7D%20pairs%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A02%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20a%20parameter%20contains%20a%20value%20and%20possibly%20other%20meta%20data%20%28size%2C%20min%2Cmax%2C%20name...%29.%5Cr%5Cn%3A-1%3A%20Add%20this%20to%20the%20parameter%20definition.%22%2C%20%22created_at%22%3A%20%222015-08-12T19%3A19%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20372%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410460%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20works%20by%20grouping%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A00%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A43%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20471%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36405918%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20sentence%20is%20unfinished.%22%2C%20%22created_at%22%3A%20%222015-08-06T11%3A59%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20understand%2C%20not%20clear%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A13%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20user%20may%20describe%20a%20system%27s%20state%20change%20by%20parts%20%28e.g.%20%5C%22X%20changes%20from%201%20to%202%20and%20Y%20changed%20from%20%5C%22foo%5C%22%20to%20%5C%22bar%5C%22%29%20but%20may%20not%20want%20the%20inference%20engine%20to%20recompute%20the%20configurations%20for%20each%20partial%20change.%5Cr%5Cn%5Cr%5CnIt%20puts%20a%20requirement%20on%20the%20Parameter%20Framework%3A%20the%20user%20must%20be%20able%20to%20decide%20when%20the%20recomputing%20takes%20place%20--%3E%20%5C%22atomicity%20regarding%20configuration%20application%5C%22.%22%2C%20%22created_at%22%3A%20%222015-08-06T14%3A31%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-12T19%3A17%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20608%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419015%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22MAY%22%2C%20%22created_at%22%3A%20%222015-08-06T14%3A17%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nope%20this%20is%20in%20a%20note%20section%20not%20a%20requirement.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A36%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20255%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409874%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20not%20both%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A52%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20did%20you%20did%20not%20understand%20in%20the%20why%20section%20%3F%20%28true%20question%2C%20not%20a%20troll%29%22%2C%20%22created_at%22%3A%20%222015-08-17T08%3A44%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20reformulation.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-18T08%3A42%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20485%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411834%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20for%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A14%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Removed%20%3A%2B1%3A%20%2C%20duplicated%20of%3A%5Cr%5Cn%3E%20It%20%2A%2ASHOULD%2A%2A%20be%20possible%20to%20express%20a%20predicate%20to%20always%20evaluates%20to%20%60true%60.%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A27%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20214%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408611%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22idem%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A36%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20lots%20of%20use%20case%20and%20justification.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T08%3A06%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20600%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412733%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22hopefully%20with%20minimal%20effort...%20may%20I%20understand%20that%20the%20rest%20of%20API%20should%20be%20painful%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A23%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Of%20course%20not.%20It%20means%20that%20the%20engine%20modify-install-test%20cycle%20should%20be%20as%20minimal%20as%20possible.%20Can%20you%20think%20of%20a%20better%20way%20to%20formulate%20it%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-17T15%3A03%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%20for%20him%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-18T09%3A16%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20538%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412213%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20is%20a%20constraint%20from%20implementation%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A18%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20467%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36426234%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20haven%27t%20introduced%20the%20API%20to%20change%20criterion%20values.%22%2C%20%22created_at%22%3A%20%222015-08-06T15%3A14%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20req%20is%20fulfilled%20by%20the%20%60applyConfiguration%60%20method.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A39%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20550%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412419%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20is%20the%20need%3F%20is%20the%20req%20%5C%22need%20ofversioning%3B%20and%20selecting%20only%20wanted%20parts%20of%20a%20complete%20configuration%5C%22%20%3F%20why%20is%20that%20mandatory%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A20%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%20-%20%5B%20%5D%20Req%20is%20about%20independant%20files%20to%20avoid%20conflict%20versioning%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T08%3A53%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20435%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411168%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20is%20that%20not%20simply%20a%20criterion%20set%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A07%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20a%20criterion%20set%20is%20a%20set%20of%20criterionS.%20Thus%20not%20ONE%20criterion.%20It%20would%20make%20no%20sense%20to%20define%20a%20criterion%20stateS%20with%20multiple%20criterionS.%5Cr%5Cn%5Cr%5CnOr%20did%20I%20missed%20something%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A53%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20437%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411265%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20about%20%5C%22ba%5C%22%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A08%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//en.wikipedia.org/wiki/Combination%20https%3A//en.wikipedia.org/wiki/Permutation%22%2C%20%22created_at%22%3A%20%222015-08-06T14%3A20%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5E%5E%20Thanks%20David.%20Added%20the%20link%20to%20wikipedia%20%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A59%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20563%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412548%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22is%20that%20a%20reqirement%20of%20user%20or%20the%20lib%20implementer%3F%20you%20seem%20to%20talk%20about%20a%20debugging%20tool%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A21%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20section%20in%20philosophy.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-18T08%3A58%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20430%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411118%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20would%20this%20be%20required%20by%20end%20user%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A07%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20a%20functional%20requirement.%20It%20is%20the%20trivial%20way%20to%20define%20a%20criterion%27s%20possible%20states.%22%2C%20%22created_at%22%3A%20%222015-08-06T14%3A21%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Indeed%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A51%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20226%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409495%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22as%20far%20as%20I%20understand%2C%20this%20requirement%20is%20more%20%5C%22all%20instance%20should%20share%20the%20same%20format%20of%20persistance%5C%22%2C%20am%20I%20wrong%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A48%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20means%20that%20the%20identifier%20computing%20function%20should%20be%20deterministic%20and%20only%20rely%20on%20information%20contained%20in%20the%20parameters.%5Cr%5Cn%5Cr%5CnBTW%2C%20in%20order%20for%20this%20to%20be%20true%2C%20the%20top-level%20parameter%20framework%20configuration%20also%20has%20to%20be%20taken%20into%20account%20%28system%20class%20name%29...%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A05%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20he%20top-level%20parameter%20framework%20configuration%5Cr%5Cn%5Cr%5CnThis%20top%20level%20config%20is%20specific%20to%20the%20PF.%20%5C%22Same%20configuration%5C%22%20includes%20everything%20and%20I%20think%20in%20sufficient.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A46%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20583%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412567%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22idem%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A21%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20section%20in%20philosophy.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-18T08%3A58%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20414%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410689%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22seems%20to%20be%20a%20trick%20around%20implementation.%20I%20don%27t%20understand%20the%20need%20from%20a%20high%20level%20standpoint%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A02%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20alternative%20formulation%20is%20%5C%22It%20should%20be%20possible%20to%20make%20a%20configuration%20always%20applicable%5C%22.%20At%20the%20time%20of%20writing%2C%20I%20preferred%20the%20other%20one.%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A28%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A44%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%20bca8b58dcba544a307f6c4311667d411d0999b3a%20doc/CMakeLists.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36760449%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Create%20the%20requirement%20option%20near%20it%27s%20use.%22%2C%20%22created_at%22%3A%20%222015-08-11T15%3A42%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A39%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/CMakeLists.txt%3AL31-41%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20284%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409985%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22is%20that%20a%20requirement%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A54%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20a%20definition%20%28as%20explained%20in%20the%20title%20of%20the%20section%29%20that%20introduces%20the%20concept%20of%20syncer%20builder.%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A13%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20367%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410392%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22to%20a%20higher%20level%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A59%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A41%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20165%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408428%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22parse%20error%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A34%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Reformulated%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20524%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412161%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22persistence%20is%20not%20serialization%3B%20the%20req%20seems%20to%20be%20persistence.%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A17%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Your%20remarks%20are%20very%20pertinent%20Seb.%20I%20must%20confess%20I%20will%20add%20some%20fixme%20in%20the%20document.%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A33%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2099%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408338%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20expect%20the%20requirement%20to%20be%20more%20end-user%20oriented%2C%20thus%20ideally%2C%20the%20pfw%20should%20be%20agnostic%20of%20user%27s%20types%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A33%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Added%20in%20the%20next%20section.%22%2C%20%22created_at%22%3A%20%222015-08-10T12%3A12%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20289%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410209%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20understant%20nor%20the%20need%2C%20nor%20the%20rational%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A56%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20you%20remarks%20in%20a%20FIXME%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A40%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23issuecomment-127899290%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Update%20of%20%23144%22%2C%20%22created_at%22%3A%20%222015-08-05T07%3A28%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20should%20push%20the%20generated%20html%20to%20github.io%20and%20then%20put%20a%20note%20in%20the%20markdown%20document%2C%20mentioning%20that%20the%20doc%20is%20best%20viewed%20as%20html%20%2B%20a%20link%20to%20said%20html%20version.%5Cr%5Cn%5Cr%5Cne.g.%20%60%3Cp%20style%3D%5C%22display%3A%20none%5C%22%3ESee%20the%20HTML%20version%20here%3A%20http%3A//...%3C/p%3E%60%22%2C%20%22created_at%22%3A%20%222015-08-06T11%3A18%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20wanted%20to%20use%20%60%3Cnote%3E%60%20as%20tag%20for%20the%20notes%20but%20pandoc%20applied%20a%20special%20treatment%20to%20them%20%28because%20it%20is%20a%20valid%20docbook%20tag%29%20and%20it%20didn%27t%20render%20as%20expected.%20Instead%2C%20I%20used%20%60%3Cnb%3E%60.%22%2C%20%22created_at%22%3A%20%222015-08-06T11%3A35%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20I%20wanted%20to%20use%20%3Cnote%3E%20as%20tag%20for%20the%20notes%20but%20pandoc%20applied%20a%20special%20treatment%20to%20them%20%28because%20it%20is%20a%20valid%20docbook%20tag%29%20and%20it%20didn%27t%20render%20as%20expected.%20Instead%2C%20I%20used%20%3Cnb%3E.%5Cr%5Cn%5Cr%5Cn%40dawagner%20could%20you%20give%20an%20example%20%3F%20I%20did%20not%20have%20problem%20using%20the%20%3Cnote%3E%20on%20some%20random%20blocks.%5Cr%5Cn%5Cr%5CnEdit%3A%20I%20actualy%20found%20out%20that%20%60%3Cnote%3E%60%20formats%20the%20code%20better%20than%20nb.%20So%20I%20%60s/nb/note%60.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-13T08%3A44%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20280%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409966%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22PF%20or%20plugin%3F%20The%20pfw%20may%20create%20whatever%20it%20need%2C%20this%20should%20be%20be%20a%20requirement%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A54%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Syncer%20are%20parts%20of%20plugin.%20If%20there%20is%20not%20way%20to%20instantiated%20syncer%20how%20should%20the%20PF%20bind%20a%20parameter%20to%20it.%20Anyway%20I%20added%20a%20FIXME%20in%20a%20note%20under%20this%20requirement.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T08%3A54%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20698%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419699%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22sorry%20for%20all%20those%20late%20comments%2C%20ask%20me%20if%20you%20want%20additional%20information%22%2C%20%22created_at%22%3A%20%222015-08-06T14%3A22%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20comments%20are%20very%20pertinent%20and%20welcomed%2C%20although%20it%20is%20true%20a%20bit%20late.%20Nevertheless%20better%20late%20then%20never.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A38%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/CMakeLists.txt%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36403950%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22try%20with%20add_custom_command%3B%20it%20should%20create%20a%20make%20target%20that%20has%20a%20real%20output%2C%20which%20avoid%20re-making%20it%20when%20up-to-date.%22%2C%20%22created_at%22%3A%20%222015-08-06T11%3A27%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A28%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/CMakeLists.txt%3AL62-90%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20243%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409730%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22then%20names%20cannot%20contain%20/%20%3F%5Cr%5Cnseems%20to%20be%20an%20implentation%20detail.%5Cr%5Cndoes%20///.././toto%20represent%20a%20valid%20path%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A51%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Don%27t%20know.%20Need%20to%20discuss%20about%20it%20like%20your%20previous%20point.%22%2C%20%22created_at%22%3A%20%222015-08-17T08%3A20%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20502%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411932%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22seems%20to%20be%20an%20implementation%20choice%2C%20not%20a%20req%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A15%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Given%20the%20why%20if%20this%20req%2C%20I%20must%20agree.%20The%20requirement%20is%20about%20configuration%20priority.%20Will%20reformulate.%20%3A-1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A31%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20507%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411960%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A16%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20philosophy%20paragraph.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T15%3A54%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20369%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410423%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22dynamic%20values%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A59%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A41%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20184%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408571%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20get%20the%20need%20from%20a%20user%27s%20perspective%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A36%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20paragraph%3A%5Cr%5Cn%3E%20For%20example%20stocking%20a%20parameter%20with%20a%20dynamic%20type%2C%20say%20either%20a%20string%20or%20a%20number%20could%20be%20done%20with%20a%20boolean%20a%20string%20and%20a%20number%20but%20this%20could%20not%20be%20pretty%20print%20and%20not%20memory%20efficient.%5Cr%5Cn%5Cr%5CnIs%20that%20ok%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-14T18%3A10%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20249%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409788%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20understand%20what%20is%20a%20syncer%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A52%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20philosophy%20section%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T08%3A48%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20542%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36412296%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22is%20persistence%20done%20thru%20a%20file%3F%20%28you%20seem%20to%20talk%20about%20implementation%29%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A19%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20426%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410938%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22is%20that%20the%20criterion%20that%20needs%20it%20or%20the%20PFW%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A05%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22criterion%20ARE%20parts%20of%20the%20PF.%20I%20do%20not%20understand%20your%20remark.%20Are%20you%20saying%20that%20this%20req%20should%20be%20put%20in%20an%20other%20section%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A51%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%20-%20%5B%20%5D%20Reformulate%20to%20avoid%20implementation%20consequences.%20%28All%20possible%20states%20of%20a%20criterion%20MUST%20be%20known%29%20%3D%3E%20to%20write%20correct%20rules%20about%20it.%22%2C%20%22created_at%22%3A%20%222015-08-18T08%3A49%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20424%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410753%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20you%20mean%20it%20is%20not%20quantic%3F%20seems%20useless%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A03%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20this%20is%20more%20of%20a%20definition%20%3F%20But%20being%20too%20explicit%20is%20not%20bad.%20If%20you%20have%20a%20more%20detailed%20grievance%2C%20feel%20free%20to%20submit%20it.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A50%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20220%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409384%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22when%20is%20that%20useful%3F%20seems%20to%20be%20log%20related%20so%20not%20really%20user%20oriented%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A47%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Moved%20this%20requirement%20in%20the%20introspectability%20section.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-17T08%3A08%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20233%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36409575%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20is%20a%20point%20of%20view%2C%20not%20a%20rational.%20Is%20that%20really%20mandatory%3F%20seems%20to%20be%20implementation%20related%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A49%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Need%20to%20talk%20further%20about%20it.%20I%20do%20not%20realy%20know%20what%20is%20the%20underlined%20requirement.%22%2C%20%22created_at%22%3A%20%222015-08-17T08%3A18%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20455%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411422%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20a%20boolean%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A10%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20a%20definition%2C%20not%20a%20requirement.%20See%20the%20%5C%22philosophy%5C%22%20section%3B%20a%20predicate%20is%20a%20function%20of%20the%20form%20%60f%3A%20x%20--%3E%20boolean%60%3A%20https%3A//en.wikipedia.org/wiki/Predicate_%2528mathematical_logic%2529%22%2C%20%22created_at%22%3A%20%222015-08-06T14%3A23%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-17T14%3A48%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20478%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36411765%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22so%20what%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T13%3A14%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22reformulated%20%3A%2B1%3A%20%3A%5Cr%5Cn%3E%20If%20no%20rules%20can%20be%20formulated%20from%20a%20criterion%20state%2C%20the%20hardware%20can%20not%20be%20abstracted%20in%20this%20state%20witch%20defeats%20the%20PF%20purpose.%22%2C%20%22created_at%22%3A%20%222015-08-17T10%3A08%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20174%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408400%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22a%20hardware%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A34%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-13T12%3A41%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20294%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36410225%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22implementation%20detail%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A57%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20so%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-17T09%3A42%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406306%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20is%20not%20complete%3A%20being%20able%20to%20get%20would%20be%20enough%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A05%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-12T19%3A29%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20618%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419086%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20is%20tuning%20from%20the%20pfw%20standpoint%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T14%3A18%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20note%20about%20the%20naming%20limitation.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-18T09%3A23%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20639%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36419297%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22is%20that%20a%20user%27s%20req%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T14%3A19%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20note%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-18T09%3A30%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%20178%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36408520%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20is%20a%20syncer%3F%20why%20do%20they%20appear%20in%20requirements%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A35%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20See%20the%20Syncer%20chapter.%22%2C%20%22created_at%22%3A%20%222015-08-13T08%3A42%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%2C%20%22Pull%2025a670dd7fc393e074582c47f3dfed298b27d72f%20doc/requirements/Requirements.md%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/156%23discussion_r36406240%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22PFW%20must%20be%20able%20to%20control%20the%20underlined%20hardware%20parameter%2C%20may%20they%20be%20mutable%20or%20not%22%2C%20%22created_at%22%3A%20%222015-08-06T12%3A04%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20unfortunately%20did%20not%20understand%20your%20sentence%2C%20are%20you%20saying%20that%20the%20PF%20could%20control%20hardware%20through%20other%20ways%20than%20parameters%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T19%3A21%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/Requirements.md%3AL1-705%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36406153'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> Does this mean that the PFW manipulates {parameter, value} pairs?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Well a parameter contains a value and possibly other meta data (size, min,max, name...).
:-1: Add this to the parameter definition.
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36406240'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> PFW must be able to control the underlined hardware parameter, may they be mutable or not
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I unfortunately did not understand your sentence, are you saying that the PF could control hardware through other ways than parameters ?
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 233'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36409575'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> this is a point of view, not a rational. Is that really mandatory? seems to be implementation related
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Need to talk further about it. I do not realy know what is the underlined requirement.
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 243'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36409730'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> then names cannot contain / ?
seems to be an implentation detail.
does ///.././toto represent a valid path?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Don't know. Need to discuss about it like your previous point.
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 294'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36410225'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> implementation detail
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Why so ?
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 426'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36410938'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> is that the criterion that needs it or the PFW?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> criterion ARE parts of the PF. I do not understand your remark. Are you saying that this req should be put in an other section ?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - [ ] Reformulate to avoid implementation consequences. (All possible states of a criterion MUST be known) => to write correct rules about it.
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 502'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36411932'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> seems to be an implementation choice, not a req
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Given the why if this req, I must agree. The requirement is about configuration priority. Will reformulate. :-1:
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 524'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36412161'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> persistence is not serialization; the req seems to be persistence.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Your remarks are very pertinent Seb. I must confess I will add some fixme in the document.
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 538'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36412213'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> this is a constraint from implementation
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 542'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36412296'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> is persistence done thru a file? (you seem to talk about implementation)
- [ ] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 550'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36412419'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> why is the need? is the req "need ofversioning; and selecting only wanted parts of a complete configuration" ? why is that mandatory?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - [ ] Req is about independant files to avoid conflict versioning ?
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#issuecomment-127899290'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Update of #144
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> We should push the generated html to github.io and then put a note in the markdown document, mentioning that the doc is best viewed as html + a link to said html version.
e.g. `<p style="display: none">See the HTML version here: http://...</p>`
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I wanted to use `<note>` as tag for the notes but pandoc applied a special treatment to them (because it is a valid docbook tag) and it didn't render as expected. Instead, I used `<nb>`.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> > I wanted to use <note> as tag for the notes but pandoc applied a special treatment to them (because it is a valid docbook tag) and it didn't render as expected. Instead, I used <nb>.
@dawagner could you give an example ? I did not have problem using the <note> on some random blocks.
Edit: I actualy found out that `<note>` formats the code better than nb. So I `s/nb/note`. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/CMakeLists.txt 29'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36403950'>File: doc/CMakeLists.txt:L62-90</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> try with add_custom_command; it should create a make target that has a real output, which avoid re-making it when up-to-date.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 11'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36405812'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> IMHO implementation detail, even if relevant
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36405886'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> the "why" should be the requirement, the rest is implementation
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 471'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36405918'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> This sentence is unfinished.
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> I don't understand, not clear
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> The user may describe a system's state change by parts (e.g. "X changes from 1 to 2 and Y changed from "foo" to "bar") but may not want the inference engine to recompute the configurations for each partial change.
It puts a requirement on the Parameter Framework: the user must be able to decide when the recomputing takes place --> "atomicity regarding configuration application".
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 19'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36406016'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> what is a parameter? Is there a link between this req and any description of the aim of the PFW? (what problem is the PFW supposed to solve?)
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Add a philosophy paragraph giving what problems the PF aims to solve.
Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 49'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36406306'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> why is not complete: being able to get would be enough
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 52'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36406455'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> quite strange requirement... I presonnally dislike libs that log stuff. I just want the lib to work, I don't want to debug it.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> This isn't specifically linked to logging: it is used for introspection too (see "Introspection" chapter).
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: done added debugging, logging, display
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 57'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36406476'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> idem
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: how is (de)serialization to string bijection any close to logging ?
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 99'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36408338'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> I would expect the requirement to be more end-user oriented, thus ideally, the pfw should be agnostic of user's types
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: Added in the next section.
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 174'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36408400'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> a hardware
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 165'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36408428'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> parse error
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Reformulated :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 178'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36408520'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> what is a syncer? why do they appear in requirements?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: See the Syncer chapter.
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 184'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36408571'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> I don't get the need from a user's perspective
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added a paragraph:
> For example stocking a parameter with a dynamic type, say either a string or a number could be done with a boolean a string and a number but this could not be pretty print and not memory efficient.
Is that ok :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 214'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36408611'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> idem
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added lots of use case and justification. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 220'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36409384'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> when is that useful? seems to be log related so not really user oriented
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Moved this requirement in the introspectability section. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 226'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36409495'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> as far as I understand, this requirement is more "all instance should share the same format of persistance", am I wrong?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> It means that the identifier computing function should be deterministic and only rely on information contained in the parameters.
BTW, in order for this to be true, the top-level parameter framework configuration also has to be taken into account (system class name)...
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> > he top-level parameter framework configuration
This top level config is specific to the PF. "Same configuration" includes everything and I think in sufficient. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 249'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36409788'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> I don't understand what is a syncer
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added a philosophy section :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 255'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36409874'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> why not both?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> What did you did not understand in the why section ? (true question, not a troll)
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added a reformulation. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 280'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36409966'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> PF or plugin? The pfw may create whatever it need, this should be be a requirement
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Syncer are parts of plugin. If there is not way to instantiated syncer how should the PF bind a parameter to it. Anyway I added a FIXME in a note under this requirement. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 284'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36409985'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> is that a requirement?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> It is a definition (as explained in the title of the section) that introduces the concept of syncer builder.
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 289'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36410209'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> I don't understant nor the need, nor the rational
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added you remarks in a FIXME :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 367'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36410392'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> to a higher level
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 369'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36410423'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> dynamic values
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 372'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36410460'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> I works by grouping
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 414'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36410689'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> seems to be a trick around implementation. I don't understand the need from a high level standpoint
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> The alternative formulation is "It should be possible to make a configuration always applicable". At the time of writing, I preferred the other one.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 424'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36410753'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> do you mean it is not quantic? seems useless
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Maybe this is more of a definition ? But being too explicit is not bad. If you have a more detailed grievance, feel free to submit it. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 430'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36411118'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> why would this be required by end user?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> This is a functional requirement. It is the trivial way to define a criterion's possible states.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Indeed :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 435'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36411168'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> why is that not simply a criterion set?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Because a criterion set is a set of criterionS. Thus not ONE criterion. It would make no sense to define a criterion stateS with multiple criterionS.
Or did I missed something ?
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 437'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36411265'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> what about "ba"?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> https://en.wikipedia.org/wiki/Combination https://en.wikipedia.org/wiki/Permutation
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> ^^ Thanks David. Added the link to wikipedia :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 455'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36411422'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> why a boolean?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> It is a definition, not a requirement. See the "philosophy" section; a predicate is a function of the form `f: x --> boolean`: https://en.wikipedia.org/wiki/Predicate_%28mathematical_logic%29
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 478'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36411765'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> so what?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> reformulated :+1: :
> If no rules can be formulated from a criterion state, the hardware can not be abstracted in this state witch defeats the PF purpose.
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 485'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36411834'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> why for?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Removed :+1: , duplicated of:
> It **SHOULD** be possible to express a predicate to always evaluates to `true`.
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 507'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36411960'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> why?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added a philosophy paragraph. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 563'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36412548'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> is that a reqirement of user or the lib implementer? you seem to talk about a debugging tool
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added a section in philosophy. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 583'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36412567'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> idem
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added a section in philosophy. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 600'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36412733'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> hopefully with minimal effort... may I understand that the rest of API should be painful?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Of course not. It means that the engine modify-install-test cycle should be as minimal as possible. Can you think of a better way to formulate it ?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Ok for him :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 608'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36419015'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> MAY
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Nope this is in a note section not a requirement. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 618'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36419086'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> what is tuning from the pfw standpoint?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added a note about the naming limitation. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 639'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36419297'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> is that a user's req?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Added a note :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 698'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36419699'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> sorry for all those late comments, ask me if you want additional information
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> You comments are very pertinent and welcomed, although it is true a bit late. Nevertheless better late then never. :+1:
- [x] <a href='#crh-comment-Pull 25a670dd7fc393e074582c47f3dfed298b27d72f doc/requirements/Requirements.md 467'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36426234'>File: doc/requirements/Requirements.md:L1-705</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> We haven't introduced the API to change criterion values.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> This req is fulfilled by the `applyConfiguration` method. :+1:
- [x] <a href='#crh-comment-Pull bca8b58dcba544a307f6c4311667d411d0999b3a doc/CMakeLists.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/156#discussion_r36760449'>File: doc/CMakeLists.txt:L31-41</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Create the requirement option near it's use.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Done :+1:


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/156?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/156?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/156'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>