### PR TITLE
xmlserializer: load Xsd Schema from xml attribute

### DIFF
--- a/bindings/python/pfw.i
+++ b/bindings/python/pfw.i
@@ -97,8 +97,8 @@ public:
     void setFailureOnFailedSettingsLoad(bool bFail);
     bool getFailureOnFailedSettingsLoad() const;
 
-    void setSchemaFolderLocation(const std::string& strSchemaFolderLocation);
-    const std::string& getSchemaFolderLocation() const;
+    void setSchemaUri(const std::string& schemaUri);
+    const std::string& getSchemaUri() const;
 
     void setValidateSchemasOnStart(bool bValidate);
     bool getValidateSchemasOnStart() const;

--- a/doc/requirements/APIs.md
+++ b/doc/requirements/APIs.md
@@ -61,7 +61,7 @@ Currently only used for XML generation. There is no requirement associated.
 
 Currently only used for XML generaton. There is no requirement associated.
 
-## `setSchemaFolderLocation` and `getSchemaFolderLocation`; `setValidateSchemasOnStart` and `getValidateSchemasOnStart`
+## `setSchemaUri` and `getSchemaUri`; `setValidateSchemasOnStart` and `getValidateSchemasOnStart`
 
 **???**
 

--- a/parameter/FrameworkConfigurationLocation.cpp
+++ b/parameter/FrameworkConfigurationLocation.cpp
@@ -27,6 +27,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "XmlDocSource.h"
 #include "FrameworkConfigurationLocation.h"
 #include <assert.h>
 
@@ -53,38 +54,5 @@ bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXm
 // File path
 std::string CFrameworkConfigurationLocation::getFilePath(const std::string& strBaseFolder) const
 {
-    if (isPathRelative()) {
-
-        return strBaseFolder + "/" + _strPath;
-    }
-    return _strPath;
-}
-
-// Folder path
-std::string CFrameworkConfigurationLocation::getFolderPath(const std::string& strBaseFolder) const
-{
-    auto slashPos = _strPath.rfind('/', -1);
-
-    if (isPathRelative()) {
-
-        if (slashPos != std::string::npos) {
-
-            return strBaseFolder + "/" + _strPath.substr(0, slashPos);
-
-        } else {
-
-            return strBaseFolder;
-        }
-    } else {
-
-        assert(slashPos != std::string::npos);
-
-        return _strPath.substr(0, slashPos);
-    }
-}
-
-// Detect relative path
-bool CFrameworkConfigurationLocation::isPathRelative() const
-{
-    return _strPath[0] != '/';
+    return CXmlDocSource::mkUri(strBaseFolder, _strPath);
 }

--- a/parameter/FrameworkConfigurationLocation.cpp
+++ b/parameter/FrameworkConfigurationLocation.cpp
@@ -40,9 +40,9 @@ CFrameworkConfigurationLocation::CFrameworkConfigurationLocation(const std::stri
 // From IXmlSink
 bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
-    xmlElement.getAttribute("Path", _strPath);
+    xmlElement.getAttribute("Path", _configurationUri);
 
-    if (_strPath.empty()) {
+    if (_configurationUri.empty()) {
 
         serializingContext.setError("Empty Path attribute in element " + xmlElement.getPath());
 
@@ -51,8 +51,7 @@ bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXm
     return true;
 }
 
-// File path
-std::string CFrameworkConfigurationLocation::getFilePath(const std::string& strBaseFolder) const
+const std::string& CFrameworkConfigurationLocation::getUri() const
 {
-    return CXmlDocSource::mkUri(strBaseFolder, _strPath);
+    return _configurationUri;
 }

--- a/parameter/FrameworkConfigurationLocation.h
+++ b/parameter/FrameworkConfigurationLocation.h
@@ -38,13 +38,13 @@ class CFrameworkConfigurationLocation : public CKindElement
 public:
     CFrameworkConfigurationLocation(const std::string& strName, const std::string& strKind);
 
-    // File path
-    std::string getFilePath(const std::string& strBaseFolder) const;
+    /** Get Configuration file URI
+     */
+    const std::string& getUri() const;
 
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
 private:
 
-    // Path
-    std::string _strPath;
+    std::string _configurationUri;
 };

--- a/parameter/FrameworkConfigurationLocation.h
+++ b/parameter/FrameworkConfigurationLocation.h
@@ -41,14 +41,9 @@ public:
     // File path
     std::string getFilePath(const std::string& strBaseFolder) const;
 
-    // Folder path
-    std::string getFolderPath(const std::string& strBaseFolder) const;
-
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
 private:
-    // Detect relative path
-    bool isPathRelative() const;
 
     // Path
     std::string _strPath;

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -326,7 +326,7 @@ CParameterMgr::CParameterMgr(const string& strConfigurationFilePath, log::ILogge
     _bAutoSyncOn(true),
     _pMainParameterBlackboard(new CParameterBlackboard),
     _pElementLibrarySet(new CElementLibrarySet),
-    _strXmlConfigurationFilePath(strConfigurationFilePath),
+    _xmlConfigurationUri(CXmlDocSource::mkUri(strConfigurationFilePath, "")),
     _pSubsystemPlugins(NULL),
     _pRemoteProcessorServer(NULL),
     _maxCommandUsageLength(0),
@@ -342,9 +342,6 @@ CParameterMgr::CParameterMgr(const string& strConfigurationFilePath, log::ILogge
     addChild(new CSelectionCriteria);
     addChild(new CSystemClass(_logger));
     addChild(new CConfigurableDomains);
-
-    // Configuration file folder
-    _strXmlConfigurationFolderPath = CXmlDocSource::mkUri(_strXmlConfigurationFilePath, ".");
 }
 
 CParameterMgr::~CParameterMgr()
@@ -453,13 +450,13 @@ bool CParameterMgr::loadFrameworkConfiguration(string& strError)
     // Parse Structure XML file
     CXmlElementSerializingContext elementSerializingContext(strError);
 
-    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(_strXmlConfigurationFilePath, true, true, elementSerializingContext);
+    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(_xmlConfigurationUri, true, true, elementSerializingContext);
     if (doc == NULL) {
         return false;
     }
 
     if (!xmlParse(elementSerializingContext, getFrameworkConfiguration(), doc,
-                  _strXmlConfigurationFolderPath, EFrameworkConfigurationLibrary)) {
+                  _xmlConfigurationUri, EFrameworkConfigurationLibrary)) {
 
         return false;
     }
@@ -523,24 +520,21 @@ bool CParameterMgr::loadStructure(string& strError)
         return false;
     }
 
