### PR TITLE
Replace INFINITY macro with infinity value from the STL

### DIFF
--- a/parameter/LogarithmicParameterAdaptation.cpp
+++ b/parameter/LogarithmicParameterAdaptation.cpp
@@ -31,6 +31,7 @@
 #include "LogarithmicParameterAdaptation.h"
 #include "Utility.h"
 #include <cmath>
+#include <limits>
 
 #define base CLinearParameterAdaptation
 
@@ -39,8 +40,11 @@ CLogarithmicParameterAdaptation::CLogarithmicParameterAdaptation() : base("Logar
     // Make sure there is no precision lose by using std::exp overload that
     // return the same type as _dLogarithmBase
     _dLogarithmBase{std::exp(decltype(_dLogarithmBase){1})},
-    _dFloorValue(-INFINITY)
+    _dFloorValue(-std::numeric_limits<double>::infinity())
 {
+    static_assert(std::numeric_limits<double>::is_iec559,
+            "Only double-precision floating points that are compliant with"
+            " IEC 559 (aka IEEE 754) are supported");
 }
 
 // Element properties


### PR DESCRIPTION
The INFINITY macro is a float but we are storing -INFINITY in a double, which
obviously isn't what we want. Use std::numeric_limits<double>::infinity()
instead and make sure that the floating points are following IEEE 754 which
guarantees that "-inf" == "-(+inf)".
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/214%23issuecomment-139337964%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/214%23issuecomment-139337964%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-09-10T18%3A36%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/214?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/214'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>