### PR TITLE
Fix some syntax and coding errors in DynamicLibrary for windows

### DIFF
--- a/utility/DynamicLibrary.hpp
+++ b/utility/DynamicLibrary.hpp
@@ -85,6 +85,11 @@ private:
     void *_handle;
 
     /**
+     * Path to the library
+     */
+    const std::string _path;
+
+    /**
     * OS Specific library name patterns
     * @{
     */

--- a/utility/posix/DynamicLibrary.cpp
+++ b/utility/posix/DynamicLibrary.cpp
@@ -41,10 +41,9 @@ const std::string DynamicLibrary::_osLibraryPrefix = "lib";
 const std::string DynamicLibrary::_osLibrarySuffix = ".so";
 
 DynamicLibrary::DynamicLibrary(const std::string& path)
+    : _path(osSanitizePathName(path))
 {
-    std::string sanitizedPath = osSanitizePathName(path);
-
-    _handle = dlopen(sanitizedPath.c_str(), RTLD_LAZY);
+    _handle = dlopen(_path.c_str(), RTLD_LAZY);
 
     if (_handle == nullptr) {
 

--- a/utility/windows/DynamicLibrary.cpp
+++ b/utility/windows/DynamicLibrary.cpp
@@ -41,18 +41,17 @@ const std::string DynamicLibrary::_osLibraryPrefix = "";
 const std::string DynamicLibrary::_osLibrarySuffix = ".dll";
 
 DynamicLibrary::DynamicLibrary(const std::string& path)
+    : _path(osSanitizePathName(path))
 {
-    static_assert(sizeof(void *) == (sizeof(HMODULE), "Incompatible object size");
+    static_assert(sizeof(void *) == sizeof(HMODULE), "Incompatible object size");
 
-    std::string sanitizedPath = osSanitizePathName(path);
-
-    HMODULE module = LoadLibrary(sanitizedPath.c_str()));
+    HMODULE module = LoadLibrary(_path.c_str());
 
     _handle = reinterpret_cast<void *>(module);
 
     if (_handle == nullptr) {
 
-        throw std::runtime_error(sanitizedPath + ": cannot open shared object file.");
+        throw std::runtime_error(_path + ": cannot open shared object file.");
     }
 }
 
@@ -67,11 +66,11 @@ void *DynamicLibrary::osGetSymbol(const std::string& symbol) const
 {
     HMODULE module = reinterpret_cast<HMODULE>(_handle);
 
-    void *sym = reinterpret_cast<void *>(GetProcAddress(Module, symbol.c_str()));
+    void *sym = reinterpret_cast<void *>(GetProcAddress(module, symbol.c_str()));
 
     if (sym == nullptr) {
 
-        throw std::runtime_error(sanitizedPath + ": undefined symbol: " + symbol);
+        throw std::runtime_error(_path + ": undefined symbol: " + symbol);
     }
 
     return sym;


### PR DESCRIPTION
Since we do not yet compile it in the CI, we missed some errors.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/201%23issuecomment-139189952%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39142925%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39143002%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39143015%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39143071%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39143155%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39143174%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39148553%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23issuecomment-139207532%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/201%23issuecomment-139224373%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/201%23issuecomment-139189952%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40miguelgaio%20Please%20review.%22%2C%20%22created_at%22%3A%20%222015-09-10T09%3A55%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-10T11%3A17%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Could%20you%20open%20a%20bug%20for%20our%20remaks%20%3F%20Ie%3A%20open%20a%20bug%20an%20link%20to%20this%20PR%20to%20know%20what%20to%20fix.%22%2C%20%22created_at%22%3A%20%222015-09-10T12%3A44%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20cb60cdb34182315a74f94e503d600cd7ddd35a19%20utility/DynamicLibrary.hpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39142925%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20we%20really%20need%20to%20add%20this%20variable%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-10T09%3A57%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20not%2C%20we%20can%27t%20refer%20to%20it%20later%20%28e.g.%20in%20error%20messages%29.%20It%20is%20not%20a%20must%2C%20but%20it%20seemed%20useful%20on%20windows.%22%2C%20%22created_at%22%3A%20%222015-09-10T09%3A58%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/DynamicLibrary.hpp%3AL85-96%22%7D%2C%20%22Pull%20cb60cdb34182315a74f94e503d600cd7ddd35a19%20utility/windows/DynamicLibrary.cpp%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39143071%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%2B%20%5C%22%20in%20library%20%5C%22%20%2B%20_path%29%3B%22%2C%20%22created_at%22%3A%20%222015-09-10T09%3A59%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22ditto%22%2C%20%22created_at%22%3A%20%222015-09-10T10%3A01%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/windows/DynamicLibrary.cpp%3AL66-77%22%7D%2C%20%22Pull%20cb60cdb34182315a74f94e503d600cd7ddd35a19%20utility/windows/DynamicLibrary.cpp%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/201%23discussion_r39143015%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20add%20the%20orginal%20path%20in%20the%20message%3A%5Cr%5Cn...file.%20Path%20generated%20from%3A%20%5C%22%20%2B%20path%29%3B%22%2C%20%22created_at%22%3A%20%222015-09-10T09%3A59%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Unrelated%20to%20this%20patch.%20Feel%20free%20to%20submit%20another%20patch%20on%20top%20of%20this.%22%2C%20%22created_at%22%3A%20%222015-09-10T10%3A01%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20personally%20prefere%20when%20strings%20displayed%20are%20surrounded%20by%20%27%27%20so%20that%20when%20the%20lib%20name%20is%20empty%2C%20the%20error%20message%20is%20explicit%20%28otherwise%2C%20you%20alwas%20have%20the%20doubt%20of%20if%20the%20name%20was%20supposed%20to%20be%20displayed%20or%20not%22%2C%20%22created_at%22%3A%20%222015-09-10T11%3A16%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/windows/DynamicLibrary.cpp%3AL41-58%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull cb60cdb34182315a74f94e503d600cd7ddd35a19 utility/DynamicLibrary.hpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/201#discussion_r39142925'>File: utility/DynamicLibrary.hpp:L85-96</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> Do we really need to add this variable ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> If not, we can't refer to it later (e.g. in error messages). It is not a must, but it seemed useful on windows.
- [ ] <a href='#crh-comment-Pull cb60cdb34182315a74f94e503d600cd7ddd35a19 utility/windows/DynamicLibrary.cpp 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/201#discussion_r39143015'>File: utility/windows/DynamicLibrary.cpp:L41-58</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> maybe add the orginal path in the message:
...file. Path generated from: " + path);
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Unrelated to this patch. Feel free to submit another patch on top of this.
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> I personally prefere when strings displayed are surrounded by '' so that when the lib name is empty, the error message is explicit (otherwise, you alwas have the doubt of if the name was supposed to be displayed or not
- [ ] <a href='#crh-comment-Pull cb60cdb34182315a74f94e503d600cd7ddd35a19 utility/windows/DynamicLibrary.cpp 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/201#discussion_r39143071'>File: utility/windows/DynamicLibrary.cpp:L66-77</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> + " in library " + _path);
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> ditto
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/201#issuecomment-139189952'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @miguelgaio Please review.
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: Could you open a bug for our remaks ? Ie: open a bug an link to this PR to know what to fix.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/201?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/201?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/201'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>