-    // Get Xml structure file name
-    string strXmlStructureFilePath = pStructureDescriptionFileLocation->getFilePath(_strXmlConfigurationFolderPath);
-
-    // Get Xml structure folder
-    string strXmlStructureFolder = CXmlDocSource::mkUri(strXmlStructureFilePath, ".");
-
     // Parse Structure XML file
     CXmlParameterSerializingContext parameterBuildContext(strError);
 
     {
-        LOG_CONTEXT("Importing system structure from file " + strXmlStructureFilePath);
+        // Get structure URI
+        string structureUri = CXmlDocSource::mkUri(_xmlConfigurationUri, pStructureDescriptionFileLocation->getUri());
 
-        _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strXmlStructureFilePath, true, true, parameterBuildContext);
+        LOG_CONTEXT("Importing system structure from file " + structureUri);
+
+        _xmlDoc *doc = CXmlDocSource::mkXmlDoc(structureUri, true, true, parameterBuildContext);
         if (doc == NULL) {
             return false;
         }
 
-        if (!xmlParse(parameterBuildContext, pSystemClass, doc, strXmlStructureFolder, EParameterCreationLibrary)) {
+        if (!xmlParse(parameterBuildContext, pSystemClass, doc, structureUri, EParameterCreationLibrary)) {
 
             return false;
         }
@@ -602,11 +596,8 @@ bool CParameterMgr::loadSettingsFromConfigFile(string& strError)
     // Get destination root element
     CConfigurableDomains* pConfigurableDomains = getConfigurableDomains();
 
-    // Get Xml configuration domains file name
-    string strXmlConfigurationDomainsFilePath = pConfigurableDomainsFileLocation->getFilePath(_strXmlConfigurationFolderPath);
-
-    // Get Xml configuration domains folder
-    string strXmlConfigurationDomainsFolder = CXmlDocSource::mkUri(_strXmlConfigurationFolderPath, ".");
+    // Get Xml configuration domains URI
+    string configurationDomainsUri = CXmlDocSource::mkUri(_xmlConfigurationUri, pConfigurableDomainsFileLocation->getUri());
 
     // Parse configuration domains XML file
     CXmlDomainImportContext xmlDomainImportContext(strError, true, *getSystemClass());
@@ -617,29 +608,29 @@ bool CParameterMgr::loadSettingsFromConfigFile(string& strError)
     // Auto validation of configurations
     xmlDomainImportContext.setAutoValidationRequired(true);
 
-    info() << "Importing configurable domains from file " << strXmlConfigurationDomainsFilePath
+    info() << "Importing configurable domains from file " << configurationDomainsUri
            << " with settings";
 
-    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strXmlConfigurationDomainsFilePath, true, true, xmlDomainImportContext);
+    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(configurationDomainsUri, true, true, xmlDomainImportContext);
     if (doc == NULL) {
         return false;
     }
 
     return xmlParse(xmlDomainImportContext, pConfigurableDomains, doc,
-                    strXmlConfigurationDomainsFolder, EParameterConfigurationLibrary,
+                    _xmlConfigurationUri, EParameterConfigurationLibrary,
                     "SystemClassName");
 }
 
 // XML parsing
 bool CParameterMgr::xmlParse(CXmlElementSerializingContext& elementSerializingContext,
                              CElement* pRootElement, _xmlDoc* doc,
-                             const string& strXmlFolder,
+                             const string& baseUri,
                              CParameterMgr::ElementLibrary eElementLibrary,
                              const string& strNameAttributeName)
 {
     // Init serializing context
     elementSerializingContext.set(_pElementLibrarySet->getElementLibrary(
-                                  eElementLibrary), strXmlFolder);
+                                  eElementLibrary), baseUri);
 
     CXmlDocSource docSource(doc, _bValidateSchemasOnStart,
                             pRootElement->getKind(),

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -125,9 +125,6 @@ using namespace core;
 // Used for remote processor server creation
 typedef IRemoteProcessorServerInterface* (*CreateRemoteProcessorServer)(uint16_t uiPort, IRemoteCommandHandler* pCommandHandler);
 
-// Global Schemas folder (fixed)
-const char* gacSystemSchemasSubFolder = "Schemas/";
-
 // Config File System looks normally like this:
 // ---------------------------------------------
 //|-- <ParameterFrameworkConfiguration>.xml
@@ -348,9 +345,6 @@ CParameterMgr::CParameterMgr(const string& strConfigurationFilePath, log::ILogge
 
     // Configuration file folder
     _strXmlConfigurationFolderPath = CXmlDocSource::mkUri(_strXmlConfigurationFilePath, ".");
-
-    // Schema absolute folder location
-    _strSchemaFolderLocation = CXmlDocSource::mkUri(_strXmlConfigurationFolderPath, gacSystemSchemasSubFolder);
 }
 
 CParameterMgr::~CParameterMgr()
@@ -652,6 +646,9 @@ bool CParameterMgr::xmlParse(CXmlElementSerializingContext& elementSerializingCo
                             pRootElement->getName(),
                             strNameAttributeName);
 
+    // Schema Uri
+    setSchemaUri(docSource.getSchemaUri());
+
     // Start clean
     pRootElement->clean();
 
@@ -785,14 +782,14 @@ bool CParameterMgr::getFailureOnFailedSettingsLoad() const
     return _bFailOnFailedSettingsLoad;
 }
 
-const string& CParameterMgr::getSchemaFolderLocation() const
+const string& CParameterMgr::getSchemaUri() const
 {
-    return _strSchemaFolderLocation;
+    return _schemaUri;
 }
 
-void CParameterMgr::setSchemaFolderLocation(const string& strSchemaFolderLocation)
+void CParameterMgr::setSchemaUri(const string& schemaUri)
 {
-    _strSchemaFolderLocation = strSchemaFolderLocation;
+    _schemaUri = schemaUri;
 }
 
 void CParameterMgr::setValidateSchemasOnStart(bool bValidate)
