### PR TITLE
Rework remote server

### DIFF
--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -110,9 +110,8 @@ include_directories(
     "${PROJECT_SOURCE_DIR}/remote-processor"
     "${PROJECT_SOURCE_DIR}/parameter/log/include")
 
-# No need to link with libremote-processor: it is accessed via dlopen()
 find_library(dl dl)
-target_link_libraries(parameter xmlserializer pfw_utility dl)
+target_link_libraries(parameter xmlserializer remote-processor pfw_utility dl)
 
 install(TARGETS parameter LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
 # Client headers

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -718,9 +718,6 @@ private:
     // Whole system structure checksum
     uint8_t _uiStructureChecksum;
 
-    // Command Handler
-    CCommandHandler* _pCommandHandler;
-
     // Remote Processor Server
     IRemoteProcessorServerInterface* _pRemoteProcessorServer;
 

--- a/remote-processor/CMakeLists.txt
+++ b/remote-processor/CMakeLists.txt
@@ -33,8 +33,7 @@ add_library(remote-processor SHARED
         Message.cpp
         RequestMessage.cpp
         AnswerMessage.cpp
-        RemoteProcessorServer.cpp
-        RemoteProcessorServerBuilder.cpp)
+        RemoteProcessorServer.cpp)
 
 set(CMAKE_THREAD_PREFER_PTHREAD 1)
 find_package(Threads REQUIRED)

--- a/remote-processor/RemoteCommandHandler.h
+++ b/remote-processor/RemoteCommandHandler.h
@@ -38,6 +38,5 @@ public:
     // Return true on success, fill result in any cases
     virtual bool remoteCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult) = 0;
 
-protected:
     virtual ~IRemoteCommandHandler() {}
 };

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -84,25 +84,26 @@ bool CRemoteProcessorServer::start(string &error)
     return true;
 }
 
-void CRemoteProcessorServer::stop()
+bool CRemoteProcessorServer::stop()
 {
     // Check state
     if (!_bIsStarted) {
-
-        return;
+        return true;
     }
 
-    // Cause exiting of the thread
+    // Cause exiting of the processing loop
     uint8_t ucData = 0;
     if (not utility::fullWrite(_aiInbandPipe[1], &ucData, sizeof(ucData))) {
-        std::cerr << "Could not query command processor thread to terminate: "
+        std::cerr << "Could not query command processor loop to terminate: "
                      "fail to write on inband pipe: "
                   << strerror(errno) << std::endl;
-        assert(false);
+        return false;
     }
+
+    return true;
 }
 
-void CRemoteProcessorServer::process(IRemoteCommandHandler &commandHandler)
+bool CRemoteProcessorServer::process(IRemoteCommandHandler &commandHandler)
 {
     struct pollfd _aPollFds[2];
 
@@ -130,11 +131,11 @@ void CRemoteProcessorServer::process(IRemoteCommandHandler &commandHandler)
             if (not utility::fullRead(_aiInbandPipe[0], &ucData, sizeof(ucData))) {
                     std::cerr << "Remote processor could not receive exit request"
                               << strerror(errno) << std::endl;
-                    assert(false);
+                    return false;
             }
 
             // Exit
-            return;
+            return true;
         }
     }
 }

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -124,11 +124,6 @@ void CRemoteProcessorServer::stop()
     _pListeningSocket = NULL;
 }
 
