### PR TITLE
Add getElementXML commands

### DIFF
--- a/parameter/BaseParameter.cpp
+++ b/parameter/BaseParameter.cpp
@@ -184,9 +184,8 @@ bool CBaseParameter::accessValue(CPathNavigator& pathNavigator, string& strValue
     return accessAsString(strValue, bSet, parameterAccessContext);
 }
 
-void CBaseParameter::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CBaseParameter::serializeXmlStructure(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
 {
-
     // Delegate to type element
     getTypeElement()->toXml(xmlElement, serializingContext);
 }

--- a/parameter/BaseParameter.h
+++ b/parameter/BaseParameter.h
@@ -69,8 +69,7 @@ public:
     bool accessAsString(std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
     virtual bool accessAsStringArray(std::vector<std::string>& astrValues, bool bSet, CParameterAccessContext& parameterAccessContext) const;
 
-    // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void serializeXmlStructure(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
 protected:
     // Parameter Access

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -34,6 +34,7 @@
 #include "ConfigurationAccessContext.h"
 #include "ConfigurableElementAggregator.h"
 #include "AreaConfiguration.h"
+#include "XmlParameterSerializingContext.h"
 #include <assert.h>
 
 #define base CElement
@@ -44,6 +45,30 @@ CConfigurableElement::CConfigurableElement(const std::string& strName) : base(st
 
 CConfigurableElement::~CConfigurableElement()
 {
+}
+
+bool CConfigurableElement::fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext)
+{
+    CXmlParameterSerializingContext& xmlParameterAccessContext = static_cast<CXmlParameterSerializingContext &>(serializingContext);
+    CParameterAccessContext &parameterAccessContext = xmlParameterAccessContext.getAccessContext();
+    if (parameterAccessContext.serializeSettings()) {
+
+        return serializeXmlSettings(const_cast<CXmlElement&>(xmlElement), static_cast<CConfigurationAccessContext &>(parameterAccessContext));
+    }
+    return deserializeXmlStructure(xmlElement, serializingContext);
+}
+
+void CConfigurableElement::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+{
+    CXmlParameterSerializingContext& xmlParameterAccessContext = static_cast<CXmlParameterSerializingContext &>(serializingContext);
+    CParameterAccessContext &parameterAccessContext = xmlParameterAccessContext.getAccessContext();
+    if (parameterAccessContext.serializeSettings()) {
+
+        serializeXmlSettings(xmlElement, static_cast<CConfigurationAccessContext &>(parameterAccessContext));
+    } else {
+
+        serializeXmlStructure(xmlElement, serializingContext);
+    }
 }
 
 // XML configuration settings parsing

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -47,6 +47,7 @@ class PARAMETER_EXPORT CConfigurableElement : public CElement
 {
     friend class CConfigurableDomain;
     friend class CDomainConfiguration;
+    friend class CConfigurableElementAccessor;
     typedef std::list<const CConfigurableDomain*>::const_iterator ConfigurableDomainListConstIterator;
 public:
     CConfigurableElement(const std::string& strName = "");
@@ -123,6 +124,12 @@ public:
 
     // XML configuration settings parsing
     virtual bool serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const;
+
+    bool fromXml(const CXmlElement &xmlElement,
+                         CXmlSerializingContext &serializingContext) override final;
+
+    void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const override final;
+
 protected:
     // Syncer (me or ascendant)
     virtual ISyncer* getSyncer() const;

--- a/parameter/ConfigurationAccessContext.cpp
+++ b/parameter/ConfigurationAccessContext.cpp
@@ -33,6 +33,16 @@
 
 using std::string;
 
+CConfigurationAccessContext::CConfigurationAccessContext(std::string& strError,
+                                                         CParameterBlackboard* pParameterBlackboard,
+                                                         bool bValueSpaceIsRaw,
+                                                         bool bOutputRawFormatIsHex,
+                                                         bool bSerializeOut) :
+    base(strError, pParameterBlackboard, bValueSpaceIsRaw, bOutputRawFormatIsHex),
+    _bSerializeOut(bSerializeOut)
+{
+}
+
 CConfigurationAccessContext::CConfigurationAccessContext(string& strError, bool bSerializeOut) :
     base(strError),
     _bSerializeOut(bSerializeOut)

--- a/parameter/ConfigurationAccessContext.h
+++ b/parameter/ConfigurationAccessContext.h
@@ -36,10 +36,18 @@
 class CConfigurationAccessContext : public CParameterAccessContext
 {
 public:
+    CConfigurationAccessContext(std::string& strError,
+                                CParameterBlackboard* pParameterBlackboard,
+                                bool bValueSpaceIsRaw,
+                                bool bOutputRawFormatIsHex,
+                                bool bSerializeOut);
+
     CConfigurationAccessContext(std::string& strError, bool bSerializeOut);
 
     // Serialization direction
     bool serializeOut() const;
+
+    virtual bool serializeSettings() const { return true; }
 
 private:
     // Serialization direction

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -108,6 +108,17 @@ public:
     // From IXmlSource
     virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
 
+
+    virtual bool deserializeXmlStructure(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext)
+    {
+        return CElement::fromXml(xmlElement, serializingContext);
+    }
+
+    virtual void serializeXmlStructure(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+    {
+        CElement::toXml(xmlElement, serializingContext);
+    }
+
     /**
      * Serialize the children to XML
      *

--- a/parameter/InstanceConfigurableElement.cpp
+++ b/parameter/InstanceConfigurableElement.cpp
@@ -217,9 +217,9 @@ bool CInstanceConfigurableElement::checkPathExhausted(CPathNavigator& pathNaviga
     return true;
 }
 
-void CInstanceConfigurableElement::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+void CInstanceConfigurableElement::serializeXmlStructure(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
 {
-    base::toXml(xmlElement, serializingContext);
+    base::serializeXmlStructure(xmlElement, serializingContext);
     // Since Description belongs to the Type of Element, delegate it to the type element.
     getTypeElement()->setXmlDescriptionAttribute(xmlElement);
 }

--- a/parameter/InstanceConfigurableElement.h
+++ b/parameter/InstanceConfigurableElement.h
@@ -105,7 +105,7 @@ public:
     virtual void getListOfElementsWithMapping(std::list<const CConfigurableElement*>&
                                                configurableElementPath) const;
 
-    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
+    virtual void serializeXmlStructure(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
 protected:
     // Syncer

--- a/parameter/ParameterAccessContext.h
+++ b/parameter/ParameterAccessContext.h
@@ -58,6 +58,12 @@ public:
     bool valueSpaceIsRaw() const;
 
     /**
+     * @brief serializeSettings
+     * @return true if serialization of settings is requested, false if serialization of structure
+     */
+    virtual bool serializeSettings() const { return false; }
+
+    /**
      * Assigns Output Raw Format for user get value interpretation.
      *
      * @param[in] bIsHex "true" for hexadecimal, "false" for decimal

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -28,6 +28,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "ParameterMgr.h"
+#include "ConfigurationAccessContext.h"
 #include "XmlParameterSerializingContext.h"
 #include "XmlElementSerializingContext.h"
 #include "SystemClass.h"
@@ -87,6 +88,7 @@
 #include <fstream>
 #include <algorithm>
 #include <mutex>
+
 
 #define base CElement
 
@@ -240,6 +242,10 @@ const CParameterMgr::SRemoteCommandParserItem CParameterMgr::gastRemoteCommandPa
             "<elem path>|/", "List parameters under element at given path or root" },
     { "getElementStructureXML", &CParameterMgr::getElementStructureXMLCommandProcess, 1,
             "<elem path>", "Get structure of element at given path in XML format" },
+    { "getElementXML", &CParameterMgr::getElementXMLCommandProcess, 1,
+            "<elem path>", "Get settings of element at given path in XML format" },
+    { "setElementXML", &CParameterMgr::setElementXMLCommandProcess, 2,
+            "<elem path> <values>", "Set settings of element at given path in XML format" },
     { "dumpElement", &CParameterMgr::dumpElementCommandProcess, 1,
             "<elem path>", "Dump structure and content of element at given path" },
     { "getElementSize", &CParameterMgr::getElementSizeCommandProcess, 1,
@@ -523,7 +529,8 @@ bool CParameterMgr::loadStructure(string& strError)
     }
 
     // Parse Structure XML file
-    CXmlParameterSerializingContext parameterBuildContext(strError);
+    CParameterAccessContext accessContext(strError);
+    CXmlParameterSerializingContext parameterBuildContext(accessContext, strError);
 
     {
         // Get structure URI
@@ -1294,6 +1301,95 @@ CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::getElementStructure
     }
 
     return CCommandHandler::ESucceeded;
+}
+
+bool CParameterMgr::getSettingsAsXML(const CConfigurableElement *configurableElement, string &result) const
+{
+    string error;
+    CConfigurationAccessContext configurationAccessContext(error, _pMainParameterBlackboard, _bValueSpaceIsRaw, _bOutputRawFormatIsHex, true);
+    CXmlParameterSerializingContext xmlParameterContext(configurationAccessContext, error);
+
+    // Use a doc source by loading data from instantiated Configurable Domains
+    CXmlMemoryDocSource memorySource(configurableElement, false, configurableElement->getKind());
+
+    // Use a doc sink that write the doc data in a string
+    ostringstream output;
+    CXmlStreamDocSink streamSink(output);
+
+    if (not streamSink.process(memorySource, xmlParameterContext)) {
+        result = error;
+        return false;
+    }
+    result = output.str();
+    return true;
+}
+
+bool CParameterMgr::setSettingsAsXML(CConfigurableElement *configurableElement, const string &settings, string &result)
+{
+    string error;
+    CConfigurationAccessContext configurationAccessContext(error, _pMainParameterBlackboard, _bValueSpaceIsRaw, _bOutputRawFormatIsHex, false);
+    CXmlParameterSerializingContext xmlParameterContext(configurationAccessContext, error);
+
+    // It doesn't make sense to resolve XIncludes on an imported file because
+    // we can't reliably decide of a "base url"
+    _xmlDoc *doc = CXmlDocSource::mkXmlDoc(settings, false, false, xmlParameterContext);
+    if (doc == NULL) {
+        return false;
+    }
+
+    if (not xmlParse(xmlParameterContext, configurableElement, doc, "", EParameterConfigurationLibrary, "Name")) {
+        return false;
+    }
+    if (_bAutoSyncOn) {
+        CSyncerSet syncerSet;
+        static_cast<CConfigurableElement *>(configurableElement)->fillSyncerSet(syncerSet);
+        core::Results results;
+        if(not syncerSet.sync(*_pMainParameterBlackboard, true, &results)) {
+            CUtility::asString(results, result);
+
+            return false;
+        }
+    }
+    return true;
+}
+
+
+CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::getElementXMLCommandProcess(const IRemoteCommand &remoteCommand, string &result)
+{
+    CElementLocator elementLocator(getSystemClass());
+
+    CElement *locatedElement = NULL;
+
+    if (not elementLocator.locate(remoteCommand.getArgument(0), &locatedElement, result)) {
+
+        return CCommandHandler::EFailed;
+    }
+
+    if (not getSettingsAsXML(static_cast<CConfigurableElement *>(locatedElement), result)) {
+        return CCommandHandler::EFailed;
+    }
+    return CCommandHandler::ESucceeded;
+}
+
+CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::setElementXMLCommandProcess(const IRemoteCommand &remoteCommand, string &result)
+{
+    if (!checkTuningModeOn(result)) {
+
+        return CCommandHandler::EFailed;
+    }
+
+    CElementLocator elementLocator(getSystemClass());
+
+    CElement *locatedElement = NULL;
+
+    if (not elementLocator.locate(remoteCommand.getArgument(0), &locatedElement, result)) {
+
+        return CCommandHandler::EFailed;
+    }
+    if (not setSettingsAsXML(static_cast<CConfigurableElement*>(locatedElement), remoteCommand.getArgument(1), result)) {
+        return CCommandHandler::EFailed;
+    }
+    return CCommandHandler::EDone;
 }
 
 CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::dumpElementCommandProcess(const IRemoteCommand& remoteCommand, string& strResult)

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -421,6 +421,8 @@ private:
     CCommandHandler::CommandStatus listElementsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus listParametersCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementStructureXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus getElementXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus setElementXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus dumpElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementSizeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus showPropertiesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
@@ -546,6 +548,23 @@ private:
     // System class Structure loading
     bool loadSettings(std::string& strError);
     bool loadSettingsFromConfigFile(std::string& strError);
+
+    /**
+     * Assign settings to a configurable element in XML format.
+     * @param[in] configurableElement
+     * @param[in] settings the settings as XML string.
+     * @param[out] error human readable error message filled in case of error
+     * @return true in case of success, false oherwise, in which case error is filled.
+     */
+    bool setSettingsAsXML(CConfigurableElement *configurableElement, const std::string &settings, std::string &error);
+
+    /**
+     * Get settings from a configurable element in XML format.
+     * @param[in] configurableElement
+     * @param[out] settings as XML string or human readable error message in case of error
+     * @return true in case of success, false oherwise, in which case error is filled.
+     */
+    bool getSettingsAsXML(const CConfigurableElement *configurableElement, std::string &sresult) const;
 
     /** Parse an XML stream into an element
      *

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -99,8 +99,7 @@ bool CSubsystem::needResync(bool /*bClear*/)
     return false;
 }
 
-// From IXmlSink
-bool CSubsystem::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CSubsystem::deserializeXmlStructure(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {
     // Subsystem class does not rely on generic fromXml algorithm of Element class.
     // So, setting here the description if found as XML attribute.

--- a/parameter/Subsystem.h
+++ b/parameter/Subsystem.h
@@ -64,8 +64,7 @@ public:
     CSubsystem(const std::string& strName, core::log::Logger& logger);
     virtual ~CSubsystem();
 
-    // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool deserializeXmlStructure(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
 
     // Susbsystem Endianness
     bool isBigEndian() const;

--- a/parameter/XmlParameterSerializingContext.cpp
+++ b/parameter/XmlParameterSerializingContext.cpp
@@ -33,7 +33,10 @@
 
 using std::string;
 
-CXmlParameterSerializingContext::CXmlParameterSerializingContext(string& strError) : base(strError)
+CXmlParameterSerializingContext::CXmlParameterSerializingContext(CParameterAccessContext &context,
+                                                                 string& strError) :
+    base(strError),
+    mAccessContext(context)
 {
 }
 

--- a/parameter/XmlParameterSerializingContext.h
+++ b/parameter/XmlParameterSerializingContext.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "XmlElementSerializingContext.h"
+#include "ParameterAccessContext.h"
 
 #include <string>
 
@@ -38,11 +39,16 @@ class CComponentLibrary;
 class CXmlParameterSerializingContext : public CXmlElementSerializingContext
 {
 public:
-    CXmlParameterSerializingContext(std::string& strError);
+    CXmlParameterSerializingContext(CParameterAccessContext &context, std::string& strError);
 
     // ComponentLibrary
     void setComponentLibrary(const CComponentLibrary* pComponentLibrary);
     const CComponentLibrary* getComponentLibrary() const;
+
+    CParameterAccessContext &getAccessContext() const { return mAccessContext; }
+
 private:
     const CComponentLibrary* _pComponentLibrary;
+
+    CParameterAccessContext &mAccessContext;
 };


### PR DESCRIPTION
Returns current element values (from main blackboard)
in XML format.

Change-Id: Ic4afe26d19009900dad8ee4c4ad80411f808befe
Signed-off-by: Patrick Benavoli <patrick.benavoli@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/260%23issuecomment-144386559%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819517%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819665%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819804%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819813%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819950%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40820200%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40820671%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23issuecomment-144478744%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23issuecomment-144706726%22%2C%20%22https%3A//github.com/01org/parameter-framework/commit/5c3a350d8ee0098112d3b74fa907a61b6e47d8e8%23commitcomment-13556688%22%2C%20%22https%3A//github.com/01org/parameter-framework/commit/5c3a350d8ee0098112d3b74fa907a61b6e47d8e8%23commitcomment-13556702%22%2C%20%22https%3A//github.com/01org/parameter-framework/commit/5c3a350d8ee0098112d3b74fa907a61b6e47d8e8%23commitcomment-13558731%22%2C%20%22https%3A//github.com/01org/parameter-framework/commit/5c3a350d8ee0098112d3b74fa907a61b6e47d8e8%23commitcomment-13558747%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/260%23issuecomment-144980327%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/260%23issuecomment-144386559%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20%40OznOg%20%40dawagner%20%40louizo%20%3A%20please%20review%22%2C%20%22created_at%22%3A%20%222015-09-30T12%3A50%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20I%20think%20we%20can%20come%20up%20with%20another%20design.%22%2C%20%22created_at%22%3A%20%222015-09-30T17%3A07%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dawagner%20%20%40OznOg%20%20%40louizo%20%40krocard%20%5Cr%5CnWIP%3A%20redesign%20proposed%20by%20Kevin%20%26%20I.%20Still%20rework%20to%20be%20done%2C%20CConfigurableContext%20to%20given%20retrieve%20from%20XML%20in%20many%20cases...%20Just%20to%20take%20the%20temperature%20with%20this%20version%22%2C%20%22created_at%22%3A%20%222015-10-01T12%3A00%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%2C%20%7B%22body%22%3A%20%22structureTo/FromXML%20to%20be%20aligned%20with%20serializeXmlSettings%20%3F%22%2C%20%22created_at%22%3A%20%222015-10-02T10%3A02%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20399ff8c71c70882971dd9488657595f596d60450%20parameter/ParameterMgr.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819950%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%3Cmutex%3E%60%20header%20removal%3A%20unrelated%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A57%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL86-94%22%7D%2C%20%22Pull%20399ff8c71c70882971dd9488657595f596d60450%20parameter/ConfigurableElementAccessor.h%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40820200%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22nope.%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A59%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElementAccessor.h%3AL1-82%22%7D%2C%20%22Pull%20399ff8c71c70882971dd9488657595f596d60450%20parameter/ConfigurableElementAccessor.h%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40820671%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20really%20a%20need%20for%20this%20class%20to%20derive%20%60IXml%2A%60%20interfaces%3F%20What%20it%20really%20does%20is%20wrapping%20a%20serializable/deserializable%20element.%22%2C%20%22created_at%22%3A%20%222015-09-30T17%3A03%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElementAccessor.h%3AL1-82%22%7D%2C%20%22Commit%205c3a350d8ee0098112d3b74fa907a61b6e47d8e8%20parameter/ConfigurableElement.cpp%2032%2070%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/commit/5c3a350d8ee0098112d3b74fa907a61b6e47d8e8%23commitcomment-13556702%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22By%20design%2C%20only%20CConfigurableElement%3A%3AstructureToXml%20returns%20false%2C%20right%3F%20Then%2C%20you%20can%20simply%20call%20%60return%20structureToXml%28xmlElement%2C%20serializingContext%29%60.%22%2C%20%22created_at%22%3A%20%222015-10-02T07%3A17%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22yep%2C%20rework%3A%20structureTo/From%20to%20be%20declared%20at%20element%20side%20to%20avoid%20this%22%2C%20%22created_at%22%3A%20%222015-10-02T09%3A43%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElement.cpp%3AL70%20%285c3a350%29%22%7D%2C%20%22Pull%20399ff8c71c70882971dd9488657595f596d60450%20parameter/ConfigurableElementAccessor.cpp%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819665%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22useless%20comments%20%28here%20and%20below%29.%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A55%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElementAccessor.cpp%3AL1-87%22%7D%2C%20%22Commit%205c3a350d8ee0098112d3b74fa907a61b6e47d8e8%20parameter/ParameterMgr.cpp%2036%201317%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/commit/5c3a350d8ee0098112d3b74fa907a61b6e47d8e8%23commitcomment-13556688%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20seems%20strange%20to%20me%20that%20a%20%2A%2Aconfiguration%2A%2A%20access%20would%20serve%20as%20serializing%20something%20else%20than%20the%20settings.%22%2C%20%22created_at%22%3A%20%222015-10-02T07%3A15%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22right%22%2C%20%22created_at%22%3A%20%222015-10-02T09%3A44%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9692938%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cc6565%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL1317%20%285c3a350%29%22%7D%2C%20%22Pull%20399ff8c71c70882971dd9488657595f596d60450%20parameter/ConfigurableElementAccessor.cpp%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819813%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22woot%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A56%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElementAccessor.cpp%3AL1-87%22%7D%2C%20%22Pull%20399ff8c71c70882971dd9488657595f596d60450%20parameter/ConfigurableElementAccessor.cpp%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819517%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22hungarian%20leftover%20in%20%60pParameterBlackboard%60.%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A53%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElementAccessor.cpp%3AL1-87%22%7D%2C%20%22Pull%20399ff8c71c70882971dd9488657595f596d60450%20parameter/ConfigurableElementAccessor.cpp%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/260%23discussion_r40819804%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22coding%20style%3A%20keep%20an%20argument%20name%20but%20comment%20it.%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A56%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElementAccessor.cpp%3AL1-87%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/260#issuecomment-144386559'>General Comment</a></b>
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> @krocard @OznOg @dawagner @louizo : please review
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :-1: I think we can come up with another design.
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> @dawagner  @OznOg  @louizo @krocard
WIP: redesign proposed by Kevin & I. Still rework to be done, CConfigurableContext to given retrieve from XML in many cases... Just to take the temperature with this version
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> structureTo/FromXML to be aligned with serializeXmlSettings ?
- [ ] <a href='#crh-comment-Pull 399ff8c71c70882971dd9488657595f596d60450 parameter/ConfigurableElementAccessor.cpp 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/260#discussion_r40819517'>File: parameter/ConfigurableElementAccessor.cpp:L1-87</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> hungarian leftover in `pParameterBlackboard`.
- [ ] <a href='#crh-comment-Pull 399ff8c71c70882971dd9488657595f596d60450 parameter/ConfigurableElementAccessor.cpp 57'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/260#discussion_r40819665'>File: parameter/ConfigurableElementAccessor.cpp:L1-87</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> useless comments (here and below).
- [ ] <a href='#crh-comment-Pull 399ff8c71c70882971dd9488657595f596d60450 parameter/ConfigurableElementAccessor.cpp 48'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/260#discussion_r40819804'>File: parameter/ConfigurableElementAccessor.cpp:L1-87</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> coding style: keep an argument name but comment it.
- [ ] <a href='#crh-comment-Pull 399ff8c71c70882971dd9488657595f596d60450 parameter/ConfigurableElementAccessor.cpp 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/260#discussion_r40819813'>File: parameter/ConfigurableElementAccessor.cpp:L1-87</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> woot ?
- [ ] <a href='#crh-comment-Pull 399ff8c71c70882971dd9488657595f596d60450 parameter/ParameterMgr.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/260#discussion_r40819950'>File: parameter/ParameterMgr.cpp:L86-94</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> `<mutex>` header removal: unrelated
- [ ] <a href='#crh-comment-Pull 399ff8c71c70882971dd9488657595f596d60450 parameter/ConfigurableElementAccessor.h 44'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/260#discussion_r40820200'>File: parameter/ConfigurableElementAccessor.h:L1-82</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> nope.
- [ ] <a href='#crh-comment-Pull 399ff8c71c70882971dd9488657595f596d60450 parameter/ConfigurableElementAccessor.h 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/260#discussion_r40820671'>File: parameter/ConfigurableElementAccessor.h:L1-82</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Is there really a need for this class to derive `IXml*` interfaces? What it really does is wrapping a serializable/deserializable element.
- [ ] <a href='#crh-comment-Commit 5c3a350d8ee0098112d3b74fa907a61b6e47d8e8 parameter/ParameterMgr.cpp 36 1317'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/commit/5c3a350d8ee0098112d3b74fa907a61b6e47d8e8#commitcomment-13556688'>File: parameter/ParameterMgr.cpp:L1317 (5c3a350)</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> It seems strange to me that a **configuration** access would serve as serializing something else than the settings.
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> right
- [ ] <a href='#crh-comment-Commit 5c3a350d8ee0098112d3b74fa907a61b6e47d8e8 parameter/ConfigurableElement.cpp 32 70'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/commit/5c3a350d8ee0098112d3b74fa907a61b6e47d8e8#commitcomment-13556702'>File: parameter/ConfigurableElement.cpp:L70 (5c3a350)</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> By design, only CConfigurableElement::structureToXml returns false, right? Then, you can simply call `return structureToXml(xmlElement, serializingContext)`.
- <a href='https://github.com/cc6565'><img border=0 src='https://avatars.githubusercontent.com/u/9692938?v=3' height=16 width=16'></a> yep, rework: structureTo/From to be declared at element side to avoid this


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/260?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/260?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/260'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>