### PR TITLE
Windows export symbols

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(cparameter SHARED ParameterFramework.cpp)
 
 include_directories(
         "${PROJECT_SOURCE_DIR}/utility"
+        "${PROJECT_BINARY_DIR}/parameter"
         "${PROJECT_SOURCE_DIR}/parameter/include")
 
 install(FILES ParameterFramework.h

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -36,7 +36,9 @@ find_package(PythonInterp 2.7 REQUIRED)
 find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
 
-include_directories(${PROJECT_SOURCE_DIR}/parameter/include)
+include_directories(
+   "${PROJECT_BINARY_DIR}/parameter"
+   "${PROJECT_SOURCE_DIR}/parameter/include")
 
 set_property(SOURCE pfw.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE pfw.i PROPERTY SWIG_FLAGS "-Wall" "-Werror")

--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -26,6 +26,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Hide symbols by default, then exposed symbols are the same in linux and windows
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 add_library(parameter SHARED
     AreaConfiguration.cpp
     ArrayParameter.cpp
@@ -104,10 +108,16 @@ add_library(parameter SHARED
     XmlFileIncluderElement.cpp
     XmlParameterSerializingContext.cpp)
 
+include (GenerateExportHeader)
+generate_export_header(parameter)
+
 include_directories(
     include
+    "${CMAKE_CURRENT_BINARY_DIR}"
+    "${PROJECT_SOURCE_DIR}/parameter"
     "${PROJECT_SOURCE_DIR}/xmlserializer"
     "${PROJECT_SOURCE_DIR}/utility"
+    "${PROJECT_BINARY_DIR}/remote-processor"
     "${PROJECT_SOURCE_DIR}/remote-processor"
     "${PROJECT_SOURCE_DIR}/parameter/log/include")
 
@@ -120,6 +130,7 @@ target_link_libraries(parameter xmlserializer remote-processor pfw_utility)
 install(TARGETS parameter LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
 # Client headers
 install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/parameter_export.h"
     include/ParameterHandle.h
     include/ParameterMgrLoggerForward.h
     include/ParameterMgrFullConnector.h
@@ -129,6 +140,7 @@ install(FILES
     DESTINATION "include/parameter/client")
 # Core (plugin) headers
 install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/parameter_export.h"
     BitParameterBlockType.h
     ConfigurableElement.h
     ConfigurableElementWithMapping.h

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include "Element.h"
 
 #include <list>
@@ -41,7 +43,7 @@ class CConfigurationAccessContext;
 class CParameterAccessContext;
 class CAreaConfiguration;
 
-class CConfigurableElement : public CElement
+class PARAMETER_EXPORT CConfigurableElement : public CElement
 {
     friend class CConfigurableDomain;
     friend class CDomainConfiguration;

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include <string>
 #include <vector>
 #include <stdint.h>
@@ -40,7 +42,7 @@
 class CXmlElementSerializingContext;
 class CErrorContext;
 
-class CElement : public IXmlSink, public IXmlSource
+class PARAMETER_EXPORT CElement : public IXmlSink, public IXmlSource
 {
 public:
     CElement(const std::string& strName = "");

--- a/parameter/ElementLibrary.h
+++ b/parameter/ElementLibrary.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include <map>
 #include <string>
 
@@ -36,7 +38,7 @@
 
 class CElementBuilder;
 
-class CElementLibrary
+class PARAMETER_EXPORT CElementLibrary
 {
     typedef std::map<std::string, const CElementBuilder*> ElementBuilderMap;
     typedef ElementBuilderMap::iterator ElementBuilderMapIterator;

--- a/parameter/InstanceConfigurableElement.h
+++ b/parameter/InstanceConfigurableElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include "ConfigurableElementWithMapping.h"
 #include "TypeElement.h"
 
@@ -39,7 +41,7 @@ class IMapper;
 class CParameterBlackboard;
 class CParameterAccessContext;
 
-class CInstanceConfigurableElement : public CConfigurableElementWithMapping
+class PARAMETER_EXPORT CInstanceConfigurableElement : public CConfigurableElementWithMapping
 {
 public:
     enum Type {

--- a/parameter/MappingContext.h
+++ b/parameter/MappingContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,10 +29,13 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
+
 #include <stdint.h>
 #include <string>
 
-class CMappingContext
+class PARAMETER_EXPORT CMappingContext
 {
     // Item structure
     struct SItem {

--- a/parameter/ParameterType.h
+++ b/parameter/ParameterType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include <stdint.h>
 #include <limits>
 
@@ -39,7 +41,7 @@
 class CParameterAccessContext;
 class CConfigurationAccessContext;
 
-class CParameterType : public CTypeElement
+class PARAMETER_EXPORT CParameterType : public CTypeElement
 {
 public:
     CParameterType(const std::string& strName);

--- a/parameter/Subsystem.h
+++ b/parameter/Subsystem.h
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include "ConfigurableElement.h"
 #include "ConfigurableElementWithMapping.h"
 #include "Mapper.h"
@@ -47,7 +49,7 @@ class CSubsystemObjectCreator;
 class CInstanceConfigurableElement;
 class CMappingData;
 
-class CSubsystem : public CConfigurableElementWithMapping, private IMapper
+class PARAMETER_EXPORT CSubsystem : public CConfigurableElementWithMapping, private IMapper
 {
     // Subsystem objects iterator
     typedef std::list<CSubsystemObject*>::const_iterator SubsystemObjectListIterator;

--- a/parameter/SubsystemObject.h
+++ b/parameter/SubsystemObject.h
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include "Syncer.h"
 #include <log/Logger.h>
 
@@ -39,7 +41,7 @@ class CInstanceConfigurableElement;
 class CMappingContext;
 class CSubsystem;
 
-class CSubsystemObject : private ISyncer
+class PARAMETER_EXPORT CSubsystemObject : private ISyncer
 {
 public:
     CSubsystemObject(CInstanceConfigurableElement* pInstanceConfigurableElement,

--- a/parameter/SubsystemObjectCreator.h
+++ b/parameter/SubsystemObjectCreator.h
@@ -29,11 +29,13 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include "SubsystemObject.h"
 #include "MappingContext.h"
 #include <string>
 
-class CSubsystemObjectCreator
+class PARAMETER_EXPORT CSubsystemObjectCreator
 {
 public:
     CSubsystemObjectCreator(const std::string& strMappingKey, uint32_t uiAncestorIdMask, size_t maxConfigurableElementSize);

--- a/parameter/TypeElement.h
+++ b/parameter/TypeElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,13 +29,15 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include "Element.h"
 #include <string>
 
 class CMappingData;
 class CInstanceConfigurableElement;
 
-class CTypeElement : public CElement
+class PARAMETER_EXPORT CTypeElement : public CElement
 {
 public:
     CTypeElement(const std::string& strName = "");

--- a/parameter/include/ParameterHandle.h
+++ b/parameter/include/ParameterHandle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -36,7 +38,7 @@
 class CBaseParameter;
 class CParameterMgr;
 
-class CParameterHandle
+class PARAMETER_EXPORT CParameterHandle
 {
 public:
     CParameterHandle(const CBaseParameter* pParameter, CParameterMgr* pParameterMgr);

--- a/parameter/include/ParameterMgrFullConnector.h
+++ b/parameter/include/ParameterMgrFullConnector.h
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include "SelectionCriterionTypeInterface.h"
 #include "SelectionCriterionInterface.h"
 #include "ParameterHandle.h"
@@ -41,7 +43,7 @@
 
 class CParameterMgr;
 
-class CParameterMgrFullConnector
+class PARAMETER_EXPORT CParameterMgrFullConnector
 {
     friend class CParameterMgrLogger<CParameterMgrFullConnector>;
 

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include "parameter_export.h"
+
 #include "SelectionCriterionTypeInterface.h"
 #include "SelectionCriterionInterface.h"
 #include "ParameterHandle.h"
@@ -36,7 +38,7 @@
 
 class CParameterMgr;
 
-class CParameterMgrPlatformConnector
+class PARAMETER_EXPORT CParameterMgrPlatformConnector
 {
     friend class CParameterMgrLogger<CParameterMgrPlatformConnector>;
 public:

--- a/remote-process/CMakeLists.txt
+++ b/remote-process/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(remote-process main.cpp)
 # TODO: separate remote-processor's includes in half (public/private)
 # And use only public headers here
 include_directories(
+    "${PROJECT_BINARY_DIR}/remote-processor"
     "${PROJECT_SOURCE_DIR}/remote-processor"
     "${PROJECT_SOURCE_DIR}/utility")
 

--- a/remote-processor/AnswerMessage.h
+++ b/remote-processor/AnswerMessage.h
@@ -29,9 +29,11 @@
  */
 #pragma once
 
+#include "remote_processor_export.h"
+
 #include "Message.h"
 
-class CAnswerMessage : public CMessage
+class REMOTE_PROCESSOR_EXPORT CAnswerMessage : public CMessage
 {
 public:
     CAnswerMessage(const std::string& strAnswer, bool bSuccess);

--- a/remote-processor/CMakeLists.txt
+++ b/remote-processor/CMakeLists.txt
@@ -26,11 +26,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Hide symbols by default, then exposed symbols are the same in linux and windows
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 add_library(remote-processor SHARED
         Message.cpp
         RequestMessage.cpp
         AnswerMessage.cpp
         RemoteProcessorServer.cpp)
+
+include (GenerateExportHeader)
+generate_export_header(remote-processor
+                       BASE_NAME remote_processor)
 
 set(CMAKE_THREAD_PREFER_PTHREAD 1)
 find_package(Threads REQUIRED)
@@ -42,7 +50,8 @@ find_package(Threads REQUIRED)
 find_path(ASIO_DIR NAMES asio.hpp)
 target_include_directories(remote-processor PUBLIC "${ASIO_DIR}")
 
-include_directories("${PROJECT_SOURCE_DIR}/utility")
+include_directories("${PROJECT_SOURCE_DIR}/utility"
+                    "${CMAKE_CURRENT_BINARY_DIR}")
 
 target_compile_definitions(remote-processor PUBLIC ASIO_STANDALONE)
 

--- a/remote-processor/Message.h
+++ b/remote-processor/Message.h
@@ -33,7 +33,10 @@
 #include <string>
 #include <cstdint>
 
-class CMessage
+#include <remote_processor_export.h>
+
+
+class REMOTE_PROCESSOR_EXPORT CMessage
 {
 public:
 

--- a/remote-processor/RemoteProcessorServer.h
+++ b/remote-processor/RemoteProcessorServer.h
@@ -29,13 +29,15 @@
  */
 #pragma once
 
+#include "remote_processor_export.h"
+
 #include <stdint.h>
 #include "RemoteProcessorServerInterface.h"
 #include <asio.hpp>
 
 class IRemoteCommandHandler;
 
-class CRemoteProcessorServer : public IRemoteProcessorServerInterface
+class REMOTE_PROCESSOR_EXPORT CRemoteProcessorServer : public IRemoteProcessorServerInterface
 {
 public:
     CRemoteProcessorServer(uint16_t uiPort);

--- a/remote-processor/RequestMessage.h
+++ b/remote-processor/RequestMessage.h
@@ -29,12 +29,14 @@
  */
 #pragma once
 
+#include "remote_processor_export.h"
+
 #include "Message.h"
 #include "RemoteCommand.h"
 #include <vector>
 #include <string>
 
-class CRequestMessage : public CMessage, public IRemoteCommand
+class REMOTE_PROCESSOR_EXPORT CRequestMessage : public CMessage, public IRemoteCommand
 {
 public:
     CRequestMessage(const std::string& strCommand);

--- a/test/functional-tests/CMakeLists.txt
+++ b/test/functional-tests/CMakeLists.txt
@@ -37,6 +37,7 @@ if(BUILD_TESTING)
     # copy it in a standard location (/usr/include on most linux distribution).
     find_path(CATCH_HEADER catch.hpp)
     include_directories(${CATCH_HEADER})
+    include_directories("${PROJECT_BINARY_DIR}/parameter")
     include_directories("${PROJECT_SOURCE_DIR}/parameter/include")
     include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 

--- a/test/test-platform/CMakeLists.txt
+++ b/test/test-platform/CMakeLists.txt
@@ -31,7 +31,9 @@ add_executable(test-platform
     TestPlatform.cpp)
 
 include_directories(
+    "${PROJECT_BINARY_DIR}/parameter"
     "${PROJECT_SOURCE_DIR}/parameter/include"
+    "${PROJECT_BINARY_DIR}/remote-processor"
     "${PROJECT_SOURCE_DIR}/remote-processor"
     "${PROJECT_SOURCE_DIR}/utility")
 

--- a/test/test-subsystem/CMakeLists.txt
+++ b/test/test-subsystem/CMakeLists.txt
@@ -39,6 +39,7 @@ if (BUILD_TESTING)
         "${PROJECT_SOURCE_DIR}/xmlserializer"
         "${PROJECT_SOURCE_DIR}/utility"
         "${PROJECT_SOURCE_DIR}/parameter/log/include"
+        "${PROJECT_BINARY_DIR}/parameter"
         "${PROJECT_SOURCE_DIR}/parameter")
 
     target_link_libraries(test-subsystem parameter)


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-139550849%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-139551740%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-139552777%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-139553260%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-139556422%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-139556506%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-140106268%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39270581%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39270711%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39270816%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39270933%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39271649%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39272902%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39274121%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39274124%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39274126%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39274127%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39274129%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39274280%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39279480%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39287250%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39287792%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39288129%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39288142%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39288225%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39288361%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39292942%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39292943%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39292945%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39292946%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39390733%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39390945%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39392772%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39395789%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39395790%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39402668%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39402761%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39403067%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39403080%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39403126%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39403207%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39404959%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39405502%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39405505%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39405506%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39405507%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39405509%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39405510%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-140112215%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23issuecomment-139550849%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22On%20windows%2C%20the%20generated%20filename%20is%20%5C%22somelib_Export.h%5C%22%20whereas%20the%20CMake%20documentation%20mentions%20%5C%22somelib_export.h%5C%22%3B%20likewise%2C%20the%20generated%20macro%20is%20%5C%22somelib_EXPORT%5C%22%20wheras%20the%20doc%20mentions%20%5C%22SOMELIB_EXPORT%5C%22...%20That%27s%20strange.%5Cr%5Cn%5Cr%5CnWhat%27s%20the%20result%20on%20Linux%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A45%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%2C%20I%20change%20the%20from%20parameter_Export%20to%20parameter_export.%5Cr%5Cnit%20not%20related%20to%20OS%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A48%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20see%20anything%20in%20the%20patch%20that%20changes%20the%20generated%20header%20name%20nor%20the%20generated%20macro%20name.%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A51%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20nevermind%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A53%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20documentation%20mentions%20%60add_compiler_export_flags%28%29%60%20which%20add%20%60-fvisibility%3Dhidden%60%20to%20the%20c%2B%2B%20flags.%20The%20documentation%20makes%20it%20looks%20like%20it%20needs%20to%20be%20called%20before%20add_library%28%29%20but%20I%27m%20convenient%20it%20isn%27t%20the%20case.%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A06%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A07%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A55%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A12%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204d34f524ea5b23cfcf0d8a779ff1a372414ebdd3%20remote-processor/RemoteProcessorServer.h%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39403067%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22missing%20include%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A53%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A11%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/RemoteProcessorServer.h%3AL35-42%22%7D%2C%20%22Pull%204d34f524ea5b23cfcf0d8a779ff1a372414ebdd3%20remote-processor/AnswerMessage.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39403126%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22missing%20include%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A53%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A11%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/AnswerMessage.h%3AL31-38%22%7D%2C%20%22Pull%204d34f524ea5b23cfcf0d8a779ff1a372414ebdd3%20parameter/CMakeLists.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39402668%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20add%20a%20comment%20about%20why%20we%20do%20that%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A50%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A11%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL26-35%22%7D%2C%20%22Pull%208576150cce7e5907da84eae353a380b80dfc43df%20parameter/CMakeLists.txt%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39270933%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20may%20simply%20use%20%60%5C%22%24%7BCMAKE_CURRENT_BINARY_DIR%7D%5C%22%60%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A34%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A07%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL105-118%22%7D%2C%20%22Pull%204d34f524ea5b23cfcf0d8a779ff1a372414ebdd3%20parameter/ConfigurableElement.h%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39403207%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Coding%20style%20says%20that%20header%20should%20be%20included%20from%20most%20local%20to%20farthest.%20Eg%3A%20local%2C%20...%20std%20header.%20I%20would%20recommend%20including%20with%20%60%5C%22%5C%22%60%2C%20not%20%60%3C%3E%60.%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A54%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A11%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElement.h%3AL29-37%22%7D%2C%20%22Pull%208576150cce7e5907da84eae353a380b80dfc43df%20parameter/CMakeLists.txt%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39270816%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20useless.%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A32%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A07%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL105-118%22%7D%2C%20%22Pull%202affd88e1693b9e816d1ef9bbdc2065d5dc1dbfc%20remote-processor/CMakeLists.txt%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39287792%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22-%20coding%20style%5Cr%5Cn-%20please%20group%20together%20the%20stuff%20related%20to%20symbol%20export%20%28like%20you%20did%20in%20parameter/CMakeLists.txt%29%22%2C%20%22created_at%22%3A%20%222015-09-11T16%3A14%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28thanks%20Travis%29%20This%20creates%20a%20%60REMOTE-PROCESSOR_EXPORT%60%20macro%20which%2C%20of%20course%2C%20breaks%20the%20build%20%3A%28%22%2C%20%22created_at%22%3A%20%222015-09-11T16%3A19%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T17%3A08%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/CMakeLists.txt%3AL26-44%22%7D%2C%20%22Pull%208576150cce7e5907da84eae353a380b80dfc43df%20parameter/CMakeLists.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39270581%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20put%20it%20right%20before%20its%20usage%2C%20so%20that%3A%5Cr%5Cn%5Cr%5Cn-%20it%27s%20obvious%20what%20it%20is%20for%5Cr%5Cn-%20we%20won%27t%20forget%20to%20remove%20it%20in%20case%20we%20don%27t%20use%20it%20anymore.%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A30%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A07%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL26-34%22%7D%2C%20%22Pull%208576150cce7e5907da84eae353a380b80dfc43df%20parameter/CMakeLists.txt%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39270711%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20coding%20style%20consistency%3A%5Cr%5Cn%5Cr%5Cn-%20change%20the%20command%20name%20to%20lower%20case%20%28if%20possible%29%5Cr%5Cn-%20remove%20the%20whitespace%20before%20the%20target%20name%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A31%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20macro%20is%20part%20of%20cmake%20project.%5Cr%5CnBetter%20to%20not%20overload%20it%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A54%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A07%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20mean%20to%20overload%20it%20but%20to%20write%20%60some_command_name%60%20instead%20of%20%60SOME_COMMAND_NAME%60%20consistently.%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A08%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A58%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL105-118%22%7D%2C%20%22Pull%204d34f524ea5b23cfcf0d8a779ff1a372414ebdd3%20parameter/InstanceConfigurableElement.h%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39402761%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22include%20last%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A50%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22this%20header%20is%20part%20of%20library%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A07%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A11%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/InstanceConfigurableElement.h%3AL29-37%22%7D%2C%20%22Pull%208576150cce7e5907da84eae353a380b80dfc43df%20parameter/CMakeLists.txt%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39271649%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20may%20simply%20use%20%60%5C%22%24%7BCMAKE_CURRENT_BINARY_DIR%7D/parameter_export.h%5C%22%60%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-11T13%3A41%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T14%3A07%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL123-130%22%7D%2C%20%22Pull%20da089390e7acfbb61b5fd7e1fd6504b7becfb3b7%20remote-processor/CMakeLists.txt%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39390733%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22if%20I%20understood%20correctly%2C%20this%20isn%27t%20needed%20on%202.8.12%2C%20right%20%3F%5Cr%5Cn%5Cr%5CnEDIT%3A%20but%20if%20you%20remove%20it%2C%20you%27ll%20probably%20have%20to%20change%20all%20the%20%60include%60s%20in%20the%20headers...%22%2C%20%22created_at%22%3A%20%222015-09-14T13%3A08%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20the%20file%20name%20is%20changed%20from%20remote-processor_export.h%20to%20remote_processor_export.h%20using%20this%20macro%22%2C%20%22created_at%22%3A%20%222015-09-14T13%3A29%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-14T13%3A54%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/CMakeLists.txt%3AL26-45%22%7D%2C%20%22Pull%202affd88e1693b9e816d1ef9bbdc2065d5dc1dbfc%20parameter/CMakeLists.txt%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39288129%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22not%20needed%20if%20you%20make%20xmlserializer%20static.%22%2C%20%22created_at%22%3A%20%222015-09-11T16%3A18%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T17%3A09%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL104-122%22%7D%2C%20%22Pull%204d34f524ea5b23cfcf0d8a779ff1a372414ebdd3%20remote-processor/RequestMessage.h%203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39403080%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22idem%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A53%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A11%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/RequestMessage.h%3AL34-41%22%7D%2C%20%22Pull%202affd88e1693b9e816d1ef9bbdc2065d5dc1dbfc%20test/test-subsystem/CMakeLists.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39288142%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22not%20needed%20if%20you%20make%20xmlserializer%20static.%22%2C%20%22created_at%22%3A%20%222015-09-11T16%3A18%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T17%3A09%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/test-subsystem/CMakeLists.txt%3AL36-43%22%7D%2C%20%22Pull%202affd88e1693b9e816d1ef9bbdc2065d5dc1dbfc%20parameter/CMakeLists.txt%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39287250%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22duplicate%22%2C%20%22created_at%22%3A%20%222015-09-11T16%3A08%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-11T16%3A20%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T17%3A09%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/CMakeLists.txt%3AL104-122%22%7D%2C%20%22Pull%20da089390e7acfbb61b5fd7e1fd6504b7becfb3b7%20bindings/python/CMakeLists.txt%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/218%23discussion_r39390945%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22add%20quotes%20around%20the%20path.%22%2C%20%22created_at%22%3A%20%222015-09-14T13%3A10%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-14T13%3A54%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/python/CMakeLists.txt%3AL36-45%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 8576150cce7e5907da84eae353a380b80dfc43df parameter/CMakeLists.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39270581'>File: parameter/CMakeLists.txt:L26-34</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Please put it right before its usage, so that:
- it's obvious what it is for
- we won't forget to remove it in case we don't use it anymore.
- [x] <a href='#crh-comment-Pull 8576150cce7e5907da84eae353a380b80dfc43df parameter/CMakeLists.txt 13'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39270711'>File: parameter/CMakeLists.txt:L105-118</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> For coding style consistency:
- change the command name to lower case (if possible)
- remove the whitespace before the target name
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> This macro is part of cmake project.
Better to not overload it
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I don't mean to overload it but to write `some_command_name` instead of `SOME_COMMAND_NAME` consistently.
- [x] <a href='#crh-comment-Pull 8576150cce7e5907da84eae353a380b80dfc43df parameter/CMakeLists.txt 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39270816'>File: parameter/CMakeLists.txt:L105-118</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Seems useless.
- [x] <a href='#crh-comment-Pull 8576150cce7e5907da84eae353a380b80dfc43df parameter/CMakeLists.txt 19'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39270933'>File: parameter/CMakeLists.txt:L105-118</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> You may simply use `"${CMAKE_CURRENT_BINARY_DIR}"`
- [x] <a href='#crh-comment-Pull 8576150cce7e5907da84eae353a380b80dfc43df parameter/CMakeLists.txt 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39271649'>File: parameter/CMakeLists.txt:L123-130</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> You may simply use `"${CMAKE_CURRENT_BINARY_DIR}/parameter_export.h"`
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#issuecomment-139550849'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> On windows, the generated filename is "somelib_Export.h" whereas the CMake documentation mentions "somelib_export.h"; likewise, the generated macro is "somelib_EXPORT" wheras the doc mentions "SOMELIB_EXPORT"... That's strange.
What's the result on Linux ?
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> No, I change the from parameter_Export to parameter_export.
it not related to OS
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I don't see anything in the patch that changes the generated header name nor the generated macro name.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Ok, nevermind :)
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> The documentation mentions `add_compiler_export_flags()` which add `-fvisibility=hidden` to the c++ flags. The documentation makes it looks like it needs to be called before add_library() but I'm convenient it isn't the case.
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> :-1:
- [x] <a href='#crh-comment-Pull 2affd88e1693b9e816d1ef9bbdc2065d5dc1dbfc parameter/CMakeLists.txt 12'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39287250'>File: parameter/CMakeLists.txt:L104-122</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> duplicate
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> What ?
- [x] <a href='#crh-comment-Pull 2affd88e1693b9e816d1ef9bbdc2065d5dc1dbfc remote-processor/CMakeLists.txt 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39287792'>File: remote-processor/CMakeLists.txt:L26-44</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> - coding style
- please group together the stuff related to symbol export (like you did in parameter/CMakeLists.txt)
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> (thanks Travis) This creates a `REMOTE-PROCESSOR_EXPORT` macro which, of course, breaks the build :(
- [x] <a href='#crh-comment-Pull 2affd88e1693b9e816d1ef9bbdc2065d5dc1dbfc parameter/CMakeLists.txt 11'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39288129'>File: parameter/CMakeLists.txt:L104-122</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> not needed if you make xmlserializer static.
- [x] <a href='#crh-comment-Pull 2affd88e1693b9e816d1ef9bbdc2065d5dc1dbfc test/test-subsystem/CMakeLists.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39288142'>File: test/test-subsystem/CMakeLists.txt:L36-43</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> not needed if you make xmlserializer static.
- [x] <a href='#crh-comment-Pull da089390e7acfbb61b5fd7e1fd6504b7becfb3b7 remote-processor/CMakeLists.txt 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39390733'>File: remote-processor/CMakeLists.txt:L26-45</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> if I understood correctly, this isn't needed on 2.8.12, right ?
EDIT: but if you remove it, you'll probably have to change all the `include`s in the headers...
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> Yes, the file name is changed from remote-processor_export.h to remote_processor_export.h using this macro
- [x] <a href='#crh-comment-Pull da089390e7acfbb61b5fd7e1fd6504b7becfb3b7 bindings/python/CMakeLists.txt 7'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39390945'>File: bindings/python/CMakeLists.txt:L36-45</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> add quotes around the path.
- [x] <a href='#crh-comment-Pull 4d34f524ea5b23cfcf0d8a779ff1a372414ebdd3 parameter/CMakeLists.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39402668'>File: parameter/CMakeLists.txt:L26-35</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> maybe add a comment about why we do that
- [x] <a href='#crh-comment-Pull 4d34f524ea5b23cfcf0d8a779ff1a372414ebdd3 parameter/InstanceConfigurableElement.h 11'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39402761'>File: parameter/InstanceConfigurableElement.h:L29-37</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> include last
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> this header is part of library
- [x] <a href='#crh-comment-Pull 4d34f524ea5b23cfcf0d8a779ff1a372414ebdd3 remote-processor/RemoteProcessorServer.h 2'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39403067'>File: remote-processor/RemoteProcessorServer.h:L35-42</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> missing include
- [x] <a href='#crh-comment-Pull 4d34f524ea5b23cfcf0d8a779ff1a372414ebdd3 remote-processor/RequestMessage.h 3'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39403080'>File: remote-processor/RequestMessage.h:L34-41</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> idem
- [x] <a href='#crh-comment-Pull 4d34f524ea5b23cfcf0d8a779ff1a372414ebdd3 remote-processor/AnswerMessage.h 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39403126'>File: remote-processor/AnswerMessage.h:L31-38</a></b>
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> missing include
- [x] <a href='#crh-comment-Pull 4d34f524ea5b23cfcf0d8a779ff1a372414ebdd3 parameter/ConfigurableElement.h 11'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/218#discussion_r39403207'>File: parameter/ConfigurableElement.h:L29-37</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Coding style says that header should be included from most local to farthest. Eg: local, ... std header. I would recommend including with `""`, not `<>`.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/218?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/218?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/218'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>