@@ -2256,13 +2253,10 @@ bool CParameterMgr::serializeElement(std::ostream& output,
         return false;
     }
 
-    // Get Schema file associated to root element
-    string xmlSchemaFilePath = CXmlDocSource::mkUri(_strSchemaFolderLocation, element.getKind() + ".xsd");
-
     // Use a doc source by loading data from instantiated Configurable Domains
     CXmlMemoryDocSource memorySource(&element, _bValidateSchemasOnStart,
                                      element.getKind(),
-                                     xmlSchemaFilePath,
+                                     getSchemaUri(),
                                      "parameter-framework",
                                      getVersion());
 

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -543,14 +543,14 @@ private:
      * @param[in] elementSerializingContext serializing context
      * @param[out] pRootElement the receiving element
      * @param[in] input the input XML stream
-     * @param[in] strXmlFolder the folder containing the XML input file (if applicable) or ""
+     * @param[in] baseUri the XML input file URI or ""
      * @param[in] eElementLibrary which element library to be used
      * @param[in] strNameAttributeName the name of the element's XML "name" attribute
      *
      * @returns true if parsing succeeded, false otherwise
      */
     bool xmlParse(CXmlElementSerializingContext& elementSerializingContext, CElement* pRootElement,
-                  _xmlDoc* doc, const std::string& strXmlFolder,
+                  _xmlDoc* doc, const std::string& baseUri,
                   ElementLibrary eElementLibrary, const std::string& strNameAttributeName = "Name");
 
     /** Wrapper for converting public APIs semantics to internal API
@@ -697,8 +697,7 @@ private:
     CElementLibrarySet* _pElementLibrarySet;
 
     // XML parsing, object creation handling
-    std::string _strXmlConfigurationFilePath; // Configuration file path
-    std::string _strXmlConfigurationFolderPath; // Root folder for configuration file
+    std::string _xmlConfigurationUri;
     std::string _schemaUri; // Place where schemas stand
 
     // Subsystem plugin location

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -171,17 +171,17 @@ public:
       */
     bool getFailureOnFailedSettingsLoad() const;
 
-    /** Get the path to the directory containing the XML Schemas
+    /** Get the XML Schemas URI
      *
-     * @returns the directory containing the XML Schemas
+     * @returns the XML Schemas URI
      */
-    const std::string& getSchemaFolderLocation() const;
+    const std::string& getSchemaUri() const;
 
-    /** Override the directory containing the XML Schemas
+    /** Override the XML Schemas URI
      *
-     * @param[in] strSchemaFolderLocation directory containing the XML Schemas
+     * @param[in] schemaUri XML Schemas URI
      */
