### PR TITLE
Appveyor: activate the compilation of parameter and remote-processor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,9 @@ cache:
 build_script:
 - mkdir build\64bits-release& cd build\64bits-release
 - cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64;%APPVEYOR_BUILD_FOLDER%\asio-1.10.6" ..\..
-- cmake --build . --config release --target xmlserializer
+- cmake --build . --config release --target parameter
+- cmake --build . --config release --target remote-processor
 - cd ..& mkdir 64bits-debug& cd 64bits-debug
 - cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64-debug;%APPVEYOR_BUILD_FOLDER%\asio-1.10.6" ..\..
-- cmake --build . --config debug --target xmlserializer
+- cmake --build . --config debug --target parameter
+- cmake --build . --config debug --target remote-processor

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,9 @@ cache:
 build_script:
 - mkdir build\64bits-release& cd build\64bits-release
 - cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64;%APPVEYOR_BUILD_FOLDER%\asio-1.10.6" ..\..
-- cmake --build . --config release --target parameter
-- cmake --build . --config release --target remote-processor
+- cmake --build . --config release --target test-platform
+- cmake --build . --config release --target remote-process
 - cd ..& mkdir 64bits-debug& cd 64bits-debug
 - cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64-debug;%APPVEYOR_BUILD_FOLDER%\asio-1.10.6" ..\..
-- cmake --build . --config debug --target parameter
-- cmake --build . --config debug --target remote-processor
+- cmake --build . --config debug --target test-platform
+- cmake --build . --config debug --target remote-process


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/223%23issuecomment-139607933%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/223%23issuecomment-140316033%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/223%23issuecomment-140324678%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/223%23issuecomment-139607933%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20%23218%20before.%22%2C%20%22created_at%22%3A%20%222015-09-11T17%3A32%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20merged%20%23229%20that%20should%20remove%20the%20%60strings.h%60%20inclusion%20failure.%20So%20I%20retrigered%20a%20appveyor%20build.%22%2C%20%22created_at%22%3A%20%222015-09-15T08%3A11%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Build%20succeeded.%20Merging.%22%2C%20%22created_at%22%3A%20%222015-09-15T08%3A45%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/223#issuecomment-139607933'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Need #218 before.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I merged #229 that should remove the `strings.h` inclusion failure. So I retrigered a appveyor build.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Build succeeded. Merging.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/223?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/223?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/223'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>