### PR TITLE
functional tests/floats: really test NaN and infinity in raw space

### DIFF
--- a/test/functional-tests/FloatingPoint.cpp
+++ b/test/functional-tests/FloatingPoint.cpp
@@ -108,6 +108,8 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
             AND_THEN("Set/Get a floating point parameter in raw value space") {
                 const float tooHigh = 12.3f;
                 const float tooLow = -50.5f;
+                const float nan = std::numeric_limits<float>::quiet_NaN();
+                const float inf = std::numeric_limits<float>::infinity();
                 REQUIRE_NOTHROW(setRawValueSpace(true));
                 for (auto &vec : Tests<string>{
                             { "(too high, as decimal)",
@@ -115,8 +117,8 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
                             { "(too low, as decimal)",
                                 std::to_string(reinterpret_cast<const uint32_t&>(tooLow)) },
                             { "(meaningless)", "foobar" },
-                            { "(infinity)", std::to_string(std::numeric_limits<float>::infinity())},
-                            { "(NaN)", std::to_string(std::numeric_limits<float>::quiet_NaN())},
+                            { "(infinity)", std::to_string(reinterpret_cast<const uint32_t&>(inf))},
+                            { "(NaN)", std::to_string(reinterpret_cast<const uint32_t&>(nan))},
                         }) {
                     GIVEN("Invalid value " + vec.title) {
                         CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);


### PR DESCRIPTION
These tests were intended to try and set the raw values corresponding to NaN
and +infinity but they actually tried to set "nan" and "inf".

The numerical values are now reinterpreted as integer before being converted to
string.

Signed-off-by: David Wagner <david.wagner@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/157?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/157'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>