-    void setSchemaFolderLocation(const std::string& strSchemaFolderLocation);
+    void setSchemaUri(const std::string& schemaUri);
 
     /** Should .xml files be validated on start ?
      *
@@ -699,7 +699,7 @@ private:
     // XML parsing, object creation handling
     std::string _strXmlConfigurationFilePath; // Configuration file path
     std::string _strXmlConfigurationFolderPath; // Root folder for configuration file
-    std::string _strSchemaFolderLocation; // Place where schemas stand
+    std::string _schemaUri; // Place where schemas stand
 
     // Subsystem plugin location
     const CSubsystemPlugins* _pSubsystemPlugins;

--- a/parameter/ParameterMgrFullConnector.cpp
+++ b/parameter/ParameterMgrFullConnector.cpp
@@ -138,14 +138,14 @@ bool CParameterMgrFullConnector::getFailureOnFailedSettingsLoad() const
     return _pParameterMgr->getFailureOnFailedSettingsLoad();
 }
 
-const string& CParameterMgrFullConnector::getSchemaFolderLocation() const
+const string& CParameterMgrFullConnector::getSchemaUri() const
 {
-    return _pParameterMgr->getSchemaFolderLocation();
+    return _pParameterMgr->getSchemaUri();
 }
 
-void CParameterMgrFullConnector::setSchemaFolderLocation(const string& strSchemaFolderLocation)
+void CParameterMgrFullConnector::setSchemaUri(const string& schemaUri)
 {
-    _pParameterMgr->setSchemaFolderLocation(strSchemaFolderLocation);
+    _pParameterMgr->setSchemaUri(schemaUri);
 }
 
 void CParameterMgrFullConnector::setValidateSchemasOnStart(bool bValidate)

--- a/parameter/ParameterMgrPlatformConnector.cpp
+++ b/parameter/ParameterMgrPlatformConnector.cpp
@@ -137,14 +137,14 @@ bool CParameterMgrPlatformConnector::getFailureOnFailedSettingsLoad() const
     return _pParameterMgr->getFailureOnFailedSettingsLoad();
 }
 
-const string& CParameterMgrPlatformConnector::getSchemaFolderLocation() const
+const string& CParameterMgrPlatformConnector::getSchemaUri() const
 {
-    return _pParameterMgr->getSchemaFolderLocation();
+    return _pParameterMgr->getSchemaUri();
 }
 
-void CParameterMgrPlatformConnector::setSchemaFolderLocation(const string& strSchemaFolderLocation)
+void CParameterMgrPlatformConnector::setSchemaUri(const string& schemaUri)
 {
-    _pParameterMgr->setSchemaFolderLocation(strSchemaFolderLocation);
+    _pParameterMgr->setSchemaUri(schemaUri);
 }
 
 bool CParameterMgrPlatformConnector::setValidateSchemasOnStart(

--- a/parameter/XmlElementSerializingContext.cpp
+++ b/parameter/XmlElementSerializingContext.cpp
@@ -38,10 +38,10 @@ CXmlElementSerializingContext::CXmlElementSerializingContext(string& strError) :
 }
 
 // Init
-void CXmlElementSerializingContext::set(const CElementLibrary* pElementLibrary, const string& strXmlFolder)
+void CXmlElementSerializingContext::set(const CElementLibrary* pElementLibrary, const string& xmlUri)
 {
     _pElementLibrary = pElementLibrary;
-    _strXmlFolder = strXmlFolder;
+    _xmlUri = xmlUri;
 }
 
 // ElementLibrary
@@ -51,7 +51,7 @@ const CElementLibrary* CXmlElementSerializingContext::getElementLibrary() const
 }
 
 // XML Folder Path
-const string& CXmlElementSerializingContext::getXmlFolder() const
+const string& CXmlElementSerializingContext::getXmlUri() const
 {
-    return _strXmlFolder;
+    return _xmlUri;
 }

--- a/parameter/XmlElementSerializingContext.cpp
+++ b/parameter/XmlElementSerializingContext.cpp
@@ -38,11 +38,10 @@ CXmlElementSerializingContext::CXmlElementSerializingContext(string& strError) :
 }
 
 // Init
-void CXmlElementSerializingContext::set(const CElementLibrary* pElementLibrary, const string& strXmlFolder, const string& strXmlSchemaFolder)
+void CXmlElementSerializingContext::set(const CElementLibrary* pElementLibrary, const string& strXmlFolder)
 {
     _pElementLibrary = pElementLibrary;
     _strXmlFolder = strXmlFolder;
-    _strXmlSchemaFolder = strXmlSchemaFolder;
 }
 
 // ElementLibrary
@@ -56,10 +55,3 @@ const string& CXmlElementSerializingContext::getXmlFolder() const
 {
     return _strXmlFolder;
 }
-
-// XML Schema Path
-const string& CXmlElementSerializingContext::getXmlSchemaPathFolder() const
-{
-    return _strXmlSchemaFolder;
-}
-

--- a/parameter/XmlElementSerializingContext.h
+++ b/parameter/XmlElementSerializingContext.h
@@ -41,14 +41,14 @@ public:
     CXmlElementSerializingContext(std::string& strError);
 
     // Init
-    void set(const CElementLibrary* pElementLibrary, const std::string& strXmlFolder);
+    void set(const CElementLibrary* pElementLibrary, const std::string& xmlUri);
 
     // ElementLibrary
     const CElementLibrary* getElementLibrary() const;
 
-    // XML File Path
-    const std::string& getXmlFolder() const;
+    // Xml URI
+    const std::string& getXmlUri() const;
 private:
     const CElementLibrary* _pElementLibrary;
-    std::string _strXmlFolder;
+    std::string _xmlUri;
 };

--- a/parameter/XmlElementSerializingContext.h
+++ b/parameter/XmlElementSerializingContext.h
@@ -41,18 +41,14 @@ public:
     CXmlElementSerializingContext(std::string& strError);
 
     // Init
-    void set(const CElementLibrary* pElementLibrary, const std::string& strXmlFolder, const std::string& strXmlSchemaFolder);
+    void set(const CElementLibrary* pElementLibrary, const std::string& strXmlFolder);
 
     // ElementLibrary
     const CElementLibrary* getElementLibrary() const;
 
     // XML File Path
     const std::string& getXmlFolder() const;
-
-    // Schema Path
-    const std::string& getXmlSchemaPathFolder() const;
 private:
     const CElementLibrary* _pElementLibrary;
     std::string _strXmlFolder;
-    std::string _strXmlSchemaFolder;
 };

--- a/parameter/XmlFileIncluderElement.cpp
+++ b/parameter/XmlFileIncluderElement.cpp
@@ -52,7 +52,7 @@ bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSeriali
     // Parse included document
     std::string strPath;
     xmlElement.getAttribute("Path", strPath);
-    strPath = CXmlDocSource::mkUri(elementSerializingContext.getXmlFolder(), strPath);
+    strPath = CXmlDocSource::mkUri(elementSerializingContext.getXmlUri(), strPath);
 
     // Instantiate parser
     std::string strIncludedElementType = getIncludedElementType();

--- a/parameter/XmlFileIncluderElement.cpp
+++ b/parameter/XmlFileIncluderElement.cpp
@@ -52,24 +52,14 @@ bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSeriali
     // Parse included document
     std::string strPath;
     xmlElement.getAttribute("Path", strPath);
-
-    // Relative path?
-    if (strPath[0] != '/') {
-
-        strPath = elementSerializingContext.getXmlFolder() + "/" + strPath;
-    }
+    strPath = CXmlDocSource::mkUri(elementSerializingContext.getXmlFolder(), strPath);
 
     // Instantiate parser
     std::string strIncludedElementType = getIncludedElementType();
     {
-        // Use a doc source that load data from a file
-        std::string strPathToXsdFile = elementSerializingContext.getXmlSchemaPathFolder() + "/" +
-                               strIncludedElementType + ".xsd";
-
         _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strPath, true, true, elementSerializingContext);
 
         CXmlDocSource docSource(doc, _bValidateSchemasOnStart,
-                                strPathToXsdFile,
                                 strIncludedElementType);
 
         if (!docSource.isParsable()) {

--- a/parameter/include/ParameterMgrFullConnector.h
+++ b/parameter/include/ParameterMgrFullConnector.h
@@ -127,17 +127,17 @@ public:
       */
     bool getFailureOnFailedSettingsLoad() const;
 
-    /** Get the path to the directory containing the XML Schemas
+    /** Get the XML Schemas URI
      *
-     * @returns the directory containing the XML Schemas
+     * @returns the XML Schemas URI
      */
-    const std::string& getSchemaFolderLocation() const;
+    const std::string& getSchemaUri() const;
 
-    /** Override the directory containing the XML Schemas
+    /** Override the XML Schemas URI
      *
-     * @param[in] strSchemaFolderLocation directory containing the XML Schemas
+     * @param[in] schemaUri the XML Schemas URI
      */
-    void setSchemaFolderLocation(const std::string& strSchemaFolderLocation);
+    void setSchemaUri(const std::string& schemaUri);
 
     /** Should .xml files be validated on start ?
      *

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -130,17 +130,17 @@ public:
       */
     bool getFailureOnFailedSettingsLoad() const;
 
-    /** Get the path to the directory containing the XML Schemas
+    /** Get the XML Schemas URI
      *
-     * @returns the directory containing the XML Schemas
+     * @returns the XML Schemas URI
      */
-    const std::string& getSchemaFolderLocation() const;
+    const std::string& getSchemaUri() const;
 
-    /** Override the directory containing the XML Schemas
+    /** Override the XML Schemas URI
      *
-     * @param[in] strSchemaFolderLocation directory containing the XML Schemas
+     * @param[in] schemaUri the XML Schemas URI
      */
