### PR TITLE
Create a ASSERT_ALWAYS macro as utility macro.

### DIFF
--- a/utility/AlwaysAssert.hpp
+++ b/utility/AlwaysAssert.hpp
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2015, Intel Corporation
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include <iostream>
+
+
+#ifdef NDEBUG
+#    include <exception>
+#    define ALWAYS_ASSERT_FAILURE(cond) std::terminate()
+#else
+#    include <cassert>
+#    define ALWAYS_ASSERT_FAILURE(cond) assert(cond)
+#endif
+
+// __func__ should be used as per C99 and C++11, but as visual studio 2013 isn't
+// compliant, use __FUNCTION__ which is compatible with linux and WIN32.
+
+
+#define ALWAYS_ASSERT(cond, iostr) \
+    do { \
+         if (!(cond)) { \
+           std::cerr << __FILE__ << ":" << __LINE__ << ":" << __FUNCTION__ \
+           << ": Assert '" #cond "' failed: " << iostr << std::endl; \
+            ALWAYS_ASSERT_FAILURE(cond); \
+         } \
+    } while (0)


### PR DESCRIPTION
When using the assert() function, the condition is not evaluated in
release mode, only in debug mode.

This new macro implements a condition verification that is build
type independent (active both in debug and release modes).

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/210%23issuecomment-139266943%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23issuecomment-140086278%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23issuecomment-142258090%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23issuecomment-142350057%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23issuecomment-142517903%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23issuecomment-142575955%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23issuecomment-142588908%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r39167691%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r39183498%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r39250715%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40074983%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40078911%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40089187%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40089188%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40113869%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40114031%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40114085%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40181217%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40193802%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194008%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194009%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194010%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194112%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194127%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194178%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194239%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194942%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194943%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194944%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40199197%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40199443%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40200218%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23issuecomment-139266943%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%20-%20You%20felt%20in%20a%20travis%20race.%20Sorry%2C%20please%20modify%20the%20patch.%5Cr%5Cn%20-%20Remove%20the%20change-id%20it%20does%20not%20need%20to%20be%20public.%5Cr%5Cn%3A-1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-10T14%3A40%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22why%20not%20just%20use%20abort%28%29%20all%20the%20time%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A07%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-22T11%3A22%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%20%40krocard%20%40miguelgaio%20%40OznOg%20%40cc6565%20please%20review%20%5E_%5E%27%20%22%2C%20%22created_at%22%3A%20%222015-09-22T17%3A04%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20you%20can%20abandon%20the%20patch%20replacing%20an%20abort%20with%20assert%20since%20%23244%20removed%20this%20code%22%2C%20%22created_at%22%3A%20%222015-09-23T07%3A19%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A45%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-23T12%3A53%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20df6f69a2d7e197b1f364f0fcf4c4b10ded957a86%20utility/AssertAlways.h%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40078911%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22-%20line%202%20long%20%28coding%20style%20max%20line%20length%20is%20100%29%5Cr%5Cn-%20s/false/%23cond/%22%2C%20%22created_at%22%3A%20%222015-09-22T12%3A19%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-22T14%3A01%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.h%3AL1-43%22%7D%2C%20%22Pull%20952d75b2e4c6f35f3e625d4f306b27c3ab18dc6a%20utility/AssertAlways.hpp%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40114085%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60TOP_ASSERT%60%20-%3E%20%60ALWAYS_ASSERT_FAILURE%60%22%2C%20%22created_at%22%3A%20%222015-09-22T17%3A14%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A45%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.hpp%3AL1-55%22%7D%2C%20%22Pull%2058919aed9d51d19af8d30e0e0d5ed92560038aa3%20utility/AssertAlways.hpp%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194127%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22cassert%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A47%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60%60%60%20cpp%5Cr%5Cn%23include%20%3Ccassert%3E%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A47%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A59%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.hpp%3AL1-55%22%7D%2C%20%22Pull%20350e7402270ba685753c520e784cc3b2bbe4c591%20utility/AssertAlways.hpp%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40193802%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22cassert%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A42%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%2C%20%7B%22body%22%3A%20%22sorry%20I%20don%27t%20understand.%20%3A8ball%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A47%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A59%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.hpp%3AL1-55%22%7D%2C%20%22Pull%20952d75b2e4c6f35f3e625d4f306b27c3ab18dc6a%20utility/AssertAlways.hpp%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40114031%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Name%20it%20%60ALWAYS_ASSERT%60%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-22T17%3A13%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A45%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.hpp%3AL1-55%22%7D%2C%20%22Pull%20531995a25b319d9dd9628e1ab91e06dd28c1f313%20utility/AssertAlways.h%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r39167691%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%20-%20coding%20style%5Cr%5Cn%20-%20Could%20you%20print%20the%20current%20line%20and%20function%20as%20the%20real%20assert%20%3F%20See%20our%20android%20assert_always%20for%20an%20example.%5Cr%5Cn%5Cr%5CnEdit%3A%20%5C%22Could%20you%20%7E%7Enot%7E%7E%20print%5C%22%22%2C%20%22created_at%22%3A%20%222015-09-10T14%3A41%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22did%20you%20mean%20%5C%22Could%20you%20%7E%7Enot%7E%7E%20print%5C%22%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-10T16%3A52%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-22T11%3A22%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.h%3AL1-40%22%7D%2C%20%22Pull%20952d75b2e4c6f35f3e625d4f306b27c3ab18dc6a%20utility/AssertAlways.hpp%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40113869%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22visual%20studio%202013%20isn%27t%20compliant%22%2C%20%22created_at%22%3A%20%222015-09-22T17%3A12%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22visual%20studio%202013%20isn%27t%20compliant%20because%20it%20don%27t%20care%20%3A%29%20%5Cr%5CnOk%2C%20will%20change%20it%20%3B-%29%22%2C%20%22created_at%22%3A%20%222015-09-23T08%3A43%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A45%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.hpp%3AL1-55%22%7D%2C%20%22Pull%207828f6c62865c309fc4e9efcb8eeb47b8a9e0c77%20utility/AlwaysAssert.hpp%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40200218%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Coding%20style%20would%20recommend%3A%5Cr%5Cn%60%60%60%20cpp%5Cr%5Cndo%20%7B%20%5C%5C%5Cr%5Cn%20%20%20%20if%20%28%21%28cond%29%29%20%7B%20%5C%5C%5Cr%5Cn%20%20%20%20%20%20%20%20std%3A%3Acerr%20%3C%3C%20__FILE__%20%3C%3C%20%5C%22%3A%5C%22%20%3C%3C%20__LINE__%20%3C%3C%20%5C%22%3A%5C%22%20%3C%3C%20__FUNCTION__%20%5C%5C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%3C%20%5C%22%3A%20Assert%20%27%5C%22%20%23cond%20%5C%22%27%20failed%3A%20%5C%22%20%3C%3C%20iostr%20%3C%3C%20std%3A%3Aendl%3B%20%5C%5C%5Cr%5Cn%20%20%20%20%20%20%20%20ALWAYS_ASSERT_FAILURE%28cond%29%3B%20%5C%5C%5Cr%5Cn%20%20%20%20%7D%20%5C%5C%5Cr%5Cn%7D%20%5C%5C%5Cr%5Cn%60%60%60%5Cr%5Cn%20-%20%3C%3C%20should%20be%20allign%2C%20%5Cr%5Cn%20-%20do%20-%3E%20if%20only%204%20space%5Cr%5Cnbut%20if%20you%20do%20not%20want%2C%20I%20would%20understand.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-23T13%3A07%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AlwaysAssert.hpp%3AL1-55%22%7D%2C%20%22Pull%2058919aed9d51d19af8d30e0e0d5ed92560038aa3%20utility/AssertAlways.hpp%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40194239%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22rename%20%60AssertAlways.hpp%60%20-%3E%20%60AlwaysAssert.hpp%60%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A48%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-23T11%3A59%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.hpp%3AL1-55%22%7D%2C%20%22Pull%20e4d58753acc85cfd18b0dff20f145dd496f74d45%20utility/AssertAlways.h%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r39250715%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22use%20the%20same%20code%20NDEBUG%20set%20or%20not%3A%20assert%20calls%20abort%2C%20thus%20this%20%27if%27%20here%20just%20adds%20useless%20complexity%20%22%2C%20%22created_at%22%3A%20%222015-09-11T08%3A25%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-22T14%3A01%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AssertAlways.h%3AL1-40%22%7D%2C%20%22Pull%2020ccbe80415bc58207fd152ca6b92f20a982cc62%20utility/AlwaysAssert.hpp%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/210%23discussion_r40199197%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Coding%20style%20would%20recommend%3A%5Cr%5Cn%60%60%60%20cpp%5Cr%5Cnstd%3A%3Acerr%20%3C%3C%20__FILE__%20%3C%3C%20%5C%22%3A%5C%22%20%3C%3C%20__LINE__%20%3C%3C%20%5C%22%3A%5C%22%20%3C%3C%20__FUNCTION__%20%5C%5C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%3C%3C%20%5C%22%3A%20Assert%20%27%5C%22%20%23cond%20%5C%22%27%20failed%3A%20%5C%22%20%3C%3C%20iostr%20%3C%3C%20std%3A%3Aendl%3B%20%5C%5C%5Cr%5Cn%60%60%60%5Cr%5Cnbut%20if%20you%20do%20not%20want%2C%20I%20would%20understand.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-23T12%3A55%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22peace%20of%20%3Acake%3A%20%5Cr%5Cndone%22%2C%20%22created_at%22%3A%20%222015-09-23T12%3A58%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12612524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/louizo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/AlwaysAssert.hpp%3AL1-55%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cc6565%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cc6565'><img src='https://avatars.githubusercontent.com/u/9692938?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 20ccbe80415bc58207fd152ca6b92f20a982cc62 utility/AlwaysAssert.hpp 51'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40199197'>File: utility/AlwaysAssert.hpp:L1-55</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Coding style would recommend:
``` cpp
std::cerr << __FILE__ << ":" << __LINE__ << ":" << __FUNCTION__ \
<< ": Assert '" #cond "' failed: " << iostr << std::endl; \
```
but if you do not want, I would understand. :+1:
- <a href='https://github.com/louizo'><img border=0 src='https://avatars.githubusercontent.com/u/12612524?v=3' height=16 width=16'></a> peace of :cake:
done
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#issuecomment-139266943'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - You felt in a travis race. Sorry, please modify the patch.
- Remove the change-id it does not need to be public.
:-1:
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> why not just use abort() all the time ?
- <a href='https://github.com/louizo'><img border=0 src='https://avatars.githubusercontent.com/u/12612524?v=3' height=16 width=16'></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/louizo'><img border=0 src='https://avatars.githubusercontent.com/u/12612524?v=3' height=16 width=16'></a> :+1:  @krocard @miguelgaio @OznOg @cc6565 please review ^_^'
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> :-1: you can abandon the patch replacing an abort with assert since #244 removed this code
- [x] <a href='#crh-comment-Pull 531995a25b319d9dd9628e1ab91e06dd28c1f313 utility/AssertAlways.h 35'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r39167691'>File: utility/AssertAlways.h:L1-40</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - coding style
- Could you print the current line and function as the real assert ? See our android assert_always for an example.
Edit: "Could you ~~not~~ print"
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> did you mean "Could you ~~not~~ print" ?
- [x] <a href='#crh-comment-Pull e4d58753acc85cfd18b0dff20f145dd496f74d45 utility/AssertAlways.h 37'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r39250715'>File: utility/AssertAlways.h:L1-40</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> use the same code NDEBUG set or not: assert calls abort, thus this 'if' here just adds useless complexity
- [x] <a href='#crh-comment-Pull df6f69a2d7e197b1f364f0fcf4c4b10ded957a86 utility/AssertAlways.h 38'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40078911'>File: utility/AssertAlways.h:L1-43</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - line 2 long (coding style max line length is 100)
- s/false/#cond/
- [x] <a href='#crh-comment-Pull 952d75b2e4c6f35f3e625d4f306b27c3ab18dc6a utility/AssertAlways.hpp 44'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40113869'>File: utility/AssertAlways.hpp:L1-55</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> visual studio 2013 isn't compliant
- <a href='https://github.com/louizo'><img border=0 src='https://avatars.githubusercontent.com/u/12612524?v=3' height=16 width=16'></a> visual studio 2013 isn't compliant because it don't care :)
Ok, will change it ;-)
- [x] <a href='#crh-comment-Pull 952d75b2e4c6f35f3e625d4f306b27c3ab18dc6a utility/AssertAlways.hpp 47'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40114031'>File: utility/AssertAlways.hpp:L1-55</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Name it `ALWAYS_ASSERT` ?
- [x] <a href='#crh-comment-Pull 952d75b2e4c6f35f3e625d4f306b27c3ab18dc6a utility/AssertAlways.hpp 37'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40114085'>File: utility/AssertAlways.hpp:L1-55</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> `TOP_ASSERT` -> `ALWAYS_ASSERT_FAILURE`
- [x] <a href='#crh-comment-Pull 350e7402270ba685753c520e784cc3b2bbe4c591 utility/AssertAlways.hpp 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40193802'>File: utility/AssertAlways.hpp:L1-55</a></b>
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> cassert
- <a href='https://github.com/louizo'><img border=0 src='https://avatars.githubusercontent.com/u/12612524?v=3' height=16 width=16'></a> sorry I don't understand. :8ball:
- [x] <a href='#crh-comment-Pull 58919aed9d51d19af8d30e0e0d5ed92560038aa3 utility/AssertAlways.hpp 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40194127'>File: utility/AssertAlways.hpp:L1-55</a></b>
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> cassert
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> 
``` cpp
#include <cassert>
```
- [x] <a href='#crh-comment-Pull 58919aed9d51d19af8d30e0e0d5ed92560038aa3 utility/AssertAlways.hpp 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40194239'>File: utility/AssertAlways.hpp:L1-55</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> rename `AssertAlways.hpp` -> `AlwaysAssert.hpp`
- [x] <a href='#crh-comment-Pull 7828f6c62865c309fc4e9efcb8eeb47b8a9e0c77 utility/AlwaysAssert.hpp 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/210#discussion_r40200218'>File: utility/AlwaysAssert.hpp:L1-55</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Coding style would recommend:
``` cpp
do { \
if (!(cond)) { \
std::cerr << __FILE__ << ":" << __LINE__ << ":" << __FUNCTION__ \
<< ": Assert '" #cond "' failed: " << iostr << std::endl; \
ALWAYS_ASSERT_FAILURE(cond); \
} \
} \
```
- << should be allign,
- do -> if only 4 space
but if you do not want, I would understand. :+1:


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/210?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/210?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/210?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/210'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>