-bool CRemoteProcessorServer::isStarted() const
-{
-    return _bIsStarted;
-}
-
 void CRemoteProcessorServer::run()
 {
     struct pollfd _aPollFds[2];

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -51,6 +51,9 @@ CRemoteProcessorServer::CRemoteProcessorServer(uint16_t uiPort, IRemoteCommandHa
 CRemoteProcessorServer::~CRemoteProcessorServer()
 {
     stop();
+
+    // Remove listening socket
+    delete _pListeningSocket;
 }
 
 // State
@@ -74,15 +77,6 @@ bool CRemoteProcessorServer::start(string &error)
 
     // Thread needs to access to the listning socket.
     _pListeningSocket = pListeningSocket.get();
-    // Create thread
-    try {
-        thread = std::thread(&CRemoteProcessorServer::run, this);
-    }
-    catch (std::exception &e) {
-        error = "Could not create a remote processor thread: " + std::string(e.what());
-        return false;
-    }
-
     // State
     _bIsStarted = true;
     pListeningSocket.release();
@@ -106,22 +100,6 @@ void CRemoteProcessorServer::stop()
                   << strerror(errno) << std::endl;
         assert(false);
     }
-
-    // Join thread
-    try {
-        thread.join();
-    }
-    catch (std::exception &e) {
-        std::cout << "Could not join with remote processor thread: "
-                  << std::string(e.what()) << std::endl;
-        assert(false);
-    }
-
-    _bIsStarted = false;
-
-    // Remove listening socket
-    delete _pListeningSocket;
-    _pListeningSocket = NULL;
 }
 
 void CRemoteProcessorServer::run()

--- a/remote-processor/RemoteProcessorServer.h
+++ b/remote-processor/RemoteProcessorServer.h
@@ -39,23 +39,22 @@ class IRemoteCommandHandler;
 class CRemoteProcessorServer : public IRemoteProcessorServerInterface
 {
 public:
-    CRemoteProcessorServer(uint16_t uiPort, IRemoteCommandHandler* pCommandHandler);
+    CRemoteProcessorServer(uint16_t uiPort);
     virtual ~CRemoteProcessorServer();
 
     // State
     virtual bool start(std::string &error);
     virtual void stop();
-    void run();
+    void process(IRemoteCommandHandler &commandHandler);
 
 private:
 
     // New connection
-    void handleNewConnection();
+    void handleNewConnection(IRemoteCommandHandler &commandHandler);
 
     // Port number
     uint16_t _uiPort;
-    // Command handler
-    IRemoteCommandHandler* _pCommandHandler;
+
     // State
     bool _bIsStarted;
     // Listening socket

--- a/remote-processor/RemoteProcessorServer.h
+++ b/remote-processor/RemoteProcessorServer.h
@@ -45,7 +45,6 @@ public:
     // State
     virtual bool start(std::string &error);
     virtual void stop();
-    virtual bool isStarted() const;
 
 private:
     // Thread

--- a/remote-processor/RemoteProcessorServer.h
+++ b/remote-processor/RemoteProcessorServer.h
@@ -45,10 +45,9 @@ public:
     // State
     virtual bool start(std::string &error);
     virtual void stop();
+    void run();
 
 private:
-    // Thread
-    void run();
 
     // New connection
     void handleNewConnection();
@@ -63,7 +62,5 @@ private:
     CListeningSocket* _pListeningSocket;
     // Inband pipe
     int _aiInbandPipe[2];
-    // Thread
-    std::thread thread;
 };
 

--- a/remote-processor/RemoteProcessorServer.h
+++ b/remote-processor/RemoteProcessorServer.h
@@ -44,8 +44,8 @@ public:
 
     // State
     virtual bool start(std::string &error);
-    virtual void stop();
-    void process(IRemoteCommandHandler &commandHandler);
+    virtual bool stop();
+    bool process(IRemoteCommandHandler &commandHandler);
 
 private:
 

