### PR TITLE
Windows: relax build errors by not promoting warnings to errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if (WIN32)
     # but doing so breaks compilation of windows headers...
     # Suppress warning 4127 (Conditional expression is constant) as it break
     # compilation when testing template value arguments or writing `while(true)`.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX /FI iso646.h -wd4127")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /FI iso646.h -wd4127")
 else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
 endif ()


### PR DESCRIPTION
Temporary workaround aimed at making our lives easier until all of the
Parameter Framework libraries compile.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/209%23issuecomment-139239264%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/209%23issuecomment-139317253%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/209%23issuecomment-139340561%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/209%23issuecomment-139239264%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20are%20removing%20werror%2C%20would%20it%20not%20be%20better%20to%20do%20W3%20instead%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-10T13%3A48%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40krocard%20Currently%2C%20we%20would%20need%20to%20compile%20with%20W1%20because%20we%20still%20have%20several%20level%203%20and%20level%202%20warnings.%5Cr%5Cn%5Cr%5CnI%20prefer%20showing%20all%20errors%20in%20order%20to%20have%20the%20CI%20compiling%20as%20many%20components%20as%20possible%20and%20tackle%20the%20warnings%20as%20technical%20debt.%22%2C%20%22created_at%22%3A%20%222015-09-10T17%3A24%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20I%20prefer%20showing%20all%20errors%20in%20order%20to%20have%20the%20CI%20compiling%20as%20many%20components%20as%20possible%20and%20tackle%20the%20warnings%20as%20technical%20debt.%5Cr%5Cn%5Cr%5CnI%20agree%20with%20this%20rational.%20The%20only%20problem%20is%20if%20we%20introduce%20new%20lvl2%20or%20lvl1%20warning.%20But%20I%20guess%20gcc/clang%20would%20raise%20them%20too.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-10T18%3A46%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/209#issuecomment-139239264'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> You are removing werror, would it not be better to do W3 instead ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard Currently, we would need to compile with W1 because we still have several level 3 and level 2 warnings.
I prefer showing all errors in order to have the CI compiling as many components as possible and tackle the warnings as technical debt.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> > I prefer showing all errors in order to have the CI compiling as many components as possible and tackle the warnings as technical debt.
I agree with this rational. The only problem is if we introduce new lvl2 or lvl1 warning. But I guess gcc/clang would raise them too. :+1:


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/209?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/209?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/209'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>