### PR TITLE
Handle -Wconversion compile flags

### DIFF
--- a/bindings/c/ParameterFramework.cpp
+++ b/bindings/c/ParameterFramework.cpp
@@ -333,7 +333,7 @@ bool pfwSetIntParameter(PfwParameterHandler *handle, int32_t value)
     return status.forward(handle->parameter.setAsSignedInteger(value, status.msg()));
 }
 
-bool pfwGetStringParameter(const PfwParameterHandler *handle, const char *value[])
+bool pfwGetStringParameter(const PfwParameterHandler *handle, char *value[])
 {
     Status &status = handle->pfw.lastStatus;
     *value = NULL;

--- a/bindings/c/ParameterFramework.h
+++ b/bindings/c/ParameterFramework.h
@@ -263,7 +263,7 @@ bool pfwSetIntParameter(PfwParameterHandler *handle, int32_t value) NONNULL USER
   * @return true on success, false on failure.
   */
 CPARAMETER_EXPORT
-bool pfwGetStringParameter(const PfwParameterHandler *handle, const char *value[]) NONNULL;
+bool pfwGetStringParameter(const PfwParameterHandler *handle, char *value[]) NONNULL;
 
 /** Set the value of a previously bind string parameter.
   * @param handle[in] Handler to a valid parameter

--- a/bindings/c/Test.cpp
+++ b/bindings/c/Test.cpp
@@ -345,12 +345,12 @@ TEST_CASE_METHOD(Test, "Parameter-framework c api use") {
                 }
 
                 WHEN("Set parameter") {
-                    const char *value;
+                    char *value;
                     REQUIRE_SUCCESS(pfwSetStringParameter(param, "ok"));
                     THEN("Get parameter should return what was set") {
                         REQUIRE_SUCCESS(pfwGetStringParameter(param, &value));
                         REQUIRE(value == std::string("ok"));
-                        pfwFree((void *)value);
+                        pfwFree(value);
                     }
                 }
 

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -111,12 +111,12 @@ bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializi
 
         if (!xmlElement.getAttribute("Min", (int32_t &)_uiMin)) {
 
-            _uiMin = 1UL << sizeInBits;
+            _uiMin = 1U << sizeInBits;
         }
 
         if (!xmlElement.getAttribute("Max", (int32_t &)_uiMax)) {
 
-            _uiMax = (1UL << sizeInBits) - 1;
+            _uiMax = (1U << sizeInBits) - 1;
         }
         signExtend((int32_t&)_uiMin);
         signExtend((int32_t&)_uiMax);
@@ -128,7 +128,7 @@ bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializi
 
         if (!xmlElement.getAttribute("Max", _uiMax)) {
 
-            _uiMax = (size_t)-1L >> (8 * sizeof(size_t) - sizeInBits);
+            _uiMax = ~0U >> (8 * sizeof(size_t) - sizeInBits);
         }
     }
 

--- a/remote-processor/CMakeLists.txt
+++ b/remote-processor/CMakeLists.txt
@@ -44,7 +44,7 @@ find_package(Threads REQUIRED)
 # If asio isn't installed in a standard directory, add the correct directory to
 # CMAKE_PREFIX_PATH (see the main README for more information).
 find_path(ASIO_DIR NAMES asio.hpp)
-target_include_directories(remote-processor PUBLIC "${ASIO_DIR}")
+target_include_directories(remote-processor SYSTEM PUBLIC "${ASIO_DIR}")
 
 include_directories("${PROJECT_SOURCE_DIR}/utility"
                     "${CMAKE_CURRENT_BINARY_DIR}")

--- a/remote-processor/Message.cpp
+++ b/remote-processor/Message.cpp
@@ -41,7 +41,7 @@ CMessage::CMessage(MsgType ucMsgId) :
 }
 
 CMessage::CMessage() :
-    _ucMsgId(static_cast<MsgType>(-1)), _uiIndex(0)
+    _ucMsgId(MsgType::EInvalid), _uiIndex(0)
 {
 }
 

--- a/remote-processor/Message.h
+++ b/remote-processor/Message.h
@@ -45,7 +45,8 @@ public:
     {
         ECommandRequest,
         ESuccessAnswer,
-        EFailureAnswer
+        EFailureAnswer,
+        EInvalid = static_cast<uint8_t>(-1),
     };
     CMessage(MsgType ucMsgId);
     CMessage();

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -38,7 +38,7 @@
 
 using std::string;
 
-CTestPlatform::CTestPlatform(const string& strClass, int iPortNumber) :
+CTestPlatform::CTestPlatform(const string& strClass, uint16_t iPortNumber) :
     mParameterMgrPlatformConnector(strClass),
     mLogger(),
     mRemoteProcessorServer(iPortNumber)

--- a/test/test-platform/TestPlatform.h
+++ b/test/test-platform/TestPlatform.h
@@ -44,7 +44,7 @@ class CTestPlatform
     typedef TRemoteCommandHandlerTemplate<CTestPlatform> CCommandHandler;
     typedef CCommandHandler::CommandStatus CommandReturn;
 public:
-    CTestPlatform(const std::string &strclass, int iPortNumber);
+    CTestPlatform(const std::string &strclass, uint16_t iPortNumber);
     virtual ~CTestPlatform();
 
     // Init

--- a/test/test-platform/main.cpp
+++ b/test/test-platform/main.cpp
@@ -41,12 +41,12 @@ using std::cerr;
 using std::endl;
 using std::string;
 
-static const int iDefaultPortNumber = 5001;
+static const uint16_t defaultPortNumber = 5001;
 
 static void showUsage()
 {
     cerr << "test-platform [-h|--help] <file path> [port number, default "
-         << iDefaultPortNumber << "]" << endl;
+         << defaultPortNumber << "]" << endl;
 }
 
 static void showInvalidUsage(const string &error)
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     options.pop_front();
 
     // Handle optional port number argument
-    int portNumber = iDefaultPortNumber;
+    uint16_t portNumber = defaultPortNumber;
 
     if (not options.empty()) {
         if (convertTo(options.front(), portNumber)) {


### PR DESCRIPTION
To support more compiler as ms one, add more constraints
on warning generation. ie. add -Wconversion flags on gcc.

Also fix build issues trig by this activation.

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/235%23issuecomment-140990009%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23issuecomment-141450217%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39726768%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39726957%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39727269%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39728945%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39838288%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39853441%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39853442%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39853444%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39853445%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39949874%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39950179%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39950462%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39950595%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39954612%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r40654337%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r40654338%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r40654339%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r40654340%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23issuecomment-140990009%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40OznOg%20%40krocard%20%40dawagner%20%40cc6565%20%20%20please%20review%22%2C%20%22created_at%22%3A%20%222015-09-17T07%3A17%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-18T13%3A21%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b92481b663609d017a7552f3c2aff8f228bf81e2%20CMakeLists.txt%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39726768%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Not%20removing%20anything.%22%2C%20%22created_at%22%3A%20%222015-09-17T09%3A33%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60%60%60%20cmake%5Cr%5Cntarget_include_directories%28remote-processor%20SYSTEM%20PUBLIC%20%5C%22%24%7BASIO_DIR%7D%5C%22%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-09-17T09%3A35%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-18T13%3A21%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CMakeLists.txt%3AL63-72%22%7D%2C%20%22Pull%2099e480f87fe51e67ec8cc192afca629d667c58d0%20remote-processor/Message.cpp%2077%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39838288%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23238%20clean%20all%20of%20this%22%2C%20%22created_at%22%3A%20%222015-09-18T09%3A31%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-18T13%3A21%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/Message.cpp%3AL246-260%22%7D%2C%20%22Pull%2099e480f87fe51e67ec8cc192afca629d667c58d0%20remote-processor/Message.h%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39949874%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22-%20For%20invalid%20value%20we%20usually%20hardcode%20some%20arbitrary%20value%20like%20%60205%60%20or%20%60187%60%20or%20%6066%60...%20Matter%20of%20style%20though.%5Cr%5Cn-%20Why%20%60%7E0%60%2C%20it%20was%20%60-1%60%20before%2C%20isn%27t%20it%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-21T08%3A40%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-29T10%3A05%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/Message.h%3AL44-52%22%7D%2C%20%22Pull%20b92481b663609d017a7552f3c2aff8f228bf81e2%20remote-processor/Message.h%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39728945%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20rather%20name%20it%20%60EInvalid%60%22%2C%20%22created_at%22%3A%20%222015-09-17T10%3A00%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-18T13%3A21%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/Message.h%3AL45-53%22%7D%2C%20%22Pull%20b92481b663609d017a7552f3c2aff8f228bf81e2%20parameter/SubsystemObjectFactory.h%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39727269%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Pretty%20sure%20that%20a%20better%20fix%20would%20be%20%60numeric_limits%3Csize_t%3E%3A%3Amax%28%29%60%22%2C%20%22created_at%22%3A%20%222015-09-17T09%3A39%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-18T13%3A21%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/SubsystemObjectFactory.h%3AL36-43%22%7D%2C%20%22Pull%2099e480f87fe51e67ec8cc192afca629d667c58d0%20bindings/c/ParameterFramework.h%20116%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39954612%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Drop%20patch%20as%20you%20did%20it%20in%20the%20other%20way.%22%2C%20%22created_at%22%3A%20%222015-09-21T09%3A47%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-29T10%3A05%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/c/ParameterFramework.h%3AL260-266%22%7D%2C%20%22Pull%2099e480f87fe51e67ec8cc192afca629d667c58d0%20test/test-subsystem/TESTSubsystemBinary.cpp%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39950595%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60//%20FIXME%3A%20use%20convertTo%3Cint%3E%20to%20detect%20overflows%60%22%2C%20%22created_at%22%3A%20%222015-09-21T08%3A52%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-29T10%3A05%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/test-subsystem/TESTSubsystemBinary.cpp%3AL59-68%22%7D%2C%20%22Pull%2099e480f87fe51e67ec8cc192afca629d667c58d0%20test/test-platform/TestPlatform.cpp%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39950462%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22-%20Maybe%20%60state%60%20should%20not%20be%20an%20%60size_t%60%20but%20rather%20an%20int%20%3F%20Either%20case%20an%20overflow%20check%20might%20be%20useful.%20Although%20maybe%20just%20add%20a%20%60TODO%60%20as%20test-platform%20is%20a%20test%20executable%20%28and%20%60nbState%60%20%3C%20%60argc%60%20if%20using%20remote-process%29.%5Cr%5Cn-%20%20Or%20maybe%20it%20is%20addValuePair%20that%20should%20take%20a%20%60size_t%60.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-21T08%3A50%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/test-platform/TestPlatform.cpp%3AL291-298%22%7D%2C%20%22Pull%2099e480f87fe51e67ec8cc192afca629d667c58d0%20test/test-platform/TestPlatform.cpp%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/235%23discussion_r39950179%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Consider%20using%20convertTo%3Cint%3E%22%2C%20%22created_at%22%3A%20%222015-09-21T08%3A45%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-29T10%3A05%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/test-platform/TestPlatform.cpp%3AL246-253%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 99e480f87fe51e67ec8cc192afca629d667c58d0 test/test-platform/TestPlatform.cpp 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39950462'>File: test/test-platform/TestPlatform.cpp:L291-298</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - Maybe `state` should not be an `size_t` but rather an int ? Either case an overflow check might be useful. Although maybe just add a `TODO` as test-platform is a test executable (and `nbState` < `argc` if using remote-process).
-  Or maybe it is addValuePair that should take a `size_t`.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#issuecomment-140990009'>General Comment</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> @OznOg @krocard @dawagner @cc6565   please review
- [x] <a href='#crh-comment-Pull b92481b663609d017a7552f3c2aff8f228bf81e2 CMakeLists.txt 6'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39726768'>File: CMakeLists.txt:L63-72</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Not removing anything.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> 
``` cmake
target_include_directories(remote-processor SYSTEM PUBLIC "${ASIO_DIR}")
```
- [x] <a href='#crh-comment-Pull b92481b663609d017a7552f3c2aff8f228bf81e2 parameter/SubsystemObjectFactory.h 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39727269'>File: parameter/SubsystemObjectFactory.h:L36-43</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Pretty sure that a better fix would be `numeric_limits<size_t>::max()`
- [x] <a href='#crh-comment-Pull b92481b663609d017a7552f3c2aff8f228bf81e2 remote-processor/Message.h 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39728945'>File: remote-processor/Message.h:L45-53</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I would rather name it `EInvalid`
- [x] <a href='#crh-comment-Pull 99e480f87fe51e67ec8cc192afca629d667c58d0 remote-processor/Message.cpp 77'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39838288'>File: remote-processor/Message.cpp:L246-260</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> #238 clean all of this
- [x] <a href='#crh-comment-Pull 99e480f87fe51e67ec8cc192afca629d667c58d0 remote-processor/Message.h 6'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39949874'>File: remote-processor/Message.h:L44-52</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - For invalid value we usually hardcode some arbitrary value like `205` or `187` or `66`... Matter of style though.
- Why `~0`, it was `-1` before, isn't it ?
- [x] <a href='#crh-comment-Pull 99e480f87fe51e67ec8cc192afca629d667c58d0 test/test-platform/TestPlatform.cpp 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39950179'>File: test/test-platform/TestPlatform.cpp:L246-253</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Consider using convertTo<int>
- [x] <a href='#crh-comment-Pull 99e480f87fe51e67ec8cc192afca629d667c58d0 test/test-subsystem/TESTSubsystemBinary.cpp 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39950595'>File: test/test-subsystem/TESTSubsystemBinary.cpp:L59-68</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> `// FIXME: use convertTo<int> to detect overflows`
- [x] <a href='#crh-comment-Pull 99e480f87fe51e67ec8cc192afca629d667c58d0 bindings/c/ParameterFramework.h 116'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/235#discussion_r39954612'>File: bindings/c/ParameterFramework.h:L260-266</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Drop patch as you did it in the other way.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/235?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/235?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/235'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>