### PR TITLE
WIP: Windows export symbols

### DIFF
--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -110,8 +110,10 @@ include_directories(
     "${PROJECT_SOURCE_DIR}/remote-processor"
     "${PROJECT_SOURCE_DIR}/parameter/log/include")
 
-find_library(dl dl)
-target_link_libraries(parameter xmlserializer remote-processor pfw_utility dl)
+if(UNIX)
+    target_link_libraraies(parameter dl)
+endif()
+target_link_libraries(parameter xmlserializer remote-processor pfw_utility)
 
 install(TARGETS parameter LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
 # Client headers

--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -115,6 +115,8 @@ if(UNIX)
 endif()
 target_link_libraries(parameter xmlserializer remote-processor pfw_utility)
 
+target_compile_definitions(parameter PRIVATE SYMBOL_EXPORTS)
+
 install(TARGETS parameter LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
 # Client headers
 install(FILES

--- a/parameter/include/ParameterHandle.h
+++ b/parameter/include/ParameterHandle.h
@@ -32,11 +32,12 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include "SymbolExport.h"
 
 class CBaseParameter;
 class CParameterMgr;
 
-class CParameterHandle
+class EXPORT_API CParameterHandle
 {
 public:
     CParameterHandle(const CBaseParameter* pParameter, CParameterMgr* pParameterMgr);

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -33,10 +33,11 @@
 #include "SelectionCriterionInterface.h"
 #include "ParameterHandle.h"
 #include "ParameterMgrLoggerForward.h"
+#include "SymbolExport.h"
 
 class CParameterMgr;
 
-class CParameterMgrPlatformConnector
+class EXPORT_API CParameterMgrPlatformConnector
 {
     friend class CParameterMgrLogger<CParameterMgrPlatformConnector>;
 public:

--- a/remote-processor/Android.mk
+++ b/remote-processor/Android.mk
@@ -49,6 +49,9 @@ common_cflags := \
         -Werror \
         -Wextra \
 
+common_c_includes := \
+    $(LOCAL_PATH)/../utility/
+
 #############################
 # Target build
 
@@ -57,6 +60,8 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := $(common_src_files)
 
 LOCAL_STATIC_LIBRARIES := libpfw_utility
+
+LOCAL_C_INCLUDES := $(common_c_includes)
 
 LOCAL_CFLAGS := $(common_cflags)
 

--- a/remote-processor/AnswerMessage.h
+++ b/remote-processor/AnswerMessage.h
@@ -34,14 +34,14 @@
 class CAnswerMessage : public CMessage
 {
 public:
-    CAnswerMessage(const std::string& strAnswer, bool bSuccess);
-    CAnswerMessage();
+    EXPORT_API CAnswerMessage(const std::string& strAnswer, bool bSuccess);
+    EXPORT_API CAnswerMessage();
 
     // Answer
-    const std::string& getAnswer() const;
+    EXPORT_API const std::string& getAnswer() const;
 
     // Status
-    bool success() const;
+    EXPORT_API bool success() const;
 private:
     // Fill data to send
     virtual void fillDataToSend();

--- a/remote-processor/CMakeLists.txt
+++ b/remote-processor/CMakeLists.txt
@@ -45,6 +45,8 @@ target_include_directories(remote-processor PUBLIC "${ASIO_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/utility")
 
 target_compile_definitions(remote-processor PUBLIC ASIO_STANDALONE)
+target_compile_definitions(remote-processor PRIVATE SYMBOL_EXPORTS)
+
 
 target_link_libraries(remote-processor pfw_utility ${CMAKE_THREAD_LIBS_INIT})
 

--- a/remote-processor/Message.h
+++ b/remote-processor/Message.h
@@ -32,15 +32,16 @@
 #include <asio.hpp>
 #include <stdint.h>
 #include <string>
+#include "SymbolExport.h"
 
 class CSocket;
 
 class CMessage
 {
 public:
-    CMessage(uint8_t ucMsgId);
-    CMessage();
-    virtual ~CMessage();
+    EXPORT_API CMessage(uint8_t ucMsgId);
+    EXPORT_API CMessage();
+    EXPORT_API virtual ~CMessage();
 
     enum Result {
         success,
@@ -60,7 +61,7 @@ public:
      *         peerDisconnected if the peer disconnected before the first socket access.
      *         error if the message could not be read/write for any other reason
      */
-    Result serialize(asio::ip::tcp::socket &socket, bool bOut, std::string &strError);
+    EXPORT_API Result serialize(asio::ip::tcp::socket &socket, bool bOut, std::string &strError);
 
 protected:
     // Msg Id

--- a/remote-processor/RequestMessage.h
+++ b/remote-processor/RequestMessage.h
@@ -37,18 +37,18 @@
 class CRequestMessage : public CMessage, public IRemoteCommand
 {
 public:
-    CRequestMessage(const std::string& strCommand);
-    CRequestMessage();
+    EXPORT_API CRequestMessage(const std::string& strCommand);
+    EXPORT_API CRequestMessage();
 
     // Command Name
-    void setCommand(const std::string& strCommand);
-    virtual const std::string& getCommand() const;
+    EXPORT_API void setCommand(const std::string& strCommand);
+    EXPORT_API virtual const std::string& getCommand() const;
 
     // Arguments
-    virtual void addArgument(const std::string& strArgument);
-    virtual uint32_t getArgumentCount() const;
-    virtual const std::string& getArgument(uint32_t uiArgument) const;
-    virtual const std::string packArguments(uint32_t uiStartArgument, uint32_t uiNbArguments) const;
+    EXPORT_API virtual void addArgument(const std::string& strArgument);
+    EXPORT_API virtual uint32_t getArgumentCount() const;
+    EXPORT_API virtual const std::string& getArgument(uint32_t uiArgument) const;
+    EXPORT_API virtual const std::string packArguments(uint32_t uiStartArgument, uint32_t uiNbArguments) const;
 
 private:
 

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -51,3 +51,7 @@ install(FILES
     Utility.h
     convert.hpp
     DESTINATION "include/utility")
+
+install(FILES
+    SymbolExport.h
+    DESTINATION "include/parameter/client")

--- a/utility/SymbolExport.h
+++ b/utility/SymbolExport.h
@@ -1,5 +1,5 @@
-/* 
- * Copyright (c) 2011-2015, Intel Corporation
+/*
+ * Copyright (c) 2014, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,35 +29,12 @@
  */
 #pragma once
 
-#include <stdint.h>
-#include "RemoteProcessorServerInterface.h"
-#include <asio.hpp>
-#include "SymbolExport.h"
-
-class IRemoteCommandHandler;
-
-class CRemoteProcessorServer : public IRemoteProcessorServerInterface
-{
-public:
-    EXPORT_API CRemoteProcessorServer(uint16_t uiPort);
-    EXPORT_API virtual ~CRemoteProcessorServer();
-
-    // State
-    EXPORT_API virtual bool start(std::string &error);
-    EXPORT_API virtual bool stop();
-    EXPORT_API bool process(IRemoteCommandHandler &commandHandler);
-
-private:
-    void acceptRegister(IRemoteCommandHandler &commandHandler);
-
-    // New connection
-    void handleNewConnection(IRemoteCommandHandler &commandHandler);
-
-    // Port number
-    uint16_t _uiPort;
-
-    asio::io_service _io_service;
-    asio::ip::tcp::acceptor _acceptor;
-    asio::ip::tcp::socket _socket;
-};
-
+#ifdef _MSC_VER
+#ifdef SYMBOL_EXPORTS
+#define EXPORT_API __declspec(dllexport)
+#else
+#define EXPORT_API __declspec(dllimport)
+#endif
+#else
+#define EXPORT_API
+#endif

--- a/xmlserializer/CMakeLists.txt
+++ b/xmlserializer/CMakeLists.txt
@@ -26,13 +26,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_library(xmlserializer SHARED
+add_library(xmlserializer STATIC
     XmlElement.cpp
     XmlSerializingContext.cpp
     XmlDocSource.cpp
     XmlMemoryDocSink.cpp
     XmlMemoryDocSource.cpp
     XmlStreamDocSink.cpp)
+
+set_target_properties(xmlserializer PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 find_package(LibXml2 REQUIRED)
 
@@ -59,11 +61,3 @@ include_directories(
 
 target_link_libraries(xmlserializer ${LIBXML2_LIBRARIES})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LIBXML2_DEFINITIONS}")
-
-install(TARGETS xmlserializer LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
-install(FILES
-    XmlSink.h
-    XmlSource.h
-    XmlElement.h
-    XmlSerializingContext.h
-    DESTINATION "include/xmlserializer")


### PR DESCRIPTION
todo:

- [ ] export classes rather than methods
- [ ] do not broadly use EXPORT_API because if library A uses headers from library B, library A is going to export symbols from library B. Instead, see http://www.cmake.org/pipermail/cmake/2009-November/033433.html
- [ ] remove android parts in these commits
- [ ] SymbolExport.h isn't provided to clients even though it is used in client headers
- [ ] Split this PR into several

xmlserializer is made static so that we don't need to export symbols (quick'n'dirty solution).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39203491%22%2C%20%22https%3A//github.com/01org/parameter-framework/commit/6816a73384b1a4096a9f772279b7f08bec86f998%23commitcomment-13167134%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39203871%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39204472%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39204603%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39210727%22%5D%2C%20%22comments%22%3A%20%7B%22Commit%206816a73384b1a4096a9f772279b7f08bec86f998%20remote-processor/CMakeLists.txt%204%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/commit/6816a73384b1a4096a9f772279b7f08bec86f998%23commitcomment-13167134%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22How%20about%5Cr%5Cn%60%60%60%20cmake%5Cr%5Cntarget_compile_definitions%28remote-processor%20PUBLIC%20ASIO_STANDALONE%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20PRIVATE%20SYMBOL_EXPORTS%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-09-10T18%3A53%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/CMakeLists.txt%3AL48%20%286816a73%29%22%7D%2C%20%22Pull%206816a73384b1a4096a9f772279b7f08bec86f998%20parameter/CMakeLists.txt%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39204603%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22target_link_librar%2Aies%2A%22%2C%20%22created_at%22%3A%20%222015-09-10T19%3A47%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL110-122%22%7D%2C%20%22Pull%206816a73384b1a4096a9f772279b7f08bec86f998%20remote-processor/CMakeLists.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39204472%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22How%20about%5Cr%5Cn%60%60%60%20cmake%5Cr%5Cntarget_compile_definitions%28remote-processor%20PUBLIC%20ASIO_STANDALONE%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20PRIVATE%20SYMBOL_EXPORTS%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-09-10T19%3A46%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/CMakeLists.txt%3AL45-53%22%7D%2C%20%22Pull%206816a73384b1a4096a9f772279b7f08bec86f998%20xmlserializer/CMakeLists.txt%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39210727%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%20is%20great%20%21%20Should%20use%20it%20for%20%5Butilty%5D%28https%3A//github.com/01org/parameter-framework/blob/master/utility/CMakeLists.txt%23L36%29%22%2C%20%22created_at%22%3A%20%222015-09-10T20%3A40%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20xmlserializer/CMakeLists.txt%3AL34-42%22%7D%2C%20%22Pull%206816a73384b1a4096a9f772279b7f08bec86f998%20utility/SymbolExport.h%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39203871%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20%5Bmail%5D%28http%3A//www.cmake.org/pipermail/cmake/2009-November/033433.html%29%20%5Cu2014from%20which%20you%20might%20have%20copy%20paste%20this%5Cu2014%20explicitly%20requires%20that%20each%20lib%20has%20a%20different%20macro%3A%5Cr%5Cn%5Cr%5Cn%3E%20If%20you%27d%20chosen%20simply%20EXPORT%20instead%20of%20FOO_EXPORT%20and%20BAR_EXPORT%2C%20%20%5Cr%5Cn%3E%20you%27d%20be%20in%20real%20trouble%20when%20it%20comes%20to%20building%20bar.%22%2C%20%22created_at%22%3A%20%222015-09-10T19%3A40%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/SymbolExport.h%3AL1-41%22%7D%2C%20%22Pull%206816a73384b1a4096a9f772279b7f08bec86f998%20utility/SymbolExport.h%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/215%23discussion_r39203491%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20indent%20the%20preprocessor%20directives%20%3F%5Cr%5Cn%60%60%60%20cpp%5Cr%5Cn%23ifdef%20_MSC_VER%5Cr%5Cn%23%20%20%20%20ifdef%20SYMBOL_EXPORTS%5Cr%5Cn%23%20%20%20%20%20%20%20%20define%20EXPORT_API%20__declspec%28dllexport%29%5Cr%5Cn%23%20%20%20%20else%5Cr%5Cn%23%20%20%20%20%20%20%20%20define%20EXPORT_API%20__declspec%28dllimport%29%5Cr%5Cn%23%20%20%20%20endif%5Cr%5Cn%23else%5Cr%5Cn%23%20%20%20%20define%20EXPORT_API%5Cr%5Cn%23endif%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-09-10T19%3A37%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/SymbolExport.h%3AL1-41%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Commit 6816a73384b1a4096a9f772279b7f08bec86f998 remote-processor/CMakeLists.txt 4 48'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/commit/6816a73384b1a4096a9f772279b7f08bec86f998#commitcomment-13167134'>File: remote-processor/CMakeLists.txt:L48 (6816a73)</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> How about
``` cmake
target_compile_definitions(remote-processor PUBLIC ASIO_STANDALONE
PRIVATE SYMBOL_EXPORTS)
```
- [ ] <a href='#crh-comment-Pull 6816a73384b1a4096a9f772279b7f08bec86f998 utility/SymbolExport.h 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/215#discussion_r39203491'>File: utility/SymbolExport.h:L1-41</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Could you indent the preprocessor directives ?
``` cpp
#ifdef _MSC_VER
#    ifdef SYMBOL_EXPORTS
#        define EXPORT_API __declspec(dllexport)
#    else
#        define EXPORT_API __declspec(dllimport)
#    endif
#else
#    define EXPORT_API
#endif
```
- [ ] <a href='#crh-comment-Pull 6816a73384b1a4096a9f772279b7f08bec86f998 utility/SymbolExport.h 32'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/215#discussion_r39203871'>File: utility/SymbolExport.h:L1-41</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> The [mail](http://www.cmake.org/pipermail/cmake/2009-November/033433.html) —from which you might have copy paste this— explicitly requires that each lib has a different macro:
> If you'd chosen simply EXPORT instead of FOO_EXPORT and BAR_EXPORT,
> you'd be in real trouble when it comes to building bar.
- [ ] <a href='#crh-comment-Pull 6816a73384b1a4096a9f772279b7f08bec86f998 remote-processor/CMakeLists.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/215#discussion_r39204472'>File: remote-processor/CMakeLists.txt:L45-53</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> How about
``` cmake
target_compile_definitions(remote-processor PUBLIC ASIO_STANDALONE
PRIVATE SYMBOL_EXPORTS)
```
- [ ] <a href='#crh-comment-Pull 6816a73384b1a4096a9f772279b7f08bec86f998 parameter/CMakeLists.txt 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/215#discussion_r39204603'>File: parameter/CMakeLists.txt:L110-122</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> target_link_librar*ies*
- [ ] <a href='#crh-comment-Pull 6816a73384b1a4096a9f772279b7f08bec86f998 xmlserializer/CMakeLists.txt 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/215#discussion_r39210727'>File: xmlserializer/CMakeLists.txt:L34-42</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> That is great ! Should use it for [utilty](https://github.com/01org/parameter-framework/blob/master/utility/CMakeLists.txt#L36)


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/215?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/215?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/215'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>