### PR TITLE
Parameter manager multithreading usage

### DIFF
--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -83,6 +83,7 @@
 #include "XmlDocSource.h"
 #include "XmlMemoryDocSource.h"
 #include "SelectionCriteriaDefinition.h"
+#include "XmlUtil.h"
 #include "Utility.h"
 #include <sstream>
 #include <fstream>
@@ -2671,4 +2672,9 @@ log::details::Info CParameterMgr::info()
 log::details::Warning CParameterMgr::warning()
 {
     return _logger.warning();
+}
+
+void CParameterMgr::initForMultiThreading()
+{
+    CXmlUtil::initForMultiThreading();
 }

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -358,6 +358,21 @@ public:
     // CElement
     virtual std::string getKind() const;
 
+    /**
+     * Call this method at program start in the "main thread" if you plan to use
+     * the parameter manager through several threads
+     *
+     * The "main thread" is a thread that lives until process exit, for instance the
+     * thread that calls the main() method.
+     *
+     * Note: this method doesn't make the parameter manager thread safe, it allows
+     * only to use the parameter framework library by several thread sequentially.
+     *
+     * This call is due to a libxml2 library requirement, which is a dependency
+     * of the parameter manager.
+     */
+    static void initForMultiThreading();
+
 private:
     CParameterMgr(const CParameterMgr&);
     CParameterMgr& operator=(const CParameterMgr&);

--- a/parameter/ParameterMgrPlatformConnector.cpp
+++ b/parameter/ParameterMgrPlatformConnector.cpp
@@ -201,3 +201,8 @@ void CParameterMgrPlatformConnector::warning(const string& log)
         _pLogger->warning(log);
     }
 }
+
+void CParameterMgrPlatformConnector::initForMultiThreading()
+{
+    CParameterMgr::initForMultiThreading();
+}

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -157,6 +157,21 @@ public:
      */
     bool getValidateSchemasOnStart() const;
 
+    /**
+     * Call this method at program start in the "main thread" if you plan to use
+     * the parameter manager through several threads.
+     *
+     * The "main thread" is a thread that lives until process exit, for instance the
+     * thread that calls the main() method.
+     *
+     * Note: this method doesn't make the parameter manager thread safe, it allows
+     * only to use the parameter framework library by several thread sequentially.
+     *
+     * This call is due to a libxml2 library requirement, which is a dependency
+     * of the parameter manager.
+     */
+    static void initForMultiThreading();
+
 private:
     CParameterMgrPlatformConnector(const CParameterMgrPlatformConnector&);
     CParameterMgrPlatformConnector& operator=(const CParameterMgrPlatformConnector&);

--- a/xmlserializer/Android.mk
+++ b/xmlserializer/Android.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2014, Intel Corporation
+# Copyright (c) 2011-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -38,6 +38,7 @@ common_src_files := \
         XmlMemoryDocSink.cpp \
         XmlMemoryDocSource.cpp \
         XmlStreamDocSink.cpp \
+        XmlUtil.cpp
 
 common_module := libxmlserializer
 

--- a/xmlserializer/CMakeLists.txt
+++ b/xmlserializer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -32,7 +32,8 @@ add_library(xmlserializer SHARED
     XmlDocSource.cpp
     XmlMemoryDocSink.cpp
     XmlMemoryDocSource.cpp
-    XmlStreamDocSink.cpp)
+    XmlStreamDocSink.cpp
+    XmlUtil.cpp)
 
 find_package(LibXml2 REQUIRED)
 

--- a/xmlserializer/XmlUtil.cpp
+++ b/xmlserializer/XmlUtil.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "XmlUtil.h"
+#include <libxml/parser.h>
+
+void CXmlUtil::initForMultiThreading()
+{
+    /* xmlInitParser must be called in the main thread if multithreading is required
+     * @see http://xmlsoft.org/threads.html
+     * @see http://www.programmershare.com/1669782/
+     */
+    xmlInitParser();
+}

--- a/xmlserializer/XmlUtil.h
+++ b/xmlserializer/XmlUtil.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+/* Provides miscellaneous utility functions */
+class CXmlUtil
+{
+public:
+    /**
+    * Call this method at program start in the "main thread" if you plan to use
+    * the xml serializer through several threads.
+    *
+    * The "main thread" is a thread that lives until process exit, for instance the
+    * thread that calls the main() method.
+    *
+    * This call is due to a libxml2 library requirement.
+    */
+    static void initForMultiThreading();
+};


### PR DESCRIPTION
The libxml2 library, which is a dependency of
the parameter framework, requires a specific usage
in case of multithreading.

Indeed, if the libxml2 library is used by several
threads, the function xmlInitParser() has to be called
at program start in the main thread (i.e. a thread that
lives until process exit).

This patch introduces a static method "initForMultithreading"
to follow this requirement. The user has to call it at program
start in the main thread if multithreading is used.

Signed-off-by: Thomas Cahuzac <thomasx.cahuzac@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/211%23issuecomment-139246443%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/211%23issuecomment-139270463%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/211%23issuecomment-139307452%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/211%23discussion_r39197129%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/211%23issuecomment-139246443%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20as%20%2355%20%22%2C%20%22created_at%22%3A%20%222015-09-10T14%3A11%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20test%20but%20explain%20what%20this%20must%20be%20done%20here%20http%3A//www.xmlsoft.org/threads.html%5Cr%5Cncall%20xmlInitParser%28%29%20in%20the%20%5C%22main%5C%22%20thread%20before%20using%20any%20of%20the%20libxml2%20API%20%28except%20possibly%20selecting%20a%20different%20memory%20allocator%29%22%2C%20%22created_at%22%3A%20%222015-09-10T14%3A51%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22duplicate%20of%20%2355%22%2C%20%22created_at%22%3A%20%222015-09-10T16%3A49%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2085e072e7df5fae1b0f8f657c8f15a9a4ce033a31%20xmlserializer/XmlUtil.h%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/211%23discussion_r39197129%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20rather%20use%20a%20namespace%20than%20a%20class.%20There%20is%20no%20invariant%20nor%20member%20to%20protect%20here.%22%2C%20%22created_at%22%3A%20%222015-09-10T18%3A39%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20xmlserializer/XmlUtil.h%3AL1-48%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/211#issuecomment-139246443'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Same as #55
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> No test but explain what this must be done here http://www.xmlsoft.org/threads.html
call xmlInitParser() in the "main" thread before using any of the libxml2 API (except possibly selecting a different memory allocator)
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> duplicate of #55
- [ ] <a href='#crh-comment-Pull 85e072e7df5fae1b0f8f657c8f15a9a4ce033a31 xmlserializer/XmlUtil.h 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/211#discussion_r39197129'>File: xmlserializer/XmlUtil.h:L1-48</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I would rather use a namespace than a class. There is no invariant nor member to protect here.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/211?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/211?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/211'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>