### PR TITLE
python bindings: fix a typo in the sample

### DIFF
--- a/bindings/python/sample.py
+++ b/bindings/python/sample.py
@@ -40,7 +40,7 @@ class MyLogger(PyPfw.ILogger):
     def info(self, msg):
         logging.info(msg)
     def warning(self, msg):
-        logging.warning(mgg)
+        logging.warning(msg)
 
 
 logging.root.setLevel(logging.INFO)


### PR DESCRIPTION
A typo was introduced by 6be17d8e2906ed60f2f1b13a396b0b6b4c479f1b which caused
the script to crash.

The only available information during the crash was:

    terminate called after throwing an instance of 'Swig::DirectorMethodException'

What actually happened was that an undefined name ('mgg' instead of 'msg') was
used.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/213%23issuecomment-139337698%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/213%23issuecomment-139338901%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/213%23issuecomment-139337698%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20I%20guess%20this%20sample%20is%20for%20documentation%20only%20and%20not%20tested.%22%2C%20%22created_at%22%3A%20%222015-09-10T18%3A34%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Unfortunately%2C%20yes...%20I%27ll%20log%20this%20as%20tech%20debt.%22%2C%20%22created_at%22%3A%20%222015-09-10T18%3A40%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/213#issuecomment-139337698'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: I guess this sample is for documentation only and not tested.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Unfortunately, yes... I'll log this as tech debt.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/213?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/213?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/213'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>