### PR TITLE
Parameter manager multithreading usage

### DIFF
--- a/xmlserializer/CMakeLists.txt
+++ b/xmlserializer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -32,7 +32,8 @@ add_library(xmlserializer STATIC
     XmlDocSource.cpp
     XmlMemoryDocSink.cpp
     XmlMemoryDocSource.cpp
-    XmlStreamDocSink.cpp)
+    XmlStreamDocSink.cpp
+    XmlUtil.cpp)
 
 set_target_properties(xmlserializer PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 

--- a/xmlserializer/XmlUtil.cpp
+++ b/xmlserializer/XmlUtil.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <libxml/parser.h>
+
+/* Provides miscellaneous utility functions */
+class CXmlUtil
+{
+public:
+    /* xmlInitParser must be called in the main thread if multithreading is required
+     * @see http://xmlsoft.org/threads.html
+     * @see http://www.programmershare.com/1669782/
+     */
+    CXmlUtil() {
+        xmlInitParser();
+    }
+};
+
+static CXmlUtil xml_init;


### PR DESCRIPTION
The libxml2 library, which is a dependency of
the parameter framework, requires a specific usage
in case of multithreading.

Indeed, if the libxml2 library is used by several
threads, the function xmlInitParser() has to be called
at program start in the main thread (i.e. a thread that
lives until process exit).

This patch introduces a static method "initForMultithreading"
to follow this requirement. The user has to call it at program
start in the main thread if multithreading is used.

Signed-off-by: Thomas Cahuzac <thomasx.cahuzac@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/246%23issuecomment-142222723%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/246%23issuecomment-142224513%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/246%23discussion_r40105267%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/246%23discussion_r40115386%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/246%23discussion_r40180758%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/246%23issuecomment-142222723%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Based%20on%20%2355%20%22%2C%20%22created_at%22%3A%20%222015-09-22T09%3A15%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-22T09%3A23%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2042d46ada8d3552c7f8d1d521b7bb3a2c38700ba0%20xmlserializer/XmlUtil.cpp%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/246%23discussion_r40105267%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20introduced%20a%20potential%20race%20condition.%20In%20your%20second%20link%2C%20and%20by%20reading%20libxml2%27s%20code%2C%20I%20understood%20that%20%60xmlnitParser%60%20can%20be%20safely%20called%20multiple%20times%2C%20as%20long%20as%20it%20is%20called%20%2Asequentially%2A%20%28as%20opposed%20to%20%2Ain%20parallel%2A%29.%5Cr%5Cn%5Cr%5CnIt%20would%20be%20safer%20to%20put%20a%20static%20CXmlUtil%20object%20in%20a%20function%20%28e.g.%20in%20xmlserializer%20and%20call%20that%20function%20from%20ParameterMgr%27s%20constructor%29%20%28See%20%5C%22effective%20C%2B%2B%5C%22%3A%20%5C%22%20C%2B%2B%27s%20guarantees%20that%20local%20static%20objects%20are%20initialized%20when%20the%20object%27s%20definition%20is%20first%20encountered%20during%20a%20call%20to%20that%20function.%5C%22%20-%20that%20is%20not%20the%20case%20for%20non-local%20objects%2C%20e.g.%20this%20%60xml_init%60%20object%29.%22%2C%20%22created_at%22%3A%20%222015-09-22T16%3A01%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%20%20-%20xml_init-%3ExmlInit%5Cn%20%20-%20Do%20you%20mean%20that%20there%20is%20a%20race%20if%20some%20other%20code%20in%20the%20process%20%5Cncall%20xmlInitParser%20concurrently%20with%20xml_init%20initialization%20%3F%5Cn%20%20%20%20If%20so%20I%20do%20not%20see%20how%20a%20function%20static%20object%20would%20prevent%20that.%5Cn%5CnOn%2009/22/2015%2006%3A01%20PM%2C%20David%20Wagner%20wrote%3A%5Cn%3E%5Cn%3E%20In%20xmlserializer/XmlUtil.cpp%20%5Cn%3E%20%3Chttps%3A//github.com/01org/parameter-framework/pull/246%23discussion_r40105267%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%2B%23include%20%3Clibxml/parser.h%3E%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B/%2A%20Provides%20miscellaneous%20utility%20functions%20%2A/%5Cn%3E%20%3E%20%2Bclass%20CXmlUtil%5Cn%3E%20%3E%20%2B%7B%5Cn%3E%20%3E%20%2Bpublic%3A%5Cn%3E%20%3E%20%2B%20%20%20%20/%2A%20xmlInitParser%20must%20be%20called%20in%20the%20main%20thread%20if%20multithreading%20is%20required%5Cn%3E%20%3E%20%2B%20%20%20%20%20%2A%20%40see%20http%3A//xmlsoft.org/threads.html%5Cn%3E%20%3E%20%2B%20%20%20%20%20%2A%20%40see%20http%3A//www.programmershare.com/1669782/%5Cn%3E%20%3E%20%2B%20%20%20%20%20%2A/%5Cn%3E%20%3E%20%2B%20%20%20%20CXmlUtil%28%29%20%7B%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20xmlInitParser%28%29%3B%5Cn%3E%20%3E%20%2B%20%20%20%20%7D%5Cn%3E%20%3E%20%2B%7D%3B%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2Bstatic%20CXmlUtil%20xml_init%3B%5Cn%3E%5Cn%3E%20This%20introduced%20a%20potential%20race%20condition.%20In%20your%20second%20link%2C%20and%20%5Cn%3E%20by%20reading%20libxml2%27s%20code%2C%20I%20understood%20that%20%7CxmlnitParser%7C%20can%20be%20%5Cn%3E%20safely%20called%20multiple%20times%2C%20as%20long%20as%20it%20is%20called%20/sequentially/%20%5Cn%3E%20%28as%20opposed%20to%20/in%20parallel/%29.%5Cn%3E%5Cn%3E%20It%20would%20be%20safer%20to%20put%20a%20static%20CXmlUtil%20object%20in%20a%20function%20%28e.g.%20%5Cn%3E%20in%20xmlserializer%20and%20call%20that%20function%20from%20ParameterMgr%27s%20%5Cn%3E%20constructor%29%20%28See%20%5C%22effective%20C%2B%2B%5C%22%3A%20%5C%22%20C%2B%2B%27s%20guarantees%20that%20local%20%5Cn%3E%20static%20objects%20are%20initialized%20when%20the%20object%27s%20definition%20is%20first%20%5Cn%3E%20encountered%20during%20a%20call%20to%20that%20function.%5C%22%20-%20that%20is%20not%20the%20case%20%5Cn%3E%20for%20non-local%20objects%2C%20e.g.%20this%20%7Cxml_init%7C%20object%29.%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%20%5Cn%3E%20%3Chttps%3A//github.com/01org/parameter-framework/pull/246/files%23r40105267%3E.%5Cn%3E%5Cn%5Cn---------------------------------------------------------------------%5CnIntel%20Corporation%20SAS%20%28French%20simplified%20joint%20stock%20company%29%5CnRegistered%20headquarters%3A%20%5C%22Les%20Montalets%5C%22-%202%2C%20rue%20de%20Paris%2C%20%5Cn92196%20Meudon%20Cedex%2C%20France%5CnRegistration%20Number%3A%20%20302%20456%20199%20R.C.S.%20NANTERRE%5CnCapital%3A%204%2C572%2C000%20Euros%5Cn%5CnThis%20e-mail%20and%20any%20attachments%20may%20contain%20confidential%20material%20for%5Cnthe%20sole%20use%20of%20the%20intended%20recipient%28s%29.%20Any%20review%20or%20distribution%5Cnby%20others%20is%20strictly%20prohibited.%20If%20you%20are%20not%20the%20intended%5Cnrecipient%2C%20please%20contact%20the%20sender%20and%20delete%20all%20copies.%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-22T17%3A24%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Of%20course%2C%20we%20can%27t%20prevent%20%2Athat%2A.%20I%20actually%20meant%20that%20%60xml_init%60%20might%20be%20created%20twice%20in%20parallel%20and%20I%20considered%20the%20alternative%20-%20that%20%60ParameterMgr%60s%20constructor%20could%20be%20called%20twice%20in%20parallel%20-%20is%20less%20likely.%5Cr%5Cn%5Cr%5CnBut%20thinking%20again%20about%20that%2C%20I%20realize%20that%27s%20probably%20a%20wrong%20assumption.%5Cr%5Cn%5Cr%5Cn%3A%2B1%3A%20after%20your%20coding%20style%20remark.%22%2C%20%22created_at%22%3A%20%222015-09-23T08%3A37%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20xmlserializer/XmlUtil.cpp%3AL1-47%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/246#issuecomment-142222723'>General Comment</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> Based on #55
- [x] <a href='#crh-comment-Pull 42d46ada8d3552c7f8d1d521b7bb3a2c38700ba0 xmlserializer/XmlUtil.cpp 46'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/246#discussion_r40105267'>File: xmlserializer/XmlUtil.cpp:L1-47</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> This introduced a potential race condition. In your second link, and by reading libxml2's code, I understood that `xmlnitParser` can be safely called multiple times, as long as it is called *sequentially* (as opposed to *in parallel*).
It would be safer to put a static CXmlUtil object in a function (e.g. in xmlserializer and call that function from ParameterMgr's constructor) (See "effective C++": " C++'s guarantees that local static objects are initialized when the object's definition is first encountered during a call to that function." - that is not the case for non-local objects, e.g. this `xml_init` object).
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - xml_init->xmlInit
- Do you mean that there is a race if some other code in the process
call xmlInitParser concurrently with xml_init initialization ?
If so I do not see how a function static object would prevent that.
On 09/22/2015 06:01 PM, David Wagner wrote:
>
> In xmlserializer/XmlUtil.cpp
> <https://github.com/01org/parameter-framework/pull/246#discussion_r40105267>:
>
> > +#include <libxml/parser.h>
> > +
> > +/* Provides miscellaneous utility functions */
> > +class CXmlUtil
> > +{
> > +public:
> > +    /* xmlInitParser must be called in the main thread if multithreading is required
> > +     * @see http://xmlsoft.org/threads.html
> > +     * @see http://www.programmershare.com/1669782/
> > +     */
> > +    CXmlUtil() {
> > +        xmlInitParser();
> > +    }
> > +};
> > +
> > +static CXmlUtil xml_init;
>
> This introduced a potential race condition. In your second link, and
> by reading libxml2's code, I understood that |xmlnitParser| can be
> safely called multiple times, as long as it is called /sequentially/
> (as opposed to /in parallel/).
>
> It would be safer to put a static CXmlUtil object in a function (e.g.
> in xmlserializer and call that function from ParameterMgr's
> constructor) (See "effective C++": " C++'s guarantees that local
> static objects are initialized when the object's definition is first
> encountered during a call to that function." - that is not the case
> for non-local objects, e.g. this |xml_init| object).
>
> —
> Reply to this email directly or view it on GitHub
> <https://github.com/01org/parameter-framework/pull/246/files#r40105267>.
>
---------------------------------------------------------------------
Intel Corporation SAS (French simplified joint stock company)
Registered headquarters: "Les Montalets"- 2, rue de Paris,
92196 Meudon Cedex, France
Registration Number:  302 456 199 R.C.S. NANTERRE
Capital: 4,572,000 Euros
This e-mail and any attachments may contain confidential material for
the sole use of the intended recipient(s). Any review or distribution
by others is strictly prohibited. If you are not the intended
recipient, please contact the sender and delete all copies.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Of course, we can't prevent *that*. I actually meant that `xml_init` might be created twice in parallel and I considered the alternative - that `ParameterMgr`s constructor could be called twice in parallel - is less likely.
But thinking again about that, I realize that's probably a wrong assumption.
:+1: after your coding style remark.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/246?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/246?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/246'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>