### PR TITLE
Wrong XML "Name" attribute in enum value pairs

### DIFF
--- a/parameter/EnumValuePair.cpp
+++ b/parameter/EnumValuePair.cpp
@@ -85,5 +85,7 @@ void CEnumValuePair::toXml(CXmlElement& xmlElement, CXmlSerializingContext& seri
     // Numerical
     xmlElement.setAttribute("Numerical", getNumericalAsString());
 
-    base::toXml(xmlElement, serializingContext);
+    // Ask for children processing only so as to avoid setting the Name attribute
+    // which does not exist for this element
+    base::childrenToXml(xmlElement, serializingContext);
 }


### PR DESCRIPTION
When exporting an element's structure (via the C++ API or via the tuning
interface), a spurious "Name" attribute appears for EnumPair nodes, while
only "Literal" and "Numerical" attributes should be present. This is because
the XML import / export feature assummes the existence of a Name attribute
for all XML nodes. The Name default processing can however be skipped from the
toXml() methods by calling the base class' childrenToXml() method instead
of the toXml() one.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/258?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/258'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>