### PR TITLE
Use appveyor cache to speed up initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Also, CMake can build a project out-of-tree, which is the recommended method:
     cmake /path/to/sources/of/parameter-framework
     make
 
-After an install you may want to run the parameter-framework tests with
+After a build you may want to run the parameter-framework tests with
 `make test`.
 
 You may take a look at `.travis.yml` and `appveyor.yml` for examples on how we

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Also, CMake can build a project out-of-tree, which is the recommended method:
     make
 
 After a build you may want to run the parameter-framework tests with
-`make test`.
+`make test` or `ctest`.
 
 You may take a look at `.travis.yml` and `appveyor.yml` for examples on how we
 build the Parameter Framework in the CI.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,16 +5,18 @@ branches:
 os: Visual Studio 2015
 install:
 - cinst cmake.portable wget 7zip.commandline
-- if not exist / (
+- dir
+- if not exist libxml2-x86_64 (
     wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip &
     7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
-- if not exist / (
+- if not exist libxml2-x86_64-debug (
     wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip &
     7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
-- if not exist / (
+- if not exist asio-1.10.6 (
     wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz &
     7z x asio-1.10.6.tar.gz &
     7z x asio-1.10.6.tar)
+- dir
 - set PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64;%APPVEYOR_BUILD_FOLDER%\asio-1.10.6
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64'
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,13 @@ branches:
 os: Visual Studio 2015
 install:
 - cinst cmake.portable wget 7zip.commandline
-- if not exist libxml2-x86_64 (
+- if not exist / (
     wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip &
     7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
-- if not exist libxml2-x86_64-debug (
+- if not exist / (
     wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip &
     7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
-- if not exist asio-1.10.6 (
+- if not exist / (
     wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz &
     7z x asio-1.10.6.tar.gz &
     7z x asio-1.10.6.tar)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,18 +5,24 @@ branches:
 os: Visual Studio 2015
 install:
 - cinst cmake.portable wget 7zip.commandline
-- wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-- wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-- wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz
-- 7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-- 7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-- 7z x asio-1.10.6.tar.gz
-- 7z x asio-1.10.6.tar
+- if not exist libxml2-x86_64 (
+    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
+    7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
+- if not exist libxml2-x86_64-debug (
+    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
+    7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
+- if not exist asio-1.10.6 (
+    wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz
+    7z x asio-1.10.6.tar.gz
+    7z x asio-1.10.6.tar)
 - set PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64;%APPVEYOR_BUILD_FOLDER%\asio-1.10.6
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64'
 cache:
 - C:\ProgramData\chocolatey\bin -> appveyor.yml
 - C:\ProgramData\chocolatey\lib -> appveyor.yml
+- libxml2-x86_64                -> appveyor.yml
+- libxml2-x86_64-debug          -> appveyor.yml
+- asio-1.10.6                   -> appveyor.yml
 build_script:
 - mkdir build\64bits-release& cd build\64bits-release
 - cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -DCMAKE_PREFIX_PATH="%PREFIX_PATH%" ..\..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,15 @@ os: Visual Studio 2015
 install:
 - cinst cmake.portable wget 7zip.commandline
 - if not exist libxml2-x86_64 (
-    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip;
-    7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip;)
+    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip &
+    7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
 - if not exist libxml2-x86_64-debug (
-    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip;
-    7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip;)
+    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip &
+    7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
 - if not exist asio-1.10.6 (
-    wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz;
-    7z x asio-1.10.6.tar.gz;
-    7z x asio-1.10.6.tar;)
+    wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz &
+    7z x asio-1.10.6.tar.gz &
+    7z x asio-1.10.6.tar)
 - set PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64;%APPVEYOR_BUILD_FOLDER%\asio-1.10.6
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64'
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,15 @@ os: Visual Studio 2015
 install:
 - cinst cmake.portable wget 7zip.commandline
 - if not exist libxml2-x86_64 (
-    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-    7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
+    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip;
+    7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip;)
 - if not exist libxml2-x86_64-debug (
-    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-    7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
+    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip;
+    7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip;)
 - if not exist asio-1.10.6 (
-    wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz
-    7z x asio-1.10.6.tar.gz
-    7z x asio-1.10.6.tar)
+    wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz;
+    7z x asio-1.10.6.tar.gz;
+    7z x asio-1.10.6.tar;)
 - set PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64;%APPVEYOR_BUILD_FOLDER%\asio-1.10.6
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64'
 cache:


### PR DESCRIPTION
- Use the cache feature for depedancies
 - Use VS instead of nmake for multithreading
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/234%23issuecomment-140540857%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/234%23issuecomment-140540857%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A-1%3A%20For%20some%20unknown%20reason%2C%20appveyor%20is%20not%20restoring%20the%20cache.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-15T21%3A06%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/234#issuecomment-140540857'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :-1: For some unknown reason, appveyor is not restoring the cache.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/234?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/234?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/234'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>