### PR TITLE
Rework the plugin entry-point API to be a well-known symbol name

### DIFF
--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -151,6 +151,7 @@ install(FILES
     ParameterBlockType.h
     ParameterType.h
     PathNavigator.h
+    Plugin.h
     Subsystem.h
     SubsystemLibrary.h
     SubsystemObject.h

--- a/parameter/Plugin.h
+++ b/parameter/Plugin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2015, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,14 +27,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "Plugin.h"
-#include "LoggingElementBuilderTemplate.h"
-#include "SkeletonSubsystem.h"
+#pragma once
 
+/** @file
+ *
+ * This file is intended to be used by the plugins.
+ *
+ * The compilation unit defining the entry point (aka the Subsystem Builder)
+ * should include this file a define a function corresponding to the one
+ * declared below.
+ */
 
-void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary* pSubsystemLibrary, core::log::Logger& logger)
-{
-    pSubsystemLibrary->addElementBuilder(
-            "Skeleton",
-            new TLoggingElementBuilderTemplate<CSkeletonSubsystem>(logger));
+#include <SubsystemLibrary.h>
+
+extern "C" {
+#if defined(__clang__) || defined(__GNUC__)
+    __attribute__((visibility("default")))
+#elif defined(_MSC_VER)
+    __declspec(dllexport)
+#endif
+    void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary*, core::log::Logger&);
 }

--- a/parameter/SubsystemLibrary.h
+++ b/parameter/SubsystemLibrary.h
@@ -34,6 +34,15 @@
 #include "LoggingElementBuilderTemplate.h"
 #include <string>
 
+/** Plugin entry point symbol
+ *
+ * Needs to be implemented by plugin libraries. This function's purpose is to
+ * register element builders;
+ *
+ * "V1" refers to the version of this entry-point API.
+ */
+#define PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1 ParameterFrameworkPluginEntryPointMagicV1
+
 class CSubsystemLibrary :
         public CDefaultElementLibrary<TLoggingElementBuilderTemplate<CVirtualSubsystem> >
 {

--- a/parameter/SystemClass.h
+++ b/parameter/SystemClass.h
@@ -100,9 +100,6 @@ private:
     bool loadSubsystemsFromSharedLibraries(core::Results& errors,
                                            const CSubsystemPlugins* pSubsystemPlugins);
 
-    // Plugin symbol computation
-    static std::string getPluginSymbol(const std::string& strPluginPath);
-
     /** Load subsystem plugin shared libraries.
      *
      * @param[in:out] lstrPluginFiles is the path list of the plugins shared libraries to load.
@@ -121,5 +118,9 @@ private:
 
     /** Application Logger we need to provide to plugins */
     core::log::Logger& _logger;
+
+    /** The entry point symbol that must be implemented by plugins
+     */
+    static const char entryPointSymbol[];
 };
 

--- a/skeleton-subsystem/CMakeLists.txt
+++ b/skeleton-subsystem/CMakeLists.txt
@@ -40,7 +40,7 @@ endif ()
 #
 # Find PFW libraries and include directories
 #
-find_path(PFW_INCLUDE_ROOT NAMES parameter/plugin/Subsystem.h)
+find_path(PFW_INCLUDE_ROOT NAMES parameter/plugin/Plugin.h)
 
 find_library(PFW_CORE_LIBRARY NAMES parameter)
 

--- a/test/test-subsystem/CMakeLists.txt
+++ b/test/test-subsystem/CMakeLists.txt
@@ -35,10 +35,6 @@ if (BUILD_TESTING)
         TESTSubsystemString.cpp
         TESTSubsystemBuilder.cpp)
 
-    include (GenerateExportHeader)
-    generate_export_header(test-subsystem
-                           BASE_NAME test_subsystem)
-
     include_directories(
         "${CMAKE_CURRENT_BINARY_DIR}"
         "${PROJECT_SOURCE_DIR}/xmlserializer"

--- a/test/test-subsystem/TESTSubsystemBuilder.cpp
+++ b/test/test-subsystem/TESTSubsystemBuilder.cpp
@@ -27,20 +27,14 @@
 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#include "test_subsystem_export.h"
-
-#include "SubsystemLibrary.h"
+#include "Plugin.h"
 #include "LoggingElementBuilderTemplate.h"
 #include "TESTSubsystem.h"
 
 
-extern "C"
-{
-TEST_SUBSYSTEM_EXPORT
-void getTESTSubsystemBuilder(CSubsystemLibrary* pSubsystemLibrary, core::log::Logger& logger)
+void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary* pSubsystemLibrary, core::log::Logger& logger)
 {
     pSubsystemLibrary->addElementBuilder("TEST",
                                          new TLoggingElementBuilderTemplate<CTESTSubsystem>(
                                              logger));
-}
 }


