### PR TITLE
Fix PFW core KlocWork issues

### DIFF
--- a/parameter/DomainConfiguration.cpp
+++ b/parameter/DomainConfiguration.cpp
@@ -37,6 +37,7 @@
 #include "XmlDomainExportContext.h"
 #include "ConfigurationAccessContext.h"
 #include <assert.h>
+#include <cstdlib>
 #include "RuleParser.h"
 
 #define base CBinarySerializableElement
@@ -508,7 +509,8 @@ CAreaConfiguration* CDomainConfiguration::getAreaConfiguration(const CConfigurab
         }
     }
     // Not found?
-    assert(0);
+    // FIXME: replace by a always enabled assert
+    abort();
 
     return NULL;
 }
@@ -590,7 +592,8 @@ CAreaConfiguration* CDomainConfiguration::getAreaConfiguration(uint32_t uiAreaCo
         }
     }
 
-    assert(0);
+    // FIXME: replace by a always enabled assert
+    abort();
 
     return NULL;
 }


### PR DESCRIPTION
PFW core contains some critical KW issues
of type NPD.FUNC.MUST .

This patch fixes these KW issues by adding a check
on pointers address before their use.

Signed-off-by: wzairix <wajdix.zairi@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/158%23issuecomment-133064019%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23issuecomment-135335771%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r36745935%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r36833459%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r37314583%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r37395648%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r37395836%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r37396309%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r38197616%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r38197617%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r38197618%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r38197619%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/158%23issuecomment-133064019%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20Thanks%20for%20this%20pull%20request.%20Will%20be%20merged%20after%20%40OznOg%20review.%22%2C%20%22created_at%22%3A%20%222015-08-20T16%3A15%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-27T08%3A12%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f47e16dd4fd50204618c6fa423c57611837e6ebc%20parameter/DomainConfiguration.cpp%2073%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r37395648%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20far%20as%20y%20know%2C%20replacing%20the%20assert%20by%20abort%20as%20you%20did%20should%20remove%20the%20need%20for%20those%20%60pChildAreaConfiguration%20%21%3D%20NULL%60%20tests.%20Could%20you%20confirm/infirm%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-19T09%3A28%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-28T13%3A12%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/DomainConfiguration.cpp%3AL498-510%22%7D%2C%20%22Pull%20f47e16dd4fd50204618c6fa423c57611837e6ebc%20parameter/DomainConfiguration.cpp%2091%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r37395836%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22To%20my%20opinion%20those%202%20assert%20-%3E%20abort%20substitution%20should%20be%20enough%20to%20avoid%20klockwork%20critical.%22%2C%20%22created_at%22%3A%20%222015-08-19T09%3A31%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-28T13%3A12%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/DomainConfiguration.cpp%3AL604-611%22%7D%2C%20%22Pull%20ffd0bde8bc5c3dee558526a3323741711463b58f%20parameter/DomainConfiguration.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r36745935%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20must%20say%20I%20do%20not%20really%20like%20this%20way%20of%20fixing%20this.%20With%20your%20way%2C%20instead%20of%20segfaulting%20the%20code%20will%20behave%20erratically%20in%20case%20of%20error.%20%2B%20a%20test%20needs%20to%20be%20added%20after%20each%20getAreaConfigaration.%20Could%20getAreaConfiguration%20avoid%20returning%20NULL%20%3F%20Maybe%20we%20could%20call%20explicitly%20%60abort%28%29%60%20instead%20of%20%60assert%280%29%60%20in%20getAreaConfiguration%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-11T13%3A46%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Refer%20to%20getAreaConfiguration%28%29%20function%20implementation%20we%20cannot%20avoid%20the%20NULL%20return%20since%20the%20function%20should%20retrun%20an%20address.%20But%20i%20agree%20with%20you%20%20about%20system%20behaviour%20in%20error%20case.%20%20We%20can%20abort%20in%20%20to%20getAreaConfiguration%28%29%20avoid%20this%20case.%22%2C%20%22created_at%22%3A%20%222015-08-12T07%3A38%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13729748%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wzairix%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20that%20we%20should%20abort%2C%20or%20use%20some%20kind%20of%20%5C%22always_assert%5C%22.%20There%20is%20some%20patches%20in%20the%20pipe%20to%20introduce%20such%20asserts.%5Cr%5Cn%5Cr%5CnManagement%20was%20very%20clear%20not%20to%20introduce%20workaround%20for%20klockwork%20false%20positive.%20Ie%20adding%20an%20assert%20%28or%20an%20initialization%29%20is%20OK%20but%20modifying%20the%20code%20flow%20should%20be%20avoided.%22%2C%20%22created_at%22%3A%20%222015-08-18T15%3A42%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-28T13%3A12%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/DomainConfiguration.cpp%3AL397-407%22%7D%2C%20%22Pull%20f47e16dd4fd50204618c6fa423c57611837e6ebc%20parameter/DomainConfiguration.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/158%23discussion_r37396309%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%60%60%7B.cpp%7D%5Cr%5Cn%23include%20%3Ccstdlib%3E%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-08-19T09%3A36%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-28T13%3A12%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/DomainConfiguration.cpp%3AL37-44%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull ffd0bde8bc5c3dee558526a3323741711463b58f parameter/DomainConfiguration.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/158#discussion_r36745935'>File: parameter/DomainConfiguration.cpp:L397-407</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I must say I do not really like this way of fixing this. With your way, instead of segfaulting the code will behave erratically in case of error. + a test needs to be added after each getAreaConfigaration. Could getAreaConfiguration avoid returning NULL ? Maybe we could call explicitly `abort()` instead of `assert(0)` in getAreaConfiguration ?
- <a href='https://github.com/wzairix'><img border=0 src='https://avatars.githubusercontent.com/u/13729748?v=3' height=16 width=16'></a> Refer to getAreaConfiguration() function implementation we cannot avoid the NULL return since the function should retrun an address. But i agree with you  about system behaviour in error case.  We can abort in  to getAreaConfiguration() avoid this case.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I think that we should abort, or use some kind of "always_assert". There is some patches in the pipe to introduce such asserts.
Management was very clear not to introduce workaround for klockwork false positive. Ie adding an assert (or an initialization) is OK but modifying the code flow should be avoided.
- [x] <a href='#crh-comment-Pull f47e16dd4fd50204618c6fa423c57611837e6ebc parameter/DomainConfiguration.cpp 73'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/158#discussion_r37395648'>File: parameter/DomainConfiguration.cpp:L498-510</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> As far as y know, replacing the assert by abort as you did should remove the need for those `pChildAreaConfiguration != NULL` tests. Could you confirm/infirm ?
- [x] <a href='#crh-comment-Pull f47e16dd4fd50204618c6fa423c57611837e6ebc parameter/DomainConfiguration.cpp 91'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/158#discussion_r37395836'>File: parameter/DomainConfiguration.cpp:L604-611</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> To my opinion those 2 assert -> abort substitution should be enough to avoid klockwork critical.
- [x] <a href='#crh-comment-Pull f47e16dd4fd50204618c6fa423c57611837e6ebc parameter/DomainConfiguration.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/158#discussion_r37396309'>File: parameter/DomainConfiguration.cpp:L37-44</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> 
```{.cpp}
#include <cstdlib>
```
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/158#issuecomment-133064019'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: Thanks for this pull request. Will be merged after @OznOg review.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/158?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/158?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/158'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>