### PR TITLE
Disambiguate make_unique in case it is provided by the STL

### DIFF
--- a/parameter/SystemClass.cpp
+++ b/parameter/SystemClass.cpp
@@ -100,7 +100,7 @@ bool CSystemClass::loadSubsystems(string& strError,
     _pSubsystemLibrary->addElementBuilder("Virtual", new VirtualSubsystemBuilder(_logger));
     // Set virtual subsytem as builder fallback if required
     if (bVirtualSubsystemFallback) {
-        _pSubsystemLibrary->setDefaultBuilder(make_unique<VirtualSubsystemBuilder>(_logger));
+        _pSubsystemLibrary->setDefaultBuilder(utility::make_unique<VirtualSubsystemBuilder>(_logger));
     }
 
     // Add subsystem defined in shared libraries
@@ -212,7 +212,7 @@ bool CSystemClass::loadPlugins(list<string>& lstrPluginFiles, core::Results& err
 
         // Load attempt
         try {
-            auto library = make_unique<DynamicLibrary>(strPluginFileName);
+            auto library = utility::make_unique<DynamicLibrary>(strPluginFileName);
 
             // Load symbol from library
             auto subSystemBuilder = library->getSymbol<GetSubsystemBuilder>(strPluginSymbol);

--- a/utility/Memory.hpp
+++ b/utility/Memory.hpp
@@ -30,6 +30,8 @@
 
 #include <memory>
 
+namespace utility {
+
 /** Implementation of C++14's std::make_unique.
  *
  * TODO: Specialisation for array types is not implemented.
@@ -40,3 +42,4 @@ std::unique_ptr<T> make_unique(Args &&... args)
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
+} // namespace utility


### PR DESCRIPTION
std::make_unique is a C++14 addition but we are, for now, sticking with the
C++11 standard. Since we have defined our own make_unique function, we need to
disambiguate it for MSVC, which defines std::make_unique.

This is done by putting our make_unique in the 'utility' namespace.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/206%23issuecomment-139229303%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-10T13%3A06%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40OznOg%20It%20doesn%27t%20seem%20possible%20to%20choose%20a%20C%2B%2B%20standard%20%28cf.%20https%3A//msdn.microsoft.com/en-us/library/19z1t1wy.aspx%29.%20As%20a%20result%2C%20it%20is%20impossible%20to%20know%20against%20which%20standard%20we%20are%20compiling%20%28C%2B%2B11%20or%20C%2B%2B14%29.%20Which%20is%20why%20I%20prefer%20acting%20as%20if%20C%2B%2B14%20features%20weren%27t%20available.%22%2C%20%22created_at%22%3A%20%222015-09-10T13%3A20%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/206%23issuecomment-139229303%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/206%23issuecomment-139232228%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/206#issuecomment-139229303'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @OznOg It doesn't seem possible to choose a C++ standard (cf. https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx). As a result, it is impossible to know against which standard we are compiling (C++11 or C++14). Which is why I prefer acting as if C++14 features weren't available.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/206?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/206?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/206?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/206'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>