--- a/remote-processor/RemoteProcessorServerInterface.h
+++ b/remote-processor/RemoteProcessorServerInterface.h
@@ -36,7 +36,7 @@ class IRemoteProcessorServerInterface
 {
 public:
     virtual bool start(std::string &strError) = 0;
-    virtual void stop() = 0;
+    virtual bool stop() = 0;
 
     /* FIXME this was missing but is explicitly called */
     virtual ~IRemoteProcessorServerInterface() {}

--- a/remote-processor/RemoteProcessorServerInterface.h
+++ b/remote-processor/RemoteProcessorServerInterface.h
@@ -37,7 +37,6 @@ class IRemoteProcessorServerInterface
 public:
     virtual bool start(std::string &strError) = 0;
     virtual void stop() = 0;
-    virtual bool isStarted() const = 0;
 
     /* FIXME this was missing but is explicitly called */
     virtual ~IRemoteProcessorServerInterface() {}

--- a/remote-processor/Socket.cpp
+++ b/remote-processor/Socket.cpp
@@ -90,34 +90,6 @@ void CSocket::initSockAddrIn(struct sockaddr_in* pSockAddrIn, uint32_t uiInAddr,
     bzero(&pSockAddrIn->sin_zero, sizeof(pSockAddrIn->sin_zero));
 }
 
-// Non blocking state
-void CSocket::setNonBlocking(bool bNonBlocking)
-{
-    int iFlags = fcntl(_iSockFd, F_GETFL, 0);
-
-    assert(iFlags != -1);
-
-    if (bNonBlocking) {
-
-        iFlags |= O_NONBLOCK;
-    } else {
-
-        iFlags &= ~O_NONBLOCK;
-    }
-    fcntl(_iSockFd, F_SETFL, iFlags);
-}
-
-// Communication timeout
-void CSocket::setTimeout(uint32_t uiMilliseconds)
-{
-    struct timeval tv;
-    tv.tv_sec = uiMilliseconds / 1000;
-    tv.tv_usec = (uiMilliseconds % 1000) * 1000;
-
-    setsockopt(_iSockFd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
-    setsockopt(_iSockFd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-}
-
 // Read
 bool CSocket::read(void* pvData, uint32_t uiSize)
 {

--- a/remote-processor/Socket.h
+++ b/remote-processor/Socket.h
@@ -50,12 +50,6 @@ public:
     CSocket(int iSockId);
     virtual ~CSocket();
 
-    // Non blocking state
-    void setNonBlocking(bool bNonBlocking);
-
-    // Communication timeout
-    void setTimeout(uint32_t uiMilliseconds);
-
     /* Read data
      *
      * On failure errno will be set appropriately (see send).

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -62,75 +62,6 @@ CTestPlatform::CTestPlatform(const string& strClass, int iPortNumber) :
     _pParameterMgrPlatformConnector(new CParameterMgrPlatformConnector(strClass)),
     _pParameterMgrPlatformConnectorLogger(new CParameterMgrPlatformConnectorLogger)
 {
-    _pCommandHandler = new CCommandHandler(this);
-
-    // Add command parsers
-    _pCommandHandler->addCommandParser("exit", &CTestPlatform::exit,
-                                       0, "", "Exit TestPlatform");
-    _pCommandHandler->addCommandParser(
-        "createExclusiveSelectionCriterionFromStateList",
-        &CTestPlatform::createExclusiveSelectionCriterionFromStateList,
-        2, "<name> <stateList>",
-        "Create inclusive selection criterion from state name list");
-    _pCommandHandler->addCommandParser(
-        "createInclusiveSelectionCriterionFromStateList",
-        &CTestPlatform::createInclusiveSelectionCriterionFromStateList,
-        2, "<name> <stateList>",
-        "Create exclusive selection criterion from state name list");
-
-    _pCommandHandler->addCommandParser(
-        "createExclusiveSelectionCriterion",
-        &CTestPlatform::createExclusiveSelectionCriterion,
-        2, "<name> <nbStates>", "Create inclusive selection criterion");
-    _pCommandHandler->addCommandParser(
-        "createInclusiveSelectionCriterion",
-        &CTestPlatform::createInclusiveSelectionCriterion,
-        2, "<name> <nbStates>", "Create exclusive selection criterion");
-
-    _pCommandHandler->addCommandParser("start", &CTestPlatform::startParameterMgr,
-                                       0, "", "Start ParameterMgr");
-
-    _pCommandHandler->addCommandParser("setCriterionState", &CTestPlatform::setCriterionState,
-                                       2, "<name> <state>",
-                                       "Set the current state of a selection criterion");
-    _pCommandHandler->addCommandParser(
-        "applyConfigurations",
-        &CTestPlatform::applyConfigurations,
-        0, "", "Apply configurations selected by current selection criteria states");
-
-    _pCommandHandler->addCommandParser(
-        "setFailureOnMissingSubsystem",
-        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setFailureOnMissingSubsystem>,
-        1, "true|false", "Set policy for missing subsystems, "
-                         "either abort start or fallback on virtual subsystem.");
-    _pCommandHandler->addCommandParser(
-        "getMissingSubsystemPolicy",
-        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getFailureOnMissingSubsystem>,
-        0, "", "Get policy for missing subsystems, "
-               "either abort start or fallback on virtual subsystem.");
-
-    _pCommandHandler->addCommandParser(
-        "setFailureOnFailedSettingsLoad",
-        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setFailureOnFailedSettingsLoad>,
-        1, "true|false",
-        "Set policy for failed settings load, either abort start or continue without domains.");
-    _pCommandHandler->addCommandParser(
-        "getFailedSettingsLoadPolicy",
-        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getFailureOnFailedSettingsLoad>,
-        0, "",
-        "Get policy for failed settings load, either abort start or continue without domains.");
-
-    _pCommandHandler->addCommandParser(
-        "setValidateSchemasOnStart",
-        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setValidateSchemasOnStart>,
-        1, "true|false",
-        "Set policy for schema validation based on .xsd files (false by default).");
-    _pCommandHandler->addCommandParser(
-        "getValidateSchemasOnStart",
-        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getValidateSchemasOnStart>,
-        0, "",
-        "Get policy for schema validation based on .xsd files.");
-
     // Create server
     _pRemoteProcessorServer = new CRemoteProcessorServer(iPortNumber);
 
@@ -140,7 +71,6 @@ CTestPlatform::CTestPlatform(const string& strClass, int iPortNumber) :
 CTestPlatform::~CTestPlatform()
 {
     delete _pRemoteProcessorServer;
-    delete _pCommandHandler;
     delete _pParameterMgrPlatformConnectorLogger;
     delete _pParameterMgrPlatformConnector;
 }
@@ -162,7 +92,76 @@ bool CTestPlatform::run(std::string& strError)
         return false;
     }
 
-    _pRemoteProcessorServer->process(*_pCommandHandler);
+    CCommandHandler commandHandler(this);
+
+    // Add command parsers
+    commandHandler.addCommandParser("exit", &CTestPlatform::exit,
+                                       0, "", "Exit TestPlatform");
+    commandHandler.addCommandParser(
+        "createExclusiveSelectionCriterionFromStateList",
+        &CTestPlatform::createExclusiveSelectionCriterionFromStateList,
+        2, "<name> <stateList>",
+        "Create inclusive selection criterion from state name list");
+    commandHandler.addCommandParser(
+        "createInclusiveSelectionCriterionFromStateList",
+        &CTestPlatform::createInclusiveSelectionCriterionFromStateList,
+        2, "<name> <stateList>",
+        "Create exclusive selection criterion from state name list");
+
+    commandHandler.addCommandParser(
+        "createExclusiveSelectionCriterion",
+        &CTestPlatform::createExclusiveSelectionCriterion,
+        2, "<name> <nbStates>", "Create inclusive selection criterion");
+    commandHandler.addCommandParser(
+        "createInclusiveSelectionCriterion",
+        &CTestPlatform::createInclusiveSelectionCriterion,
+        2, "<name> <nbStates>", "Create exclusive selection criterion");
+
+    commandHandler.addCommandParser("start", &CTestPlatform::startParameterMgr,
+                                       0, "", "Start ParameterMgr");
+
+    commandHandler.addCommandParser("setCriterionState", &CTestPlatform::setCriterionState,
+                                       2, "<name> <state>",
+                                       "Set the current state of a selection criterion");
+    commandHandler.addCommandParser(
+        "applyConfigurations",
+        &CTestPlatform::applyConfigurations,
+        0, "", "Apply configurations selected by current selection criteria states");
+
+    commandHandler.addCommandParser(
+        "setFailureOnMissingSubsystem",
+        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setFailureOnMissingSubsystem>,
+        1, "true|false", "Set policy for missing subsystems, "
+                         "either abort start or fallback on virtual subsystem.");
+    commandHandler.addCommandParser(
+        "getMissingSubsystemPolicy",
+        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getFailureOnMissingSubsystem>,
+        0, "", "Get policy for missing subsystems, "
+               "either abort start or fallback on virtual subsystem.");
+
+    commandHandler.addCommandParser(
+        "setFailureOnFailedSettingsLoad",
+        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setFailureOnFailedSettingsLoad>,
+        1, "true|false",
+        "Set policy for failed settings load, either abort start or continue without domains.");
+    commandHandler.addCommandParser(
+        "getFailedSettingsLoadPolicy",
+        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getFailureOnFailedSettingsLoad>,
+        0, "",
+        "Get policy for failed settings load, either abort start or continue without domains.");
+
+    commandHandler.addCommandParser(
+        "setValidateSchemasOnStart",
+        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setValidateSchemasOnStart>,
+        1, "true|false",
+        "Set policy for schema validation based on .xsd files (false by default).");
+    commandHandler.addCommandParser(
+        "getValidateSchemasOnStart",
+        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getValidateSchemasOnStart>,
+        0, "",
+        "Get policy for schema validation based on .xsd files.");
+
+    _pRemoteProcessorServer->process(commandHandler);
 
     return true;
 }

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -145,27 +145,15 @@ CTestPlatform::~CTestPlatform()
     delete _pParameterMgrPlatformConnector;
 }
 
-bool CTestPlatform::waitForExit(std::string& strError)
-{
-    try {
-        exitRequest.get_future().wait();
-        return true;
-    } catch (std::exception& e) {
-        strError = e.what();
-        return false;
-    }
-}
-
 CTestPlatform::CommandReturn CTestPlatform::exit(
     const IRemoteCommand& /*command*/, string& /*strResult*/)
 {
-    // Notify of the exit request to quit application
-    exitRequest.set_value();
+    _pRemoteProcessorServer->stop();
 
     return CTestPlatform::CCommandHandler::EDone;
 }
 
-bool CTestPlatform::load(std::string& strError)
+bool CTestPlatform::run(std::string& strError)
 {
     // Start remote processor server
     if (!_pRemoteProcessorServer->start(strError)) {
@@ -173,6 +161,8 @@ bool CTestPlatform::load(std::string& strError)
         strError = "TestPlatform: Unable to start remote processor server: " + strError;
         return false;
     }
+
+    _pRemoteProcessorServer->run();
 
     return true;
 }

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -161,9 +161,7 @@ bool CTestPlatform::run(std::string& strError)
         0, "",
         "Get policy for schema validation based on .xsd files.");
 
-    _pRemoteProcessorServer->process(commandHandler);
-
-    return true;
+    return _pRemoteProcessorServer->process(commandHandler);
 }
 
 //////////////// Remote command parsers

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -132,7 +132,7 @@ CTestPlatform::CTestPlatform(const string& strClass, int iPortNumber) :
         "Get policy for schema validation based on .xsd files.");
 
     // Create server
