### PR TITLE
Utility: add path helpers

### DIFF
--- a/parameter/FrameworkConfigurationLocation.h
+++ b/parameter/FrameworkConfigurationLocation.h
@@ -47,9 +47,6 @@ public:
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
 private:
-    // Detect relative path
-    bool isPathRelative() const;
-
     // Path
     std::string _strPath;
 };

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -353,17 +353,10 @@ CParameterMgr::CParameterMgr(const string& strConfigurationFilePath, log::ILogge
     addChild(new CSystemClass(_logger));
     addChild(new CConfigurableDomains);
 
-    // Configuration file folder
-    std::string::size_type slashPos = _strXmlConfigurationFilePath.rfind('/', -1);
-    if(slashPos == std::string::npos) {
-        // Configuration folder is the current folder
-        _strXmlConfigurationFolderPath = '.';
-    } else {
-        _strXmlConfigurationFolderPath = _strXmlConfigurationFilePath.substr(0, slashPos);
-    }
 
-    // Schema absolute folder location
-    _strSchemaFolderLocation = _strXmlConfigurationFolderPath + "/" + gacSystemSchemasSubFolder;
+    _strXmlConfigurationFolderPath = CUtility::dirName(_strXmlConfigurationFilePath);
+
+    _strSchemaFolderLocation = _strXmlConfigurationFolderPath + gacSystemSchemasSubFolder;
 }
 
 CParameterMgr::~CParameterMgr()

--- a/parameter/XmlFileIncluderElement.cpp
+++ b/parameter/XmlFileIncluderElement.cpp
@@ -32,6 +32,7 @@
 #include "XmlMemoryDocSink.h"
 #include "XmlElementSerializingContext.h"
 #include "ElementLibrary.h"
+#include "Utility.h"
 #include <assert.h>
 #include <fstream>
 
@@ -54,7 +55,7 @@ bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSeriali
     xmlElement.getAttribute("Path", strPath);
 
     // Relative path?
