### PR TITLE
CMake: rely on CMAKE_PREFIX_PATH for finding user-provided dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ directory, you may do so by passing it to the `cmake .` command; e.g.
 
     cmake -DCMAKE_INSTALL_PREFIX=/path/to/custom/install .
 
+If you want to provide your own dependencies (e.g. your own version of
+libxml2), you should pass the base paths as the `CMAKE_PREFIX_PATH` variable,
+e.g.:
+
+    cmake -DCMAKE_PREFIX_PATH='/path/to/dependency1/;/path/to/dependency2/'
+
+For more information on how to use `CMAKE_PREFIX_PATH`, see CMake's
+documentation.
+
 Also, CMake can build a project out-of-tree, which is the recommended method:
 
     mkdir /path/to/build/directory
@@ -80,3 +89,6 @@ Also, CMake can build a project out-of-tree, which is the recommended method:
 
 After an install you may want to run the parameter-framework tests with
 `make test`.
+
+You may take a look at `.travis.yml` and `appveyor.yml` for examples on how we
+build the Parameter Framework in the CI.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ cache:
 - C:\ProgramData\chocolatey\lib -> appveyor.yml
 build_script:
 - mkdir build\64bits-release& cd build\64bits-release
-- cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -Dlibxml2_prebuilts="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64" ..\..
+- cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64" ..\..
 - cmake --build . --config release --target xmlserializer
 - cd ..& mkdir 64bits-debug& cd 64bits-debug
-- cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -Dlibxml2_prebuilts="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64-debug" ..\..
+- cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64-debug" ..\..
 - cmake --build . --config debug --target xmlserializer

--- a/xmlserializer/CMakeLists.txt
+++ b/xmlserializer/CMakeLists.txt
@@ -34,9 +34,6 @@ add_library(xmlserializer SHARED
     XmlMemoryDocSource.cpp
     XmlStreamDocSink.cpp)
 
-if (WIN32)
-    set(CMAKE_PREFIX_PATH "${libxml2_prebuilts}")
-endif()
 find_package(LibXml2 REQUIRED)
 
 # libxml2 has been found, but does it support XInclude ?


### PR DESCRIPTION
I used to think that CMAKE_PREFIX_PATH should not be set by the user (the one
running the "cmake" commands) but it turns out, it is the correct way to tell
CMake where to find user-provided packages, includes, libs, etc.

In order to set CMAKE_PREFIX_PATH to multiple paths, it can be set to a
semicolon-separated list of values (this is the case for a lot of other
variables in CMake).

Signed-off-by: David Wagner <david.wagner@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/191?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/191'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>