### PR TITLE
Fix vasprintf() call usage.

### DIFF
--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -51,36 +51,42 @@ CElement::~CElement()
 // Logging
 void CElement::log_info(const string& strMessage, ...) const
 {
+    int ret_val;
     char *pacBuffer;
     va_list listPointer;
 
     va_start(listPointer, strMessage);
 
-    vasprintf(&pacBuffer,  strMessage.c_str(), listPointer);
+    ret_val = vasprintf(&pacBuffer,  strMessage.c_str(), listPointer);
 
     va_end(listPointer);
 
-    if (pacBuffer != NULL) {
-        doLog(false, pacBuffer);
+    if (ret_val == -1) {
+        return ;
     }
+
+    doLog(false, pacBuffer);
 
     free(pacBuffer);
 }
 
 void CElement::log_warning(const string& strMessage, ...) const
 {
+    int ret_val;
     char *pacBuffer;
     va_list listPointer;
 
     va_start(listPointer, strMessage);
 
-    vasprintf(&pacBuffer,  strMessage.c_str(), listPointer);
+    ret_val = vasprintf(&pacBuffer,  strMessage.c_str(), listPointer);
 
     va_end(listPointer);
 
-    if (pacBuffer != NULL) {
-        doLog(true, pacBuffer);
+    if (ret_val == -1) {
+        return ;
     }
+
+    doLog(true, pacBuffer);
 
     free(pacBuffer);
 }

--- a/parameter/SubsystemObject.cpp
+++ b/parameter/SubsystemObject.cpp
@@ -215,36 +215,42 @@ void CSubsystemObject::blackboardWrite(const void* pvData, uint32_t uiSize)
 // Logging
 void CSubsystemObject::log_info(const string& strMessage, ...) const
 {
+    int ret_val;
     char *pacBuffer;
     va_list listPointer;
 
     va_start(listPointer, strMessage);
 
-    vasprintf(&pacBuffer,  strMessage.c_str(), listPointer);
+    ret_val = vasprintf(&pacBuffer,  strMessage.c_str(), listPointer);
 
     va_end(listPointer);
 
-    if (pacBuffer != NULL) {
-        _pInstanceConfigurableElement->log_info(pacBuffer);
+    if (ret_val == -1) {
+        return ;
     }
+
+    _pInstanceConfigurableElement->log_info(pacBuffer);
 
     free(pacBuffer);
 }
 
 void CSubsystemObject::log_warning(const string& strMessage, ...) const
 {
+    int ret_val;
     char *pacBuffer;
     va_list listPointer;
 
     va_start(listPointer, strMessage);
 
-    vasprintf(&pacBuffer,  strMessage.c_str(), listPointer);
+    ret_val = vasprintf(&pacBuffer,  strMessage.c_str(), listPointer);
 
     va_end(listPointer);
 
-    if (pacBuffer != NULL) {
-        _pInstanceConfigurableElement->log_warning(pacBuffer);
+    if (ret_val == -1) {
+        return ;
     }
+
+    _pInstanceConfigurableElement->log_warning(pacBuffer);
 
     free(pacBuffer);
 }


### PR DESCRIPTION
Conforming to ASPRINTF(3), use vaspritnf return value to test its success.
In case of failure the contents of buffer pointer is undefined.

Signed-off-by: Miguel Gaio <miguel.gaio@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/164?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/164'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>