-    if (strPath[0] != '/') {
+    if (CUtility::isPathRelative(strPath)) {
 
         strPath = elementSerializingContext.getXmlFolder() + "/" + strPath;
     }

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -27,9 +27,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 if (WIN32)
-    set(UTILITY_OS_SPECIFIC_FILES windows/DynamicLibrary.cpp)
+    set(UTILITY_OS_SPECIFIC_FILES windows/Utility.cpp windows/DynamicLibrary.cpp)
 else ()
-    set(UTILITY_OS_SPECIFIC_FILES posix/DynamicLibrary.cpp)
+    set(UTILITY_OS_SPECIFIC_FILES posix/Utility.cpp posix/DynamicLibrary.cpp)
 endif ()
 
 include_directories(

--- a/utility/Utility.h
+++ b/utility/Utility.h
@@ -77,4 +77,20 @@ public:
      */
     static bool isHexadecimal(const std::string& strValue);
 
+    /**
+     * Returns the string up to, but not including, the final os separator (/ on linux, \ on
+     * windows). This function aims to mock dirname() behaviour in a portable way.
+     * @param[in] path
+     *
+     * @return the dirname
+     */
+    static std::string dirName(const std::string &path);
+
+    /**
+     * Tells if a path is relative.
+     * @param[in] path
+     *
+     * @return true if path is relative, false otherwise
+     */
+    static bool isPathRelative(const std::string &path);
 };

--- a/utility/posix/Utility.cpp
+++ b/utility/posix/Utility.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,58 +27,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "FrameworkConfigurationLocation.h"
+
 #include "Utility.h"
-#include <assert.h>
 
-#define base CKindElement
+#include <libgen.h>
 
-CFrameworkConfigurationLocation::CFrameworkConfigurationLocation(const std::string& strName, const std::string& strKind) : base(strName, strKind)
+std::string CUtility::dirName(const std::string &path)
 {
-}
-
-// From IXmlSink
-bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
-{
-    xmlElement.getAttribute("Path", _strPath);
-
-    if (_strPath.empty()) {
-
-        serializingContext.setError("Empty Path attribute in element " + xmlElement.getPath());
-
-        return false;
+    auto slashPos = path.rfind('/', -1);
+    if (slashPos == std::string::npos) {
+        return { "" };
     }
-    return true;
+    return path.substr(0, slashPos);
 }
 
-// File path
-std::string CFrameworkConfigurationLocation::getFilePath(const std::string& strBaseFolder) const
+bool CUtility::isPathRelative(const std::string &path)
 {
-    if (CUtility::isPathRelative(_strPath)) {
-
-        return strBaseFolder + "/" + _strPath;
-    }
-    return _strPath;
+    return path[0] != '/';
 }
-
-// Folder path
-std::string CFrameworkConfigurationLocation::getFolderPath(const std::string& strBaseFolder) const
-{
-    auto slashPos = _strPath.rfind('/', -1);
-
-    if (CUtility::isPathRelative(_strPath)) {
-
-        if (slashPos == std::string::npos) {
-
-            return strBaseFolder;
-        }
-
-        return strBaseFolder + "/" + CUtility::dirName(_strPath);
-    } else {
-
-        assert(slashPos != std::string::npos);
-
-        return CUtility::dirName(_strPath);
-    }
-}
-

--- a/utility/windows/Utility.cpp
+++ b/utility/windows/Utility.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,58 +27,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "FrameworkConfigurationLocation.h"
+
 #include "Utility.h"
-#include <assert.h>
 
-#define base CKindElement
-
-CFrameworkConfigurationLocation::CFrameworkConfigurationLocation(const std::string& strName, const std::string& strKind) : base(strName, strKind)
+std::string CUtility::dirName(const std::string &path)
 {
+    char directory[_MAX_DIR];
+
+    _splitpath_s(path.c_str(), NULL, 0, directory, _MAX_DIR, NULL, 0, NULL, 0);
+
+    return directory;
 }
 
-// From IXmlSink
-bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CUtility::isPathRelative(const std::string &path)
 {
-    xmlElement.getAttribute("Path", _strPath);
-
-    if (_strPath.empty()) {
-
-        serializingContext.setError("Empty Path attribute in element " + xmlElement.getPath());
-
-        return false;
-    }
-    return true;
+    return dirName(path)[0] != '\\';
 }
-
-// File path
-std::string CFrameworkConfigurationLocation::getFilePath(const std::string& strBaseFolder) const
-{
-    if (CUtility::isPathRelative(_strPath)) {
-
-        return strBaseFolder + "/" + _strPath;
-    }
-    return _strPath;
-}
-
-// Folder path
-std::string CFrameworkConfigurationLocation::getFolderPath(const std::string& strBaseFolder) const
-{
-    auto slashPos = _strPath.rfind('/', -1);
-
-    if (CUtility::isPathRelative(_strPath)) {
-
-        if (slashPos == std::string::npos) {
-
-            return strBaseFolder;
-        }
-
-        return strBaseFolder + "/" + CUtility::dirName(_strPath);
-    } else {
-
-        assert(slashPos != std::string::npos);
-
-        return CUtility::dirName(_strPath);
-    }
-}
-


### PR DESCRIPTION
This patch add a dirname and a isPathRelative() in utility and uses it in the code.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39852733%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39885003%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39961147%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39961662%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39961725%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39965719%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20ebf33000e2c65742b725e5c0264ffd1b45658042%20utility/windows/Utility.cpp%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39961662%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20%5BPath.GetDirectoryName%5D%28https%3A//msdn.microsoft.com/en-us/library/ee433810.aspx%29%22%2C%20%22created_at%22%3A%20%222015-09-21T11%3A41%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22this%20is%20C%23%20not%20C%2B%2B%22%2C%20%22created_at%22%3A%20%222015-09-21T12%3A43%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/windows/Utility.cpp%3AL1-46%22%7D%2C%20%22Pull%20ebf33000e2c65742b725e5c0264ffd1b45658042%20utility/windows/Utility.cpp%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39961725%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22WTF%20%3F%20%22%2C%20%22created_at%22%3A%20%222015-09-21T11%3A43%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/windows/Utility.cpp%3AL1-46%22%7D%2C%20%22Pull%20ebf33000e2c65742b725e5c0264ffd1b45658042%20utility/posix/Utility.cpp%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39852733%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20not%20using%20dirname%28%29%20/%20%20POSIX.1%202000%20compliant%5Cr%5Cnthen%20explictly%20add%20war%20if%20dirname%20%3D%20%5C%22.%5C%22%20return%20empty%20string%22%2C%20%22created_at%22%3A%20%222015-09-18T13%3A12%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60dirname%60%20is%20not%20standard%20C%20or%20C%2B%2B%20%28posix%20as%20you%20said%29%20so%20I%20guess%20it%20is%20not%20available%20on%20Windows.%22%2C%20%22created_at%22%3A%20%222015-09-21T11%3A32%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/posix/Utility.cpp%3AL1-48%22%7D%2C%20%22Pull%20ebf33000e2c65742b725e5c0264ffd1b45658042%20parameter/FrameworkConfigurationLocation.cpp%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/240%23discussion_r39885003%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22is%20this%20still%20relevant%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-18T18%3A19%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/FrameworkConfigurationLocation.cpp%3AL66-85%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull ebf33000e2c65742b725e5c0264ffd1b45658042 utility/posix/Utility.cpp 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/240#discussion_r39852733'>File: utility/posix/Utility.cpp:L1-48</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> Why not using dirname() /  POSIX.1 2000 compliant
then explictly add war if dirname = "." return empty string
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> `dirname` is not standard C or C++ (posix as you said) so I guess it is not available on Windows.
- [ ] <a href='#crh-comment-Pull ebf33000e2c65742b725e5c0264ffd1b45658042 parameter/FrameworkConfigurationLocation.cpp 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/240#discussion_r39885003'>File: parameter/FrameworkConfigurationLocation.cpp:L66-85</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> is this still relevant ?
- [ ] <a href='#crh-comment-Pull ebf33000e2c65742b725e5c0264ffd1b45658042 utility/windows/Utility.cpp 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/240#discussion_r39961662'>File: utility/windows/Utility.cpp:L1-46</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Use [Path.GetDirectoryName](https://msdn.microsoft.com/en-us/library/ee433810.aspx)
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> this is C# not C++
- [ ] <a href='#crh-comment-Pull ebf33000e2c65742b725e5c0264ffd1b45658042 utility/windows/Utility.cpp 44'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/240#discussion_r39961725'>File: utility/windows/Utility.cpp:L1-46</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> WTF ?


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/240?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/240?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/240'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>