### PR TITLE
Distinguish between no & no new applicable configurations

### DIFF
--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -829,13 +829,25 @@ string CConfigurableDomain::getLastAppliedConfigurationName() const
 // Pending configuration
 string CConfigurableDomain::getPendingConfigurationName() const
 {
-    const CDomainConfiguration* pPendingConfiguration = getPendingConfiguration();
+    const CDomainConfiguration* pApplicableDomainConfiguration = findApplicableDomainConfiguration();
 
-    if (pPendingConfiguration) {
+    if (!pApplicableDomainConfiguration) {
 
-        return pPendingConfiguration->getName();
+        // No configuration is pending
+        return "<none>";
     }
-    return "<none>";
+
+    // Check it will be applied
+    if (pApplicableDomainConfiguration != _pLastAppliedConfiguration) {
+
+        // Found config will get applied
+        return pApplicableDomainConfiguration->getName();
+    }
+    else {
+
+        // Same configuration as current
+        return "";
+    }
 }
 
 // Ensure validity on whole domain from main blackboard


### PR DESCRIPTION
This patch allows additional distinction in the displaying of pending
configurations:
- if there's no applicable configuration the pending configuration will be
  shown as `"<none>"`;
- if the applicable configuration is same as currently applied one, it will
be displayed as an empty string `""`.

Signed-off-by: Patrick Benavoli <patrick.benavoli@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/197%23issuecomment-139179062%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-10T09%3A19%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dawagner%20%40OznOg%20please%20review.%22%2C%20%22created_at%22%3A%20%222015-09-10T13%3A26%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206708084b3edb4aca13ee762e828896356d67b6ec%20parameter/ConfigurableDomain.cpp%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/197%23discussion_r39140052%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Conflicting%20with%20commit%20message.%5Cr%5CnNow%3A%20if%20there%27s%20no%20applicable%20configuration%20the%20pending%20configuration%20will%20be%20shown%20as%20%5C%22%5C%22%3B%5Cr%5CnShould%20be%3A%20if%20there%27s%20no%20applicable%20configuration%20the%20pending%20configuration%20will%20be%20shown%20as%20%5C%22%3Cnone%3E%5C%22%3B%22%2C%20%22created_at%22%3A%20%222015-09-10T09%3A20%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableDomain.cpp%3AL829-854%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/197%23issuecomment-139179062%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/197%23discussion_r39140052%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/197%23issuecomment-139233995%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/197#issuecomment-139179062'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> @dawagner @OznOg please review.
- [x] <a href='#crh-comment-Pull 6708084b3edb4aca13ee762e828896356d67b6ec parameter/ConfigurableDomain.cpp 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/197#discussion_r39140052'>File: parameter/ConfigurableDomain.cpp:L829-854</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Conflicting with commit message.
Now: if there's no applicable configuration the pending configuration will be shown as "";
Should be: if there's no applicable configuration the pending configuration will be shown as "<none>";


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/197?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/197?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/197?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/197'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>