### PR TITLE
Switch Travis build back to containor mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ compiler:
 # it will not be necessary once travis worker is based on ubuntu > 12.04.
 # Install SWIG for bindings generation
 # Install valgrind for memcheck tests
-# Adding kalakris ppa for cmake 2.8.11.
+# Adding kubuntu-backports ppa for for cmake 2.8.12.
 # it is needed in case of multiple python version on host
 # Install python3-dev for the client simulator
 addons:
     apt:
         sources:
             - ubuntu-toolchain-r-test
-            - kalakris-cmake
+            - kubuntu-backports
         packages:
             - swig
             - valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,13 @@ compiler:
 # Install python3-dev for the client simulator
 addons:
     apt:
+        # Travis white list of ppa
+        # https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
         sources:
             - ubuntu-toolchain-r-test
             - kubuntu-backports
+        # Travis white list of dpkg packages
+        # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
         packages:
             - swig
             - valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Use travis docker infrastructure
-sudo: required
+sudo: false
 language: cpp
 
 env:
@@ -10,14 +10,28 @@ compiler:
     - gcc
     - clang
 
-before_install:
-    - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-    - sudo add-apt-repository --yes ppa:smspillaz/cmake-2.8.12 # Non official cmake backport
-    - sudo apt-get update -qq
+# Install a recent gcc and gcov,
+# it will not be necessary once travis worker is based on ubuntu > 12.04.
+# Install SWIG for bindings generation
+# Install valgrind for memcheck tests
+# Adding kalakris ppa for cmake 2.8.11.
+# it is needed in case of multiple python version on host
+# Install python3-dev for the client simulator
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+            - kalakris-cmake
+        packages:
+            - swig
+            - valgrind
+            - g++-4.8
+            - cmake
+            - python3-dev
+            - libasio-dev
 
 install:
-    - sudo apt-get install --yes swig cmake cmake-data valgrind g++-4.8 python3-dev libasio-dev
-    - sudo pip install cpp-coveralls
+    - pip install --user cpp-coveralls; export PATH=$HOME/.local/bin:$PATH
     - wget --directory-prefix $PREFIX/include
               https://raw.github.com/philsquared/Catch/master/single_include/catch.hpp
     - wget 'https://01.org/sites/default/files/asio-1.10.6.tar.gz'


### PR DESCRIPTION
travis was reverted to it's legacy mode, building with a vm instead of
a docker based container.

This change was made to be able to use sudo to install a recent cmake
package.

Nevertheless it had several disadvantages:
 - travis.yml is less readable
 - build is slower (not that much though)
 - recipe require sudo

After double checking, a few ppa witelisted for the container
contained a cmake recent backport. So using docker travis mode
is possible.

 - Revert to container build as this is the preferred and recommended travis build mode.
 - Install a more version cmake with a whitelisted ppa backport
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/227%23issuecomment-140081933%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/227%23issuecomment-140099363%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/227%23issuecomment-140099537%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/227%23issuecomment-140110931%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/227%23issuecomment-140120806%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/227%23issuecomment-140081933%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22after%20%23218%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-14T13%3A52%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%40dawagner%20%40miguelgaio%20%40OznOg%20Please%20review.%20Ignore%20last%20patch%20%28%5C%22Add%20support%20for%20Export/Import%20symbols%20API%5C%22%29%20as%20it%20is%20a%20travis%20test%20to%20check%20that%20%23218%20is%20not%20broken.%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A31%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23218%20is%20not%20brocken%20by%20this%20pull%20request%20as%20proven%20by%20https%3A//travis-ci.org/01org/parameter-framework/builds/80249749%22%2C%20%22created_at%22%3A%20%222015-09-14T14%3A31%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A08%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-14T15%3A45%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/227#issuecomment-140081933'>General Comment</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> after #218 ?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: @dawagner @miguelgaio @OznOg Please review. Ignore last patch ("Add support for Export/Import symbols API") as it is a travis test to check that #218 is not broken.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> #218 is not brocken by this pull request as proven by https://travis-ci.org/01org/parameter-framework/builds/80249749


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/227?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/227?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/227'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>