### PR TITLE
Clean up of CParameterAccessContext constructors

### DIFF
--- a/parameter/ParameterAccessContext.cpp
+++ b/parameter/ParameterAccessContext.cpp
@@ -34,21 +34,19 @@
 CParameterAccessContext::CParameterAccessContext(std::string& strError,
                                                  CParameterBlackboard* pParameterBlackboard,
                                                  bool bValueSpaceIsRaw,
-                                                 bool bOutputRawFormatIsHex,
-                                                 uint32_t uiBaseOffset)
+                                                 bool bOutputRawFormatIsHex)
     : base(strError), _pParameterBlackboard(pParameterBlackboard),
     _bValueSpaceIsRaw(bValueSpaceIsRaw), _bOutputRawFormatIsHex(bOutputRawFormatIsHex),
-    _bBigEndianSubsystem(false), _bAutoSync(true), _uiBaseOffset(uiBaseOffset)
+    _bBigEndianSubsystem(false), _bAutoSync(true), _uiBaseOffset(0)
 {
 }
 
 CParameterAccessContext::CParameterAccessContext(std::string& strError,
                                                  bool bBigEndianSubsystem,
-                                                 CParameterBlackboard* pParameterBlackboard,
-                                                 uint32_t uiBaseOffset)
+                                                 CParameterBlackboard* pParameterBlackboard)
     : base(strError), _pParameterBlackboard(pParameterBlackboard), _bValueSpaceIsRaw(false),
     _bOutputRawFormatIsHex(false), _bBigEndianSubsystem(bBigEndianSubsystem), _bAutoSync(true),
-    _uiBaseOffset(uiBaseOffset)
+    _uiBaseOffset(0)
 {
 }
 

--- a/parameter/ParameterAccessContext.h
+++ b/parameter/ParameterAccessContext.h
@@ -38,15 +38,22 @@ class CParameterBlackboard;
 class CParameterAccessContext : public CErrorContext
 {
 public:
+    /**
+     * Constructors
+     *
+     * @param[in] pParameterBlackboard The blackboard the parameter value will be read from or
+     * written to
+     * @param[in] bValueSpaceIsRaw true if value space is raw, false if it is real
+     * @param[in] bOutputRawFormatIsHex true if output raw format is hexa, false it is decimal
+     * @param[out] strError The output error message
+     *
     CParameterAccessContext(std::string& strError,
                             CParameterBlackboard* pParameterBlackboard,
                             bool bValueSpaceIsRaw,
-                            bool bOutputRawFormatIsHex = false,
-                            uint32_t uiOffsetBase = 0);
+                            bool bOutputRawFormatIsHex = false);
     CParameterAccessContext(std::string& strError,
                             bool bBigEndianSubsystem,
-                            CParameterBlackboard* pParameterBlackboard,
-                            uint32_t uiOffsetBase = 0);
+                            CParameterBlackboard* pParameterBlackboard);
     CParameterAccessContext(std::string& strError);
 
     // ParameterBlackboard


### PR DESCRIPTION
Removed unnecessary uiBaseOffset from the constructors signature as base offset
is always passed through setBaseOffset() method.

Signed-off-by: Patrick Benavoli <patrick.benavoli@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/196?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/196'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>