-    _pRemoteProcessorServer = new CRemoteProcessorServer(iPortNumber, _pCommandHandler);
+    _pRemoteProcessorServer = new CRemoteProcessorServer(iPortNumber);
 
     _pParameterMgrPlatformConnector->setLogger(_pParameterMgrPlatformConnectorLogger);
 }
@@ -162,7 +162,7 @@ bool CTestPlatform::run(std::string& strError)
         return false;
     }
 
-    _pRemoteProcessorServer->run();
+    _pRemoteProcessorServer->process(*_pCommandHandler);
 
     return true;
 }

--- a/test/test-platform/TestPlatform.h
+++ b/test/test-platform/TestPlatform.h
@@ -33,7 +33,6 @@
 #include "RemoteCommandHandlerTemplate.h"
 #include <string>
 #include <list>
-#include <future>
 
 class CParameterMgrPlatformConnectorLogger;
 class CRemoteProcessorServer;
@@ -48,10 +47,7 @@ public:
     virtual ~CTestPlatform();
 
     // Init
-    bool load(std::string& strError);
-
-    /** Wait for a remote client exit request */
-    bool waitForExit(std::string& strError);
+    bool run(std::string& strError);
 
 private:
     //////////////// Remote command parsers
@@ -155,8 +151,5 @@ private:
 
     // Remote Processor Server
     CRemoteProcessorServer* _pRemoteProcessorServer;
