### PR TITLE
Cut dependency between plugins and xmlserializer

### DIFF
--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -236,6 +236,11 @@ void CElement::setXmlNameAttribute(CXmlElement& xmlElement) const
     }
 }
 
+std::string CElement::getXmlNameAttribute(const CXmlElement& xmlElement)
+{
+    return xmlElement.getNameAttribute();
+}
+
 // Name
 void CElement::setName(const string& strName)
 {

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -120,6 +120,13 @@ public:
     virtual void childrenToXml(CXmlElement& xmlElement,
                                CXmlSerializingContext& serializingContext) const;
 
+    /**
+    * @return the "Name" attribute value of an xml element or
+    * empty string if attribute is not present
+    * @param[in] xmlElement the XML element
+    */
+    static std::string getXmlNameAttribute(const CXmlElement& xmlElement);
+
     // Content structure dump
     void dumpContent(std::string& strContent, CErrorContext& errorContext, const uint32_t uiDepth = 0) const;
 

--- a/parameter/NamedElementBuilderTemplate.h
+++ b/parameter/NamedElementBuilderTemplate.h
@@ -35,10 +35,8 @@ template <class ElementType>
 class TNamedElementBuilderTemplate : public CElementBuilder
 {
 public:
-    TNamedElementBuilderTemplate() : CElementBuilder() {}
-
     virtual CElement* createElement(const CXmlElement& xmlElement) const
     {
-        return new ElementType(xmlElement.getNameAttribute());
+        return new ElementType(CElement::getXmlNameAttribute(xmlElement));
     }
 };


### PR DESCRIPTION
Add CElement::getXmlNameAttribute() method to isolate the plugins from
xmlserializer.
This patch comes in preparation to exporting the necessary symbols to plugins
in Windows environement (using export macros).

Signed-off-by: Patrick Benavoli <patrick.benavoli@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/202%23issuecomment-139207654%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/202%23issuecomment-139215949%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/202%23issuecomment-139216148%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/202%23issuecomment-139207654%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22warning%2C%20kevin%20reworked%20it%20and%20seem%20to%20have%20doubts%20about%20usefulness%20of%20the%20patch%22%2C%20%22created_at%22%3A%20%222015-09-10T11%3A18%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20I%20reworked%20this%20patch%20%5Bin%20one%20of%20my%20branches%5D%28https%3A//github.com/01org/parameter-framework/compare/windows_port...krocard%3Aplugins_need_no_xml%29.%20But%20I%20did%20not%20created%20a%20pull%20request%20because%20I%20could%20not%20test%20the%20patch%20effect.%20Is%20it%20realy%20cutting%20any%20dependency%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-10T12%3A10%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20created%20a%20pull%20request%20with%20my%20rework.%20Adding%20my%20concern%20about%20it.%22%2C%20%22created_at%22%3A%20%222015-09-10T12%3A11%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/202#issuecomment-139207654'>General Comment</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> warning, kevin reworked it and seem to have doubts about usefulness of the patch
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Yes I reworked this patch [in one of my branches](https://github.com/01org/parameter-framework/compare/windows_port...krocard:plugins_need_no_xml). But I did not created a pull request because I could not test the patch effect. Is it realy cutting any dependency ?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I created a pull request with my rework. Adding my concern about it.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/202?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/202?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/202'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>