-    void setSchemaFolderLocation(const std::string& strSchemaFolderLocation);
+    void setSchemaUri(const std::string& schemaUri);
 
     /** Should .xml files be validated on start ?
      *

--- a/test/functional-tests-legacy/CMakeLists.txt
+++ b/test/functional-tests-legacy/CMakeLists.txt
@@ -32,6 +32,8 @@ if (BUILD_TESTING)
     set(PFW_ROOT ${CMAKE_BINARY_DIR}/tmp/test-parameters)
     set(PFW_RESULT ${PFW_ROOT}/result)
 
+    file(COPY ${CMAKE_SOURCE_DIR}/Schemas/ DESTINATION ${PFW_ROOT}/xml/Schemas)
+
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/xml/configuration/Structure/Test/TestSubsystem.xml.in
         ${PFW_ROOT}/xml/configuration/Structure/Test/TestSubsystem.xml @ONLY)
@@ -47,10 +49,14 @@ if (BUILD_TESTING)
         ${CMAKE_CURRENT_SOURCE_DIR}/xml/configuration/Settings/Test/TestConfigurableDomains.xml
         ${PFW_ROOT}/xml/configuration/Settings/Test/TestConfigurableDomains.xml
         COPYONLY)
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ACTCampaignEngine.py DESTINATION ${PFW_ROOT}/)
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/PfwTestCase DESTINATION ${PFW_ROOT}/)
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Util DESTINATION ${PFW_ROOT}/)
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/xml/XML_Test DESTINATION ${PFW_ROOT}/xml/)
 
     add_test(NAME functional-test-legacy
-             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-             COMMAND ${python2} ACTCampaignEngine.py)
+             WORKING_DIRECTORY ${PFW_ROOT}
+             COMMAND ${python2} ${PFW_ROOT}/ACTCampaignEngine.py)
 
     # Custom function defined in the top-level CMakeLists
     set_test_env(functional-test-legacy)

--- a/test/functional-tests-legacy/Util/PfwUnitTestLib.py
+++ b/test/functional-tests-legacy/Util/PfwUnitTestLib.py
@@ -74,6 +74,7 @@ class Hal(RemoteCli):
 
     # Starts the Pfw
     def start(self):
+        self.sendCmd("setValidateSchemasOnStart true")
         self.sendCmd("start")
 
 # A PfwTestCase gather tests performed on one instance of the PFW.

--- a/test/functional-tests-legacy/xml/TestConfigurableDomains.xml
+++ b/test/functional-tests-legacy/xml/TestConfigurableDomains.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/lab/ICS/hardware/intel/PRIVATE/parameter-framework/test/configuration/Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ConfigurableDomains.xsd"
+  SystemClassName="Test">
 	<ConfigurableDomain Name="Domain_0">
 		<Configurations>
 			<Configuration Name="Conf_0">

--- a/test/functional-tests-legacy/xml/XML_Test/Reference_Compliant.xml
+++ b/test/functional-tests-legacy/xml/XML_Test/Reference_Compliant.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/lab/ICS/hardware/intel/PRIVATE/parameter-framework/test/configuration/Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ConfigurableDomains.xsd"
+  SystemClassName="Test">
 	<ConfigurableDomain Name="Domain_1">
 		<Configurations>
 			<Configuration Name="Conf_1_0">

--- a/test/functional-tests-legacy/xml/XML_Test/Reference_Criteria.xml
+++ b/test/functional-tests-legacy/xml/XML_Test/Reference_Criteria.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
 	<ConfigurableDomain Name="Domain_1">
 		<Configurations>
 			<Configuration Name="Conf_1_0">

--- a/test/functional-tests-legacy/xml/XML_Test/Reference_Split_Domain.xml
+++ b/test/functional-tests-legacy/xml/XML_Test/Reference_Split_Domain.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--DOMAIN 1 DEFINITION-->
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ConfigurableDomains.xsd"
+  SystemClassName="Test">
 	<ConfigurableDomain Name="Domain_1">
 		<Configurations>
 			<Configuration Name="Conf_1_0">

--- a/test/functional-tests-legacy/xml/XML_Test/Reference_dumpDomains.xml
+++ b/test/functional-tests-legacy/xml/XML_Test/Reference_dumpDomains.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/lab/ICS/hardware/intel/PRIVATE/parameter-framework/test/configuration/Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ConfigurableDomains.xsd"
+  SystemClassName="Test">
 
 	<ConfigurableDomain Name="Domain_0_1">
 		<Configurations>

--- a/test/functional-tests-legacy/xml/XML_Test/Uncompliant_OutboundParameter.xml
+++ b/test/functional-tests-legacy/xml/XML_Test/Uncompliant_OutboundParameter.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ConfigurableDomains.xsd"
+  SystemClassName="Test">
 	<ConfigurableDomain Name="Domain_1">
 		<Configurations>
 			<Configuration Name="Conf_1_0">

--- a/test/functional-tests-legacy/xml/XML_Test/Uncompliant_UndeclaredConfigurableElement.xml
+++ b/test/functional-tests-legacy/xml/XML_Test/Uncompliant_UndeclaredConfigurableElement.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ConfigurableDomains.xsd"
+  SystemClassName="Test">
 	<ConfigurableDomain Name="Domain_1">
 		<Configurations>
 			<Configuration Name="Conf_1_0">

--- a/test/functional-tests-legacy/xml/XML_Test/Uncompliant_UndeclaredParameter.xml
+++ b/test/functional-tests-legacy/xml/XML_Test/Uncompliant_UndeclaredParameter.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ConfigurableDomains.xsd"
+  SystemClassName="Test">
 	<ConfigurableDomain Name="Domain_1">
 		<Configurations>
 			<Configuration Name="Conf_1_0">

--- a/test/functional-tests-legacy/xml/configuration/ParameterFrameworkConfiguration.xml
+++ b/test/functional-tests-legacy/xml/configuration/ParameterFrameworkConfiguration.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ParameterFrameworkConfiguration SystemClassName="Test" ServerPort="5000" TuningAllowed="true">
+<ParameterFrameworkConfiguration
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Schemas/ParameterFrameworkConfiguration.xsd"
+ SystemClassName="Test" ServerPort="5000" TuningAllowed="true">
     <SubsystemPlugins>
         <Location Folder="">
             <Plugin Name="libtest-subsystem.so"/>

--- a/test/functional-tests-legacy/xml/configuration/Settings/Test/TestConfigurableDomains.xml
+++ b/test/functional-tests-legacy/xml/configuration/Settings/Test/TestConfigurableDomains.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/lab/ICS/hardware/intel/PRIVATE/parameter-framework/test/configuration/Schemas/ConfigurableDomains.xsd" SystemClassName="Test">
+<ConfigurableDomains
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/ConfigurableDomains.xsd"
+  SystemClassName="Test">
 	<ConfigurableDomain Name="Domain_0">
 		<Configurations>
 			<Configuration Name="Conf_0">

--- a/test/functional-tests-legacy/xml/configuration/Structure/Test/TestClass.xml
+++ b/test/functional-tests-legacy/xml/configuration/Structure/Test/TestClass.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<SystemClass Name="Test">
+<SystemClass
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/SystemClass.xsd"
+  Name="Test">
     <SubsystemInclude Path="TestSubsystem.xml"/>
 </SystemClass>

--- a/test/functional-tests-legacy/xml/configuration/Structure/Test/TestSubsystem.xml.in
+++ b/test/functional-tests-legacy/xml/configuration/Structure/Test/TestSubsystem.xml.in
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Subsystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/lab/ICS/hardware/intel/PRIVATE/parameter-framework/test/configuration/Schemas/Subsystem.xsd" Name="Test" Type="TEST" Endianness="Little">
+<Subsystem
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/Subsystem.xsd"
+  Name="Test" Type="TEST" Endianness="Little">
 	<ComponentLibrary>
 		<ComponentType Name="TEST_DIR">
 			<!-- Tested Booleans -->

--- a/test/functional-tests/include/ParameterFramework.hpp
+++ b/test/functional-tests/include/ParameterFramework.hpp
@@ -71,8 +71,8 @@ public:
     using PF::setFailureOnFailedSettingsLoad;
     using PF::getForceNoRemoteInterface;
     using PF::setForceNoRemoteInterface;
-    using PF::getSchemaFolderLocation;
-    using PF::setSchemaFolderLocation;
+    using PF::getSchemaUri;
+    using PF::setSchemaUri;
     using PF::getValidateSchemasOnStart;
     using PF::setValidateSchemasOnStart;
     using PF::isValueSpaceRaw;

--- a/tools/xmlGenerator/domainGenerator.py
+++ b/tools/xmlGenerator/domainGenerator.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
             help="Directory of parameter-framework XML Schemas on target \
         machine (may be different than generating machine). \
         Defaults to \"Schemas\"",
-            default="Schemas")
+            default="Schemas/")
     argparser.add_argument('--validate',
             help="Validate the settings against XML schemas",
             action='store_true')
@@ -272,7 +272,7 @@ if __name__ == "__main__":
             if args.schemas_dir is not None:
                 schemas_dir = args.schemas_dir
             else:
-                schemas_dir = os.path.join(install_path, "Schemas")
+                schemas_dir = os.path.join(install_path, "Schemas/")
             pfw.setSchemaFolderLocation(schemas_dir)
 
         logger = PfwLogger()

--- a/tools/xmlGenerator/domainGenerator.py
+++ b/tools/xmlGenerator/domainGenerator.py
@@ -271,9 +271,7 @@ if __name__ == "__main__":
             pfw.setValidateSchemasOnStart(True)
             if args.schemas_dir is not None:
                 schemas_dir = args.schemas_dir
-            else:
-                schemas_dir = os.path.join(install_path, "Schemas/")
-            pfw.setSchemaFolderLocation(schemas_dir)
+                pfw.setSchemaUri(schemas_dir)
 
         logger = PfwLogger()
         pfw.setLogger(logger)
@@ -326,7 +324,9 @@ if __name__ == "__main__":
     # dirty hack: we change the schema location (right before exporting the
     # domains) to their location on the target (which may be different than on
     # the machine that is generating the domains)
-    pfw.setSchemaFolderLocation(args.target_schemas_dir)
+
+    if args.target_schema_dir is not None:
+        pfw.setSchemaUri(args.target_schema_dir)
 
     # Export the resulting settings to the standard output
     ok, domains, error = pfw.exportDomainsXml("", True, False)

--- a/xmlserializer/XmlDocSource.cpp
+++ b/xmlserializer/XmlDocSource.cpp
@@ -29,13 +29,19 @@
  */
 
 #include "XmlDocSource.h"
