### PR TITLE
Use appveyor cache to speed up initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Also, CMake can build a project out-of-tree, which is the recommended method:
     cmake /path/to/sources/of/parameter-framework
     make
 
-After an install you may want to run the parameter-framework tests with
-`make test`.
+After a build you may want to run the parameter-framework tests with
+`make test` or `ctest`.
 
 You may take a look at `.travis.yml` and `appveyor.yml` for examples on how we
 build the Parameter Framework in the CI.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
 - if not exist asio-1.10.6 (
     wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz &
     7z x asio-1.10.6.tar.gz &
-    7z x asio-1.10.6.tar)
+    7z x -i"!asio*/include" asio-1.10.6.tar)
 - set PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\asio-1.10.6
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64'
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,18 +5,24 @@ branches:
 os: Visual Studio 2015
 install:
 - cinst cmake.portable wget 7zip.commandline
-- wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-- wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-- wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz
-- 7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-- 7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip
-- 7z x asio-1.10.6.tar.gz
-- 7z x asio-1.10.6.tar
+- if not exist libxml2-x86_64 (
+    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip &
+    7z x libxml2-x86_64-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
+- if not exist libxml2-x86_64-debug (
+    wget --no-check-certificate https://01.org/sites/default/files/libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip &
+    7z x libxml2-x86_64-debug-3eaedba1b64180668fdab7ad2eba549586017bf3.zip)
+- if not exist asio-1.10.6 (
+    wget --no-check-certificate https://01.org/sites/default/files/asio-1.10.6.tar.gz &
+    7z x asio-1.10.6.tar.gz &
+    7z x asio-1.10.6.tar)
 - set PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\asio-1.10.6
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64'
 cache:
 - C:\ProgramData\chocolatey\bin -> appveyor.yml
 - C:\ProgramData\chocolatey\lib -> appveyor.yml
+- libxml2-x86_64                -> appveyor.yml
+- libxml2-x86_64-debug          -> appveyor.yml
+- asio-1.10.6                   -> appveyor.yml
 build_script:
 - mkdir build\64bits-release& cd build\64bits-release
 - cmake -G "NMake Makefiles" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DBASH_COMPLETION=OFF -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%\libxml2-x86_64;%PREFIX_PATH%" ..\..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 1.0.{build}
 branches:
   only:
   - windows_port
+# Only download the 50 first commits like travis to speedup clone
+clone_depth: 50
 os: Visual Studio 2015
 install:
 - cinst cmake.portable wget 7zip.commandline


### PR DESCRIPTION
- Avoid downloading all commits (dl only the 50 first)
- Only unpack asio header
- Use Appveyor cache for external dependency

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/236%23issuecomment-140866235%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23issuecomment-140866535%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23issuecomment-141002599%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23issuecomment-141006325%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23discussion_r39772927%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23discussion_r39831455%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23issuecomment-141411210%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23discussion_r39847302%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23discussion_r39849256%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23discussion_r39852232%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/236%23discussion_r39852463%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/236%23issuecomment-140866235%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20can%20not%20be%20sure%20it%20this%20cache%20setup%20works.%20It%20seems%20only%20some%20builds%20use%20the%20cache.%5Cr%5Cn%20-%20This%20build%20does%3A%20https%3A//ci.appveyor.com/project/parameter-framework/parameter-framework/build/1.0.206%5Cr%5Cn%20-%20This%20build%20mention%20that%20the%20cache%20is%20invalided%3A%20https%3A//ci.appveyor.com/project/parameter-framework/parameter-framework/build/1.0.212%5Cr%5Cn%20-%20This%20build%20does%20not%20even%20mention%20the%20cache%20%28most%20do%20not%29%3A%20https%3A//ci.appveyor.com/project/parameter-framework/parameter-framework/build/1.0.211%5Cr%5Cn%5Cr%5CnI%20really%20do%20not%20understand%20why%20the%20cache%20is%20not%20restored%20in%20some%20builds.%20Nevertheless%20I%20am%20quite%20confident%20that%20if%20ever%20it%20is%20restored%2C%20dependencies%20should%20not%20be%20installed%20again.%5Cr%5Cn%5Cr%5CnMy%20implementation%20is%20heavily%20inspired%20from%20http%3A//stackoverflow.com/questions/31480622/appveyor-caching-of-dependencies%22%2C%20%22created_at%22%3A%20%222015-09-16T19%3A43%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Please%20review%20%40dawagner%20%40OznOg%20%40cc6565%20%40miguelgaio%22%2C%20%22created_at%22%3A%20%222015-09-16T19%3A44%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40krocard%20The%20doc%20mentions%3A%20%5C%22the%20resulting%20cache%20cannot%20exceed%20100MB%5C%22.%20Maybe%20that%27s%20the%20reason%20why%20the%20cache%20is%20broken%3A%20asio%2Blibxml2%2Blibxml_debug%20%3D%2056MB%5Cr%5Cn%5Cr%5CnI%27d%20suggest%20extracting%20only%20useful%20parts%20of%20the%20asio%20archive%20%28i.e.%20only%20the%20%60include%60%20folder%29.%20This%20brings%20the%20total%20down%20to%2029MB.%22%2C%20%22created_at%22%3A%20%222015-09-17T08%3A25%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20would%20be%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%207z%20x%20%27-x%21asio-1.10.6/doc%27%20%27-x%21asio-1.10.6/src%27%20asio-1.10.6.tar%22%2C%20%22created_at%22%3A%20%222015-09-17T08%3A37%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%40miguelgaio%20please%20review.%22%2C%20%22created_at%22%3A%20%222015-09-18T10%3A13%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205408614d748bd8ffab9b558b094e1e2a8b0781c2%20appveyor.yml%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/236%23discussion_r39847302%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20checksum%20check.%22%2C%20%22created_at%22%3A%20%222015-09-18T11%3A56%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20not.%22%2C%20%22created_at%22%3A%20%222015-09-18T12%3A27%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20do%20you%20what%20to%20protect%20from%20%3F%5Cr%5Cn%20-%20If%20it%20is%20from%20transfer%20corruption%2C%207zip%20will%20protect%20from%20that%5Cr%5Cn%20-%20If%20it%20is%20from%20a%20attacher%2C%20then%20it%20would%20be%20useful.%5Cr%5Cn%5Cr%5CnNevertheless%20I%20did%20not%20find%20a%20way%20of%20easly%20do%20the%20check.%20wget%20does%20not%20have%20an%20such%20option.%5Cr%5Cn%5Cr%5CnThus%20I%20will%20not%20do%20it%20as%3A%5Cr%5Cn%20-%20it%20has%20nothing%20to%20do%20with%20seeding%20up%20the%20setup%5Cr%5Cn%20-%20it%20is%20not%20trivial%5Cr%5Cn%20-%20such%20attach%20would%20not%20be%20very%20dangerous.%22%2C%20%22created_at%22%3A%20%222015-09-18T13%3A07%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22to%20confirm%20a%20contract%20and%20you%20have%20a%20control%20on%20remote%20library%22%2C%20%22created_at%22%3A%20%222015-09-18T13%3A10%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20appveyor.yml%3AL2-30%22%7D%2C%20%22Pull%200c5e695ba368081b680cc3910a00456603cddf1c%20appveyor.yml%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/236%23discussion_r39772927%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40dawagner%20said%3A%5Cr%5Cn%3E%20Unfortunately%2C%20this%20can%20break%20%60git%20describe%20--tags%60%20-%20which%20is%20used%20in%20the%20main%20CMakeLists.txt.%20This%20is%20currently%20only%20used%20for%20documentation%20generation%20but%20I%27m%20afraid%20it%20will%20lead%20to%20%5C%22interesting%20bugs%5C%22%20when%20we%20want%20to%20use%20it%20for%20more.%5Cr%5CnWell%20travis%20has%20a%2050%20history%20so%20I%20should%20maybe%20use%20the%20same.%20What%20is%20your%20opinion%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-17T17%3A22%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20may%20be%20an%20acceptable%20compromise.%5Cr%5Cn%5Cr%5CnBTW%3A%20I%20just%20made%20a%20%60git%20clone%20--depth%3D10%20--branch%3Dwindows_port%60%20but%20I%20get%20more%20than%2010%20commits%20on%20the%20first%20parent%20history%20line...%20I%20don%27t%20get%20how%20that%20works.%22%2C%20%22created_at%22%3A%20%222015-09-18T07%3A50%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20appveyor.yml%3AL2-30%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 0c5e695ba368081b680cc3910a00456603cddf1c appveyor.yml 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/236#discussion_r39772927'>File: appveyor.yml:L2-30</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> @dawagner said:
> Unfortunately, this can break `git describe --tags` - which is used in the main CMakeLists.txt. This is currently only used for documentation generation but I'm afraid it will lead to "interesting bugs" when we want to use it for more.
Well travis has a 50 history so I should maybe use the same. What is your opinion ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> That may be an acceptable compromise.
BTW: I just made a `git clone --depth=10 --branch=windows_port` but I get more than 10 commits on the first parent history line... I don't get how that works.
- [x] <a href='#crh-comment-Pull 5408614d748bd8ffab9b558b094e1e2a8b0781c2 appveyor.yml 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/236#discussion_r39847302'>File: appveyor.yml:L2-30</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> Add checksum check.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Why not.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> What do you what to protect from ?
- If it is from transfer corruption, 7zip will protect from that
- If it is from a attacher, then it would be useful.
Nevertheless I did not find a way of easly do the check. wget does not have an such option.
Thus I will not do it as:
- it has nothing to do with seeding up the setup
- it is not trivial
- such attach would not be very dangerous.
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> to confirm a contract and you have a control on remote library
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/236#issuecomment-140866235'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I can not be sure it this cache setup works. It seems only some builds use the cache.
- This build does: https://ci.appveyor.com/project/parameter-framework/parameter-framework/build/1.0.206
- This build mention that the cache is invalided: https://ci.appveyor.com/project/parameter-framework/parameter-framework/build/1.0.212
- This build does not even mention the cache (most do not): https://ci.appveyor.com/project/parameter-framework/parameter-framework/build/1.0.211
I really do not understand why the cache is not restored in some builds. Nevertheless I am quite confident that if ever it is restored, dependencies should not be installed again.
My implementation is heavily inspired from http://stackoverflow.com/questions/31480622/appveyor-caching-of-dependencies
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: Please review @dawagner @OznOg @cc6565 @miguelgaio
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard The doc mentions: "the resulting cache cannot exceed 100MB". Maybe that's the reason why the cache is broken: asio+libxml2+libxml_debug = 56MB
I'd suggest extracting only useful parts of the asio archive (i.e. only the `include` folder). This brings the total down to 29MB.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> That would be:
7z x '-x!asio-1.10.6/doc' '-x!asio-1.10.6/src' asio-1.10.6.tar
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: @miguelgaio please review.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/236?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/236?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/236'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>