### PR TITLE
Add the consistency requirement in next

### DIFF
--- a/doc/requirements/requirements.md
+++ b/doc/requirements/requirements.md
@@ -1002,17 +1002,36 @@ PF **MAY** support at least:
 needs emerge to use it on other platform.</why>
 
 ## Tuning
-### Get and set multiple parameter values in one request.
-Get and set the content of one or more parameter or multiple parameters
-as xml.
-<why>For performance reason. Tools often need to update multiple parameter
-and having one call per parameter is too slow. (benchmark ?)</why>
+### Get and set multiple parameter values in one request
+#### Atomicity
+When setting multiple parameters from one client request,
+and when one or more parameter value is invalid (eg. out of range),
+no parameter **SHOULD** be set.
+Eg: an invalid request to change parameters **SHOULD** not impact the parameters
+values nor the subsystems.
+<note>This may be implemented by first checking parameters validity
+before setting them, or implementing a rollback mechanism, or any other way.</note>
+<why>To provide parameter mutation atomicity to the client.
+This is especially important if the client wants to implement parameter consistency.
+Eg: let two parameters have excluding values,
+if a transaction fail after the first parameter is set but not the second,
+the excluding constraint may be violated.
+It also usefull for the client to know the state of the parameters
+after a parameter set without having to query the PF.</why>
 
-### Get and set parameters as binary
+#### Access parameters as Xml
+Getting and setting the content of one or more ([one, all]) parameters **SHOULD**
+be possible in xml.
+<why>For performance reason. Tools often need to update multiple parameter
+and having one call per parameter is too slow. (benchmark ?).
+This feature permit the client to save and restore from an external database parameter
+values a la `alsa.state`.</why>
+
+#### Access parameters as binary
 The PF host API **SHOULD** expose parameter values with the same API syncer use.
 <why>The current reference implementation abstracts the memory layout of
 parameters. This memory layout is specified in the parameter structure thus
-is known </why>
+is known by the client.</why>
 
 ## Stage and commit Sync
 Explicit sync **SHOULD** only sync parameters which values were updated since last sync.


### PR DESCRIPTION
With the ability to set multiple values at once, raises the problem of what should be done in case of an invalid value.

Add the optional requirement that parameters either all be modified or none.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/256%23issuecomment-144004806%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40660637%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40661481%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693634%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693690%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693712%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693737%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693774%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693821%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40776035%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/256%23issuecomment-144004806%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%40cc6565%20%40dawagner%20%40miguelGaio%20%40OznOg%22%2C%20%22created_at%22%3A%20%222015-09-29T09%3A26%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20622869132bbc65aaa2ab064b6bda939f95db57a4%20doc/requirements/requirements.md%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693634%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60asound.state%60%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A21%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22alsa-restore.service%20/%20alsa-store.service%20within%20asound.state%20file%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A23%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20I%20double%20checked%20it%20is%20called%20%28asound.state%29%5Bhttps%3A//wiki.archlinux.org/index.php/Advanced_Linux_Sound_Architecture%23ALSA_and_Systemd%5D.%20%60alsa-restore.service%60%20and%20%60alsa-store.service%60%20are%20the%20functions/service%20that%20restore%20and%20save%20the%20state.%22%2C%20%22created_at%22%3A%20%222015-09-30T09%3A46%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/requirements.md%3AL1002-1035%22%7D%2C%20%22Pull%2077fa0548353aee6ef96a6a96debea17d1496fe42%20doc/requirements/requirements.md%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40660637%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20seem%20to%20have%20mistakenly%20removed%20the%20%5C%22Tuning%5C%22%20title.%22%2C%20%22created_at%22%3A%20%222015-09-29T11%3A36%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-29T11%3A49%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/requirements.md%3AL1001-1034%22%7D%2C%20%22Pull%20622869132bbc65aaa2ab064b6bda939f95db57a4%20doc/requirements/requirements.md%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693774%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cr%5Cn%5Cr%5Cnthose%20are%20two%20req%20%28set%20and%20get%29%5Cr%5Cn%5Cr%5Cnwhat%20is%20supposed%20to%20mean%20%27or%20more%27%20in%20that%20context%3F%20do%20you%20mean%20ALL%20or%20any%20subpart%3F%20how%20do%20I%20test%3F%5Cr%5Cnhow%20should%20this%20be%20achieved%20%3F%20who%20is%20the%20implicit%20actor%3F%20%28who%20does%20the%20job%3F%29%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A23%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/requirements.md%3AL1002-1035%22%7D%2C%20%22Pull%20622869132bbc65aaa2ab064b6bda939f95db57a4%20doc/requirements/requirements.md%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693712%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22not%20sure%20this%20is%20really%20usefull%20%28misleading%20implementation%20details%29%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A22%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/requirements.md%3AL1002-1035%22%7D%2C%20%22Pull%20622869132bbc65aaa2ab064b6bda939f95db57a4%20doc/requirements/requirements.md%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693737%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22atomicity%3F%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A22%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/requirements.md%3AL1002-1035%22%7D%2C%20%22Pull%20622869132bbc65aaa2ab064b6bda939f95db57a4%20doc/requirements/requirements.md%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/256%23discussion_r40693690%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ore%20%28typo%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-29T16%3A22%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20doc/requirements/requirements.md%3AL1002-1035%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 622869132bbc65aaa2ab064b6bda939f95db57a4 doc/requirements/requirements.md 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/256#discussion_r40693690'>File: doc/requirements/requirements.md:L1002-1035</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> ore (typo)
- [x] <a href='#crh-comment-Pull 622869132bbc65aaa2ab064b6bda939f95db57a4 doc/requirements/requirements.md 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/256#discussion_r40693712'>File: doc/requirements/requirements.md:L1002-1035</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> not sure this is really usefull (misleading implementation details)
- [x] <a href='#crh-comment-Pull 622869132bbc65aaa2ab064b6bda939f95db57a4 doc/requirements/requirements.md 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/256#discussion_r40693737'>File: doc/requirements/requirements.md:L1002-1035</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> atomicity?
- [x] <a href='#crh-comment-Pull 622869132bbc65aaa2ab064b6bda939f95db57a4 doc/requirements/requirements.md 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/256#discussion_r40693774'>File: doc/requirements/requirements.md:L1002-1035</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> those are two req (set and get)
what is supposed to mean 'or more' in that context? do you mean ALL or any subpart? how do I test?
how should this be achieved ? who is the implicit actor? (who does the job?)
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/256#issuecomment-144004806'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: @cc6565 @dawagner @miguelGaio @OznOg
- [x] <a href='#crh-comment-Pull 77fa0548353aee6ef96a6a96debea17d1496fe42 doc/requirements/requirements.md 8'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/256#discussion_r40660637'>File: doc/requirements/requirements.md:L1001-1034</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> You seem to have mistakenly removed the "Tuning" title.
- [x] <a href='#crh-comment-Pull 622869132bbc65aaa2ab064b6bda939f95db57a4 doc/requirements/requirements.md 28'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/256#discussion_r40693634'>File: doc/requirements/requirements.md:L1002-1035</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> `asound.state` ?
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> alsa-restore.service / alsa-store.service within asound.state file
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: I double checked it is called (asound.state)[https://wiki.archlinux.org/index.php/Advanced_Linux_Sound_Architecture#ALSA_and_Systemd]. `alsa-restore.service` and `alsa-store.service` are the functions/service that restore and save the state.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/256?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/256?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/256'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>