+#include "AlwaysAssert.hpp"
 #include <libxml/tree.h>
 #include <libxml/xmlschemas.h>
 #include <libxml/parser.h>
 #include <libxml/xinclude.h>
+#include <libxml/uri.h>
 #include <stdlib.h>
+#include <memory>
+#include <stdexcept>
 
 using std::string;
+using xml_unique_ptr = std::unique_ptr<xmlChar, decltype(xmlFree)>;
+
 
 // Schedule for libxml2 library
 bool CXmlDocSource::_bLibXml2CleanupScheduled;
@@ -44,7 +50,6 @@ CXmlDocSource::CXmlDocSource(_xmlDoc *pDoc, bool bValidateWithSchema,
                              _xmlNode *pRootNode) :
       _pDoc(pDoc),
       _pRootNode(pRootNode),
-      _strXmlSchemaFile(""),
       _strRootElementType(""),
       _strRootElementName(""),
       _strNameAttributeName(""),
@@ -54,13 +59,11 @@ CXmlDocSource::CXmlDocSource(_xmlDoc *pDoc, bool bValidateWithSchema,
 }
 
 CXmlDocSource::CXmlDocSource(_xmlDoc *pDoc, bool bValidateWithSchema,
-                             const string& strXmlSchemaFile,
                              const string& strRootElementType,
                              const string& strRootElementName,
                              const string& strNameAttributeName) :
     _pDoc(pDoc),
     _pRootNode(xmlDocGetRootElement(pDoc)),
-    _strXmlSchemaFile(strXmlSchemaFile),
     _strRootElementType(strRootElementType),
     _strRootElementName(strRootElementName),
     _strNameAttributeName(strNameAttributeName),
