### PR TITLE
Distinguish between no & no new applicable configurations

### DIFF
--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -827,13 +827,25 @@ string CConfigurableDomain::getLastAppliedConfigurationName() const
 // Pending configuration
 string CConfigurableDomain::getPendingConfigurationName() const
 {
-    const CDomainConfiguration* pPendingConfiguration = getPendingConfiguration();
+    const CDomainConfiguration* pApplicableDomainConfiguration = findApplicableDomainConfiguration();
 
-    if (pPendingConfiguration) {
+    if (!pApplicableDomainConfiguration) {
 
-        return pPendingConfiguration->getName();
+        // No configuration is pending
+        return "<none>";
     }
-    return "<none>";
+
+    // Check it will be applied
+    if (pApplicableDomainConfiguration != _pLastAppliedConfiguration) {
+
+        // Found config will get applied
+        return pApplicableDomainConfiguration->getName();
+    }
+    else {
+
+        // Same configuration as current
+        return "";
+    }
 }
 
 // Ensure validity on whole domain from main blackboard


### PR DESCRIPTION
This patch allows additional distinction in the displaying of pending
configurations:
- if there's no applicable configuration the pending configuration will be
  shown as "<none>";
- if the applicable configuration is same as currently applied one, it will
be displayed as an empty string "".

Signed-off-by: Patrick Benavoli <patrick.benavoli@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/224%23issuecomment-140021096%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/224%23issuecomment-140027030%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/224%23issuecomment-140136207%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/224%23issuecomment-140021096%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20previously%20reviewed%20on%20%23197%22%2C%20%22created_at%22%3A%20%222015-09-14T09%3A50%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20needs%20to%20be%20documented%20somewhere.%22%2C%20%22created_at%22%3A%20%222015-09-14T10%3A08%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-14T16%3A33%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/224#issuecomment-140021096'>General Comment</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> :+1: previously reviewed on #197
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> This needs to be documented somewhere.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/224?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/224?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/224'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>