### PR TITLE
Remove an unused attribute

### DIFF
--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -704,9 +704,6 @@ private:
     // Subsystem plugin location
     const CSubsystemPlugins* _pSubsystemPlugins;
 
-    // Whole system structure checksum
-    uint8_t _uiStructureChecksum;
-
     // Remote Processor Server
     IRemoteProcessorServerInterface* _pRemoteProcessorServer;
 


### PR DESCRIPTION
This attribute is a leftover of the "binary settings" feature removal and this
was caught by static analysis (Coverity).

Signed-off-by: David Wagner <david.wagner@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/254%23issuecomment-143679355%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/254%23issuecomment-143679355%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-28T08%3A41%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/254?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/254'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>