### PR TITLE
Fix vasprintf() call usage.

### DIFF
--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -52,36 +52,42 @@ CElement::~CElement()
 // Logging
 void CElement::log_info(const char* strMessage, ...) const
 {
+    int ret_val;
     char *pacBuffer;
     va_list listPointer;
 
     va_start(listPointer, strMessage);
 
-    vasprintf(&pacBuffer,  strMessage, listPointer);
+    ret_val = vasprintf(&pacBuffer,  strMessage, listPointer);
 
     va_end(listPointer);
 
-    if (pacBuffer != NULL) {
-        doLog(false, pacBuffer);
+    if (ret_val == -1) {
+        return;
     }
+
+    doLog(true, pacBuffer);
 
     free(pacBuffer);
 }
 
 void CElement::log_warning(const char* strMessage, ...) const
 {
+    int ret_val;
     char *pacBuffer;
     va_list listPointer;
 
     va_start(listPointer, strMessage);
 
-    vasprintf(&pacBuffer,  strMessage, listPointer);
+    ret_val = vasprintf(&pacBuffer,  strMessage, listPointer);
 
     va_end(listPointer);
 
-    if (pacBuffer != NULL) {
-        doLog(true, pacBuffer);
+    if (ret_val == -1) {
+        return;
     }
+
+    doLog(true, pacBuffer);
 
     free(pacBuffer);
 }

--- a/parameter/SubsystemObject.cpp
+++ b/parameter/SubsystemObject.cpp
@@ -215,36 +215,42 @@ void CSubsystemObject::blackboardWrite(const void* pvData, uint32_t uiSize)
 // Logging
 void CSubsystemObject::log_info(std::string strMessage, ...) const
 {
+    int ret_val;
     char *pacBuffer;
     va_list listPointer;
 
     va_start(listPointer, strMessage);
 
-    vasprintf(&pacBuffer, strMessage.c_str(), listPointer);
+    ret_val = vasprintf(&pacBuffer, strMessage.c_str(), listPointer);
 
     va_end(listPointer);
 
-    if (pacBuffer != NULL) {
-        _pInstanceConfigurableElement->log_info("%s", pacBuffer);
+    if (ret_val == -1) {
+        return ;
     }
+
+    _pInstanceConfigurableElement->log_info("%s", pacBuffer);
 
     free(pacBuffer);
 }
 
 void CSubsystemObject::log_warning(std::string strMessage, ...) const
 {
+    int ret_val;
     char *pacBuffer;
     va_list listPointer;
 
     va_start(listPointer, strMessage);
 
-    vasprintf(&pacBuffer, strMessage.c_str(), listPointer);
+    ret_val = vasprintf(&pacBuffer, strMessage.c_str(), listPointer);
 
     va_end(listPointer);
 
-    if (pacBuffer != NULL) {
-        _pInstanceConfigurableElement->log_warning("%s", pacBuffer);
+    if (ret_val == -1) {
+        return ;
     }
+
+    _pInstanceConfigurableElement->log_warning("%s", pacBuffer);
 
     free(pacBuffer);
 }


### PR DESCRIPTION
Conforming to ASPRINTF(3), use vasprintf return value to test its success.
In case of failure the contents of buffer pointer is undefined.

Signed-off-by: Miguel Gaio <miguel.gaio@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/165%23issuecomment-132959115%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/165%23issuecomment-132987299%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/165%23issuecomment-135367993%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/165%23issuecomment-132959115%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40miguelgalo%20Is%20this%20not%20equivalent%20to%20%2327%20%3F%20If%20so%20it%20is%20a%20know%20issue%20that%20we%20decided%20not%20to%20fix%20due%20to%20a%20complete%20log%20rework%20that%20was%20about%20to%20be%20merged%20%28that%20was%20in%20december%2014%29.%22%2C%20%22created_at%22%3A%20%222015-08-20T09%3A53%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20point%20must%20be%20handled%20as%20the%20build%20is%20broken%20using%20GNU%20compiler%204.8%20%28delivered%2003%202013%29%20and%20more.%22%2C%20%22created_at%22%3A%20%222015-08-20T12%3A07%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22Solved%20by%20log%20rework%20in%20%23168%20will%20be%20merged%20in%20windows_port%20then%20master%20shortly.%22%2C%20%22created_at%22%3A%20%222015-08-27T09%3A52%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/165#issuecomment-132959115'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> @miguelgalo Is this not equivalent to #27 ? If so it is a know issue that we decided not to fix due to a complete log rework that was about to be merged (that was in december 14).
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> This point must be handled as the build is broken using GNU compiler 4.8 (delivered 03 2013) and more.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Solved by log rework in #168 will be merged in windows_port then master shortly.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/165?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/165?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/165'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>