### PR DESCRIPTION
The plugins' entry-point used to be a symbol which name was constructed based
on the library name but the Parameter Framework was trying to deduce it based
on how library files are usually named on Linux, i.e. prefixed with "lib", then
the soname, then ".so".

This is not always true on Linux and this is usually false on Windows.

Also, if the API of this symbol changes, there is no way to know at
compile-time.

Which is why this rework introduces a macro to be used by plugins. This macro
is the name of the entry-point symbol to be declared by plugins and will be
retrieved by the Parameter Framework.

If the plugin entry point API changes, we will change the name of the macro
(it contains a version number), which will cause the plugins to raise an error
at compile time instead of failing at runtime.

For now, we only support one API version at a time: if the API changes from V1
to V2, the plugins won't compile and the Parameter Framework won't recognize
previously-compiled plugins using V1. If we want backward-compatibility, we can
add it later by declaring both macros (V1 and V2) and trying to find the symbol
corresponding to V1 if the symbol corresponding to V2 can't be found.

The first name of the macro is: PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1

Signed-off-by: David Wagner <david.wagner@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/255%23issuecomment-143731870%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23issuecomment-143737176%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23issuecomment-143750899%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23issuecomment-144101141%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23issuecomment-144107060%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23issuecomment-144107094%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23discussion_r40548461%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23discussion_r40550070%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23discussion_r40690561%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23discussion_r40691793%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/255%23discussion_r40691855%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/255%23issuecomment-143731870%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20Please%20review%22%2C%20%22created_at%22%3A%20%222015-09-28T12%3A41%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22nice%20to%20see%20the%20removal%20of%20SystemClass%3A%3AgetPluginSymbol%28%29%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-28T12%3A58%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22Great%20patch%20%3A%2B1%3A%20%28need%20to%20fix%20CI%20though%20%3B%29%22%2C%20%22created_at%22%3A%20%222015-09-28T13%3A59%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%2C%20discussed%20with%20you%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-29T15%3A52%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/820313%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/OznOg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A10%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A11%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20754ad80cf9d24bec55e21a47ae2b8e151511c4eb%20parameter/SystemClass.cpp%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/255%23discussion_r40548461%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20this%20not%20be%20done%20in%20the%20CSubsystemLibrary%20%3F%20Ie%20have%20a%20static%20const%20char%20%2A%20with%20the%20name.%20In%20the%20same%20way%20you%20have%20a%20type%20alias%20SubsystemBuilderFunction.%22%2C%20%22created_at%22%3A%20%222015-09-28T13%3A01%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Done%22%2C%20%22created_at%22%3A%20%222015-09-28T13%3A16%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/SystemClass.cpp%3AL168-191%22%7D%2C%20%22Pull%20fd3cc1492bc0bc0fa443bde219fb3ea6171748cb%20parameter/Plugin.h%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/255%23discussion_r40690561%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20OS%20specific%20stuff%20may%20be%20wrapped%20in%20utilty/%5C%5C%3Cos%5C%5C%3E%5Cr%5CnIThis%20helps%20to%20identify%20all%20amount%20of%20workaround%20to%20port%20a%20new%20OSes%22%2C%20%22created_at%22%3A%20%222015-09-29T15%3A55%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22see%20with%20Miguell%2C%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A05%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20really%20only%20needed%20here.%20Besides%2C%20I%27d%20prefer%20not%20adding%20any%20more%20dependencies%20to%20%5C%22utility%5C%22%20-%20it%20will%20be%20painful%20to%20remove%20if/when%20we%20have%20a%20real%20core/plugin%20split.%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A05%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/Plugin.h%3AL1-51%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull fd3cc1492bc0bc0fa443bde219fb3ea6171748cb parameter/Plugin.h 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/255#discussion_r40690561'>File: parameter/Plugin.h:L1-51</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> This OS specific stuff may be wrapped in utilty/\<os\>
IThis helps to identify all amount of workaround to port a new OSes
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> see with Miguell, :+1:
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> This is really only needed here. Besides, I'd prefer not adding any more dependencies to "utility" - it will be painful to remove if/when we have a real core/plugin split.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/255#issuecomment-143731870'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard Please review
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> nice to see the removal of SystemClass::getPluginSymbol()
:+1:
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Great patch :+1: (need to fix CI though ;)
- <a href='https://github.com/OznOg'><img border=0 src='https://avatars.githubusercontent.com/u/820313?v=3' height=16 width=16'></a> ok, discussed with you :+1:
- [x] <a href='#crh-comment-Pull 754ad80cf9d24bec55e21a47ae2b8e151511c4eb parameter/SystemClass.cpp 67'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/255#discussion_r40548461'>File: parameter/SystemClass.cpp:L168-191</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Should this not be done in the CSubsystemLibrary ? Ie have a static const char * with the name. In the same way you have a type alias SubsystemBuilderFunction.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: Done


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/255?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/255?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/255?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/255'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>