-
-    /** Future used to notify of an exit command */
-    std::promise<void> exitRequest;
 };
 

--- a/test/test-platform/TestPlatform.h
+++ b/test/test-platform/TestPlatform.h
@@ -146,9 +146,6 @@ private:
     // Logger
     CParameterMgrPlatformConnectorLogger* _pParameterMgrPlatformConnectorLogger;
 
-    // Command Handler
-    CCommandHandler* _pCommandHandler;
-
     // Remote Processor Server
     CRemoteProcessorServer* _pRemoteProcessorServer;
 };

--- a/test/test-platform/main.cpp
+++ b/test/test-platform/main.cpp
@@ -42,16 +42,6 @@ using namespace std;
 
 const int iDefaultPortNumber = 5001;
 
-// Starts test-platform in blocking mode
-static bool startBlockingTestPlatform(const char *filePath, int portNumber, string &strError)
-{
-    // Create param mgr
-    CTestPlatform testPlatform(filePath, portNumber);
-
-    // Start platformmgr
-    return testPlatform.load(strError) && testPlatform.waitForExit(strError);
-}
-
 static void showUsage()
 {
     cerr << "test-platform [-h] <file path> [port number, default "
@@ -106,9 +96,7 @@ int main(int argc, char *argv[])
     portNumber = argc > indexFilePath + 1 ? atoi(argv[indexFilePath + 1]) : iDefaultPortNumber;
 
     string strError;
-    bool startError = startBlockingTestPlatform(filePath, portNumber, strError);
-
-    if (!startError) {
+    if (!CTestPlatform(filePath, portNumber).run(strError)) {
 
         cerr << "Test-platform error:" << strError.c_str() << endl;
         return -1;


### PR DESCRIPTION
Split the RemoteProcessorServer into a server object (in charge of listening and processing messages from a pipe) and background server in charge of threading the server object.
It allows the test platform to bypass thread creation and avoid useless synchronization. 

It also changes the way parameter library is linking with remote processor: this library is not opened through a dlopen any more but parameter links with dynamic remote processor library instead.

Creating or not the remote processor server depends now only of the tuning allowed flag set within the configuration file of the Parameter Framework.

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/185%23issuecomment-138493486%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/185%23issuecomment-138493861%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/185%23issuecomment-138494720%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/185%23issuecomment-138493486%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40cc6565%20Please%20fix%20all%20the%20commit%20messages.%22%2C%20%22created_at%22%3A%20%222015-09-08T09%3A23%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40cc6565%20%40OznOg%20Please%20provide%20a%20more%20complete%20Pull%20Request%20message%20mentioning%20the%20new%20separation%20of%20responsibilities.%22%2C%20%22created_at%22%3A%20%222015-09-08T09%3A25%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%2C%20in%20most%20commit%20message%20headlines%2C%20it%20is%20impossible%20to%20tell%20which%20component%20is%20changed.%5Cr%5Cn%5Cr%5Cne.g.%5Cr%5Cn%5Cr%5Cn%20%20%20%20move%20commands%20into%20where%20it%20belongs%20%5Cr%5Cn%5Cr%5Cnbecomes%5Cr%5Cn%5Cr%5Cn%20%20%20%20test-platform%3A%20move%20command%20definitions%20to%20the%20thread%20function%22%2C%20%22created_at%22%3A%20%222015-09-08T09%3A28%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/185#issuecomment-138493486'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @cc6565 Please fix all the commit messages.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @cc6565 @OznOg Please provide a more complete Pull Request message mentioning the new separation of responsibilities.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Also, in most commit message headlines, it is impossible to tell which component is changed.
e.g.
move commands into where it belongs
becomes
test-platform: move command definitions to the thread function


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/185?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/185?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/185'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>