@@ -95,6 +98,11 @@ string CXmlDocSource::getRootElementAttributeString(const string& strAttributeNa
     string attribute;
     topMostElement.getAttribute(strAttributeName, attribute);
     return attribute;
+}
+
+string CXmlDocSource::getSchemaUri() const
+{
+    return mkUri(string((const char *)_pDoc->URL), getRootElementAttributeString("noNamespaceSchemaLocation"));
 }
 
 _xmlDoc* CXmlDocSource::getDoc() const
@@ -173,7 +181,9 @@ void CXmlDocSource::init()
 bool CXmlDocSource::isInstanceDocumentValid()
 {
 #ifdef LIBXML_SCHEMAS_ENABLED
-    xmlDocPtr pSchemaDoc = xmlReadFile(_strXmlSchemaFile.c_str(), NULL, XML_PARSE_NONET);
+    string schemaUri = getSchemaUri();
+
+    xmlDocPtr pSchemaDoc = xmlReadFile(schemaUri.c_str(), NULL, XML_PARSE_NONET);
 
     if (!pSchemaDoc) {
         // Unable to load Schema
@@ -221,6 +231,19 @@ bool CXmlDocSource::isInstanceDocumentValid()
 #else
     return true;
 #endif
+}
+
+std::string CXmlDocSource::mkUri(const std::string& base, const std::string& relative)
+{
+    xml_unique_ptr baseUri(xmlPathToURI((const xmlChar *)base.c_str()), xmlFree);
+    xml_unique_ptr relativeUri(xmlPathToURI((const xmlChar *)relative.c_str()), xmlFree);
+    /* return null pointer if baseUri or relativeUri are null pointer  */
+    xml_unique_ptr xmlUri(xmlBuildURI(relativeUri.get(), baseUri.get()), xmlFree);
+
+    ALWAYS_ASSERT(xmlUri != nullptr, "unable to make URI from: \""
+                                      << base << "\" and \"" << relative << "\"");
+
+    return (const char *)xmlUri.get();
 }
 
 _xmlDoc* CXmlDocSource::mkXmlDoc(const string& source, bool fromFile, bool xincludes, CXmlSerializingContext& serializingContext)

--- a/xmlserializer/XmlDocSource.h
+++ b/xmlserializer/XmlDocSource.h
@@ -70,7 +70,6 @@ public:
       * @param[in] bValidateWithSchema a boolean that toggles schema validation
       */
     CXmlDocSource(_xmlDoc* pDoc, bool bValidateWithSchema,
-                           const std::string& strXmlSchemaFile = "",
                            const std::string& strRootElementType = "",
                            const std::string& strRootElementName = "",
                            const std::string& strNameAttributeName = "");
@@ -105,6 +104,13 @@ public:
 
     /**
       * Getter method.
+      *
+      * @return schema URI
+      */
+    std::string getSchemaUri() const;
+
+    /**
+      * Getter method.
       * Method that returns the root element's attribute with name matching strAttributeName.
       *
       * @param[in] strAttributeName is a std::string used to find the corresponding attribute
@@ -128,6 +134,23 @@ public:
     * @return false if any error occurs during the parsing
     */
     virtual bool isParsable() const;
+
+    /**
+     * Helper method to build final URI from base and relative uri/path
+     *
+     * base = "/path/to/file.xml"
+     *  - uri                   - returned value
+     *  .                       /path/to/
+     *  file.xsd                /path/to/file.xsd
+     *  ../from/file.xsd        /path/from/file.xsd
+     *  /path2/file.xsd         /path2/file.xsd
+     *
+     * @param[in] base uri, if base is directory, it must contains separator last
+     * @param[in] relative uri
+    *
+    * @return new made URI if succeeded relative input otherwise
+     */
+    static std::string mkUri(const std::string& base, const std::string& relative);
 
     /**
      * Helper method for creating an xml document from either a file or a
@@ -170,11 +193,6 @@ private:
       * @return true if document is valid, false if any error occures
       */
     bool isInstanceDocumentValid();
-
-    /**
-      * Schema file
-      */
-    std::string _strXmlSchemaFile;
 
     /**
       * Element type info

--- a/xmlserializer/XmlMemoryDocSource.cpp
+++ b/xmlserializer/XmlMemoryDocSource.cpp
@@ -36,16 +36,18 @@
 
 CXmlMemoryDocSource::CXmlMemoryDocSource(const IXmlSource* pXmlSource, bool bValidateWithSchema,
                                          const std::string& strRootElementType,
-                                         const std::string& strXmlSchemaFile,
+                                         const std::string& schemaBaseUri,
                                          const std::string& strProduct,
                                          const std::string& strVersion):
      base(xmlNewDoc(BAD_CAST "1.0"), bValidateWithSchema,
           xmlNewNode(NULL, BAD_CAST strRootElementType.c_str())),
      _pXmlSource(pXmlSource),
-     _strXmlSchemaFile(strXmlSchemaFile),
      _strProduct(strProduct),
      _strVersion(strVersion)
 {
+    // Get Schema file
+    _strXmlSchemaFile = CXmlDocSource::mkUri(schemaBaseUri, strRootElementType + ".xsd");
+
     init();
 }
 

--- a/xmlserializer/XmlMemoryDocSource.h
+++ b/xmlserializer/XmlMemoryDocSource.h
@@ -52,7 +52,7 @@ public:
       */
     CXmlMemoryDocSource(const IXmlSource* pXmlSource, bool bValidateWithSchema,
                         const std::string& strRootElementType,
-                        const std::string& strXmlSchemaFile = "",
+                        const std::string& schemaBaseUri = "",
                         const std::string& strProduct = "",
                         const std::string& strVersion = "");
 


### PR DESCRIPTION
xsi:noNamespaceSchemaLocation provides xsd location.
Use libxml2 API and the attribute to found out xsd schemas

Signed-off-by: Miguel Gaio <miguel.gaio@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/248%23issuecomment-142637504%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23issuecomment-143719469%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23issuecomment-143731574%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23issuecomment-143837318%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23issuecomment-144006164%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40217333%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40218494%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40229458%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40314448%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40314653%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40315214%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40342900%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40542611%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40542614%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40542618%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40542620%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40546172%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40547789%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/248%23issuecomment-142637504%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40dawagner%20%40krocard%20%40OznOg%20%40cc6565%20please%20review%22%2C%20%22created_at%22%3A%20%222015-09-23T15%3A20%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-28T11%3A39%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22nice%20job%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-09-28T12%3A39%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40krocard%20or%20%40OznOg%20please%20review.%20I%27ll%20merge%20when%20there%20is%20another%20%2B1.%22%2C%20%22created_at%22%3A%20%222015-09-28T18%3A37%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-29T09%3A34%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2049ffd604786e225e8396aa4a2aa13d658fd40f81%20parameter/ParameterMgr.cpp%2093%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40546172%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22URI%5C%22%20or%20%5C%22Uri%5C%22%20%3F%20Please%20choose%20one%20and%20stick%20to%20it.%20%28I%27d%20choose%20%5C%22Uri%5C%22%20because%20even%20though%20it%27s%20an%20acronym%2C%20we%20have%20chose%20lowerCamelCase%20style.%20EDIT%3A%20and%20because%20we%20already%20have%20%5C%22mk%2A%2AXml%2A%2ADoc%5C%22%29%22%2C%20%22created_at%22%3A%20%222015-09-28T12%3A34%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-09-28T12%3A54%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL597-604%22%7D%2C%20%22Pull%20d14954fb9e808b40ee07233c4f805e8f3962e1b1%20xmlserializer/XmlDocSource.cpp%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40217333%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22all%20those%20free%20could%20be%20removed%20with%20unique_ptr...%22%2C%20%22created_at%22%3A%20%222015-09-23T15%3A26%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%2C%20xmlFree%20is%20not%20delete%20or%20free%28%29%22%2C%20%22created_at%22%3A%20%222015-09-23T15%3A34%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22unique_ptr%20can%20be%20provided%20with%20a%20custom%20deleter%20%28default%20is%20delete%2C%20not%20%5Cr%5Cnfree%29.%22%2C%20%22created_at%22%3A%20%222015-09-23T17%3A07%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-28T11%3A39%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20xmlserializer/XmlDocSource.cpp%3AL225-232%22%7D%2C%20%22Pull%207a207c7fd3341ebaf18501bf9f6b2f3d0efb0372%20test/CMakeLists.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40314448%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20could%20be%20worth%20copying%20this%20directory%20in%20the%20legacy%20functional%20test%20dir%20too%20%28or%20instead%29.%20And%20if%20so%2C%20it%20should%20be%20done%20in%20%60functional-tests-legacy/CMakeLists.txt%60.%5Cr%5Cn%5Cr%5CnYou%20would%20avoid%20the%20%60../../../../../../%60%20in%20the%20XML%20files%20below.%5Cr%5Cn%5Cr%5CnEDIT%3A%20and/or%20use%20%60configure_file%60%20on%20all%20the%20XML%20files%20contained%20in%20the%20legacy%20functional%20tests.%22%2C%20%22created_at%22%3A%20%222015-09-24T12%3A48%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-28T11%3A39%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/CMakeLists.txt%3AL26-34%22%7D%2C%20%22Pull%207a207c7fd3341ebaf18501bf9f6b2f3d0efb0372%20xmlserializer/XmlDocSource.h%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40315214%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20constructor%20seems%20unused.%20If%20so%2C%20you%20may%20remove%20it%20altogether%20%28in%20a%20separate%20patch%29.%22%2C%20%22created_at%22%3A%20%222015-09-24T12%3A57%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Used%20by%20XmlMemorySource%22%2C%20%22created_at%22%3A%20%222015-09-24T16%3A53%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-28T11%3A39%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20xmlserializer/XmlDocSource.h%3AL57-75%22%7D%2C%20%22Pull%207a207c7fd3341ebaf18501bf9f6b2f3d0efb0372%20test/functional-tests/CMakeLists.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/248%23discussion_r40314653%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22unrelated%20change%22%2C%20%22created_at%22%3A%20%222015-09-24T12%3A50%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-28T11%3A39%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/CMakeLists.txt%3AL42-49%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/cc6565%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/cc6565'><img src='https://avatars.githubusercontent.com/u/9692938?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/248#issuecomment-142637504'>General Comment</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> @dawagner @krocard @OznOg @cc6565 please review
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> nice job :)
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard or @OznOg please review. I'll merge when there is another +1.
- [x] <a href='#crh-comment-Pull d14954fb9e808b40ee07233c4f805e8f3962e1b1 xmlserializer/XmlDocSource.cpp 78'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/248#discussion_r40217333'>File: xmlserializer/XmlDocSource.cpp:L225-232</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> all those free could be removed with unique_ptr...
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> I'm not sure, xmlFree is not delete or free()
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> unique_ptr can be provided with a custom deleter (default is delete, not
free).
- [x] <a href='#crh-comment-Pull 7a207c7fd3341ebaf18501bf9f6b2f3d0efb0372 test/CMakeLists.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/248#discussion_r40314448'>File: test/CMakeLists.txt:L26-34</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> It could be worth copying this directory in the legacy functional test dir too (or instead). And if so, it should be done in `functional-tests-legacy/CMakeLists.txt`.
You would avoid the `../../../../../../` in the XML files below.
EDIT: and/or use `configure_file` on all the XML files contained in the legacy functional tests.
- [x] <a href='#crh-comment-Pull 7a207c7fd3341ebaf18501bf9f6b2f3d0efb0372 test/functional-tests/CMakeLists.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/248#discussion_r40314653'>File: test/functional-tests/CMakeLists.txt:L42-49</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> unrelated change
- [x] <a href='#crh-comment-Pull 7a207c7fd3341ebaf18501bf9f6b2f3d0efb0372 xmlserializer/XmlDocSource.h 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/248#discussion_r40315214'>File: xmlserializer/XmlDocSource.h:L57-75</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> This constructor seems unused. If so, you may remove it altogether (in a separate patch).
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> Used by XmlMemorySource
- [x] <a href='#crh-comment-Pull 49ffd604786e225e8396aa4a2aa13d658fd40f81 parameter/ParameterMgr.cpp 93'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/248#discussion_r40546172'>File: parameter/ParameterMgr.cpp:L597-604</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> "URI" or "Uri" ? Please choose one and stick to it. (I'd choose "Uri" because even though it's an acronym, we have chose lowerCamelCase style. EDIT: and because we already have "mk**Xml**Doc")


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/248?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/248?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/248?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/248'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>