### PR TITLE
Value as binary

### DIFF
--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -34,6 +34,7 @@
 #include "ConfigurationAccessContext.h"
 #include "ConfigurableElementAggregator.h"
 #include "AreaConfiguration.h"
+#include "Iterator.hpp"
 #include <assert.h>
 
 #define base CElement
@@ -153,6 +154,17 @@ bool CConfigurableElement::accessValue(CPathNavigator& pathNavigator, std::strin
     }
 
     return pChild->accessValue(pathNavigator, strValue, bSet, parameterAccessContext);
+}
+
+// Whole element access
+void CConfigurableElement::getSettingsAsBytes(std::vector<uint8_t>& bytes,
+                                              CParameterAccessContext& parameterAccessContext) const
+{
+    CParameterBlackboard* pParameterBlackboard = parameterAccessContext.getParameterBlackboard();
+
+    bytes.reserve(getFootPrint());
+
+    pParameterBlackboard->readBytes(bytes, getOffset() - parameterAccessContext.getBaseOffset());
 }
 
 void CConfigurableElement::getListOfElementsWithMapping(

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -102,6 +102,8 @@ public:
 
     // Whole element access
     void getSettingsAsBytes(std::vector<uint8_t>& bytes, CParameterAccessContext& parameterAccessContext) const;
+    bool setSettingsAsBytes(const std::vector<uint8_t>& bytes,
+                            CParameterAccessContext& parameterAccessContext) const;
 
     /**
      * Get the list of all the ancestors that have a mapping.

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -34,6 +34,7 @@
 #include "Element.h"
 
 #include <list>
+#include <vector>
 
 class CConfigurableDomain;
 class CSyncerSet;
@@ -98,6 +99,9 @@ public:
 
     // Parameter access
     virtual bool accessValue(CPathNavigator& pathNavigator, std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+
+    // Whole element access
+    void getSettingsAsBytes(std::vector<uint8_t>& bytes, CParameterAccessContext& parameterAccessContext) const;
 
     /**
      * Get the list of all the ancestors that have a mapping.

--- a/parameter/ParameterBlackboard.cpp
+++ b/parameter/ParameterBlackboard.cpp
@@ -102,6 +102,25 @@ void CParameterBlackboard::readBuffer(void* pvDstData, size_t size, size_t offse
     readInteger(pvDstData, size, offset, false);
 }
 
+// Element access
+void CParameterBlackboard::writeBytes(const std::vector<uint8_t>& bytes, uint32_t offset)
+{
+    assertValidAccess(offset, bytes.size());
+
+    auto dest_first = atOffset(offset);
+
+    std::copy(bytes.begin(), bytes.end(), dest_first);
+}
+
+void CParameterBlackboard::readBytes(std::vector<uint8_t>& bytes, uint32_t offset) const
+{
+    assertValidAccess(offset, bytes.size());
+
+    auto first = atOffset(offset);
+
+    std::copy_n(first, bytes.size(), bytes.begin());
+}
+
 // Access from/to subsystems
 uint8_t* CParameterBlackboard::getLocation(size_t offset)
 {

--- a/parameter/ParameterBlackboard.h
+++ b/parameter/ParameterBlackboard.h
@@ -52,6 +52,34 @@ public:
     void writeBuffer(const void* pvSrcData, size_t size, size_t offset);
     void readBuffer(void* pvDstData, size_t size, size_t offset) const;
 
+    /**
+     * Raw write the blackboard memory.
+     * May be used to write a configurable element's settings
+     *
+     * @param[in] bytes the source data bytes vector.
+     * @param[in] offset the destination offset in the blackboard.
+     *
+     * Notes:
+     *    - Endianness is not handled by the method and thus data are written in the blackboard
+     *      with same representation as the one passed.
+     *    - This function will assert if the bytes size + offset exceeds the size of the blackboard iself.
+     */
+    void writeBytes(const std::vector<uint8_t>& bytes, uint32_t offset);
+
+    /**
+     * Raw read the blackboard memory.
+     * May be used to read a configurable element's settings
+     *
+     * @param[in] bytes the destinatin data bytes vector.
+     * @param[in] offset the source offset in the blackboard.
+     *
+     * Notes:
+     *    - Endianness is not handled by the method and thus data are read in the blackboard's representation.
+     *    - This function will assert if the bytes size + offset exceeds the size of the blackboard iself.
+     *    - The user MUST reserve exactly as many elements as the amount to read
+     */
+    void readBytes(std::vector<uint8_t>& bytes, uint32_t offset) const;
+
     // Access from/to subsystems
     uint8_t* getLocation(size_t offset);
 

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -87,6 +87,7 @@
 #include <fstream>
 #include <algorithm>
 #include <mutex>
+#include <iomanip>
 
 #define base CElement
 
@@ -240,6 +241,8 @@ const CParameterMgr::SRemoteCommandParserItem CParameterMgr::gastRemoteCommandPa
             "<elem path>|/", "List parameters under element at given path or root" },
     { "getElementStructureXML", &CParameterMgr::getElementStructureXMLCommandProcess, 1,
             "<elem path>", "Get structure of element at given path in XML format" },
+    { "getElementBytes", &CParameterMgr::getElementBytesCommandProcess, 1,
+            "<elem path>", "Get settings of element at given path in Byte Array format" },
     { "dumpElement", &CParameterMgr::dumpElementCommandProcess, 1,
             "<elem path>", "Dump structure and content of element at given path" },
     { "getElementSize", &CParameterMgr::getElementSizeCommandProcess, 1,
@@ -1292,6 +1295,50 @@ CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::getElementStructure
 
         return CCommandHandler::EFailed;
     }
+
+    return CCommandHandler::ESucceeded;
+}
+
+CParameterMgr::CCommandHandler::CommandStatus
+CParameterMgr::getElementBytesCommandProcess(const IRemoteCommand& remoteCommand,
+                                              std::string& strResult)
+{
+    CElementLocator elementLocator(getSystemClass());
+
+    CElement* pLocatedElement = NULL;
+
+    if (!elementLocator.locate(remoteCommand.getArgument(0), &pLocatedElement, strResult)) {
+
+        return CCommandHandler::EFailed;
+    }
+
+    const CConfigurableElement* pConfigurableElement =
+            static_cast<CConfigurableElement*>(pLocatedElement);
+
+    // Prepare parameter access context for main blackboard.
+    // Notes:
+    //     - No need to handle output raw format and value space as Byte arrays are hexa formatted
+    //     - Pasing strResult to parameterAccessContext is only necessary wrt to constructor definition:
+    //       since it's a get type of access, no error may occur
+    CParameterAccessContext parameterAccessContext(strResult);
+    parameterAccessContext.setParameterBlackboard(_pMainParameterBlackboard);
+
+    // Get the settings
+    vector<uint8_t> bytes;
+    pConfigurableElement->getSettingsAsBytes(bytes, parameterAccessContext);
+
+    // Hexa formatting
+    std::ostringstream ostream;
+    ostream << std::hex << std::uppercase << std::setw(2) << std::setfill('0');
+
+    // Format bytes
+    for (auto byte : bytes) {
+
+        // Format
+        ostream << "0x" << static_cast<uint32_t>(byte);
+    }
+
+    strResult = ostream.str();
 
     return CCommandHandler::ESucceeded;
 }

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -422,6 +422,7 @@ private:
     CCommandHandler::CommandStatus listParametersCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementStructureXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus setElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus dumpElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementSizeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus showPropertiesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -421,6 +421,7 @@ private:
     CCommandHandler::CommandStatus listElementsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus listParametersCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementStructureXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus getElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus dumpElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementSizeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus showPropertiesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);

--- a/remote-processor/RemoteCommand.h
+++ b/remote-processor/RemoteCommand.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <vector>
 #include <string>
 
 class IRemoteCommand
@@ -42,6 +43,7 @@ public:
     virtual void addArgument(const std::string& strArgument) = 0;
     virtual size_t getArgumentCount() const = 0;
     virtual const std::string& getArgument(size_t argument) const = 0;
+    virtual const std::vector<std::string>& getArguments() const = 0;
     virtual const std::string packArguments(size_t startArgument, size_t nbArguments) const = 0;
 
 protected:

--- a/remote-processor/RequestMessage.cpp
+++ b/remote-processor/RequestMessage.cpp
@@ -69,6 +69,11 @@ size_t CRequestMessage::getArgumentCount() const
     return _argumentVector.size();
 }
 
+const std::vector<string>& CRequestMessage::getArguments() const
+{
+    return _argumentVector;
+}
+
 const string& CRequestMessage::getArgument(size_t argument) const
 {
     assert(argument < _argumentVector.size());

--- a/remote-processor/RequestMessage.h
+++ b/remote-processor/RequestMessage.h
@@ -50,6 +50,7 @@ public:
     virtual void addArgument(const std::string& strArgument);
     virtual size_t getArgumentCount() const;
     virtual const std::string& getArgument(size_t argument) const;
+    virtual const std::vector<std::string>& getArguments() const;
     virtual const std::string packArguments(size_t startArgument, size_t nbArguments) const;
 
 private:

--- a/utility/convert.hpp
+++ b/utility/convert.hpp
@@ -53,6 +53,7 @@ template<> struct ConvertionAllowed<uint32_t> {};
 template<> struct ConvertionAllowed<int32_t> {};
 template<> struct ConvertionAllowed<uint16_t> {};
 template<> struct ConvertionAllowed<int16_t> {};
+template<> struct ConvertionAllowed<uint8_t> {};
 template<> struct ConvertionAllowed<float> {};
 template<> struct ConvertionAllowed<double> {};
 
@@ -116,6 +117,42 @@ template<typename T>
 static inline bool convertTo(const std::string &str, T &result)
 {
     return details::convertTo<T>(str, result);
+}
+
+/** Specialization for uint8_t of convertTo template function.
+ *
+ * This function follows the same paradigm than it's generic version.
+ *
+ * The generic version was converting int8 as it was a character
+ * (uint8_t is an alias to unsigned char on most compiler).
+ * Thus converting "1" would return 49 ie '1'.
+ * As convertTo is thought as an _numerical_ conversion tool
+ * (contrary to boost::lexical_cast for example),
+ * forbid considering the input as a character and consider uint8_t
+ * (aka unsigned char) as a number exclusively.
+ *
+ * TODO: Add the specialization for int8_t too.
+ *
+ * @param[in]  str    the string to parse.
+ * @param[out] result reference to object where to store the result.
+ *
+ * @return true if conversion was successful, false otherwise.
+ */
+template<>
+inline bool convertTo<uint8_t>(const std::string &str, uint8_t &result)
+{
+    uint32_t res;
+
+    if (!convertTo<uint32_t>(str, res)) {
+        return false;
+    }
+
+    if (res > std::numeric_limits<uint8_t>::max()) {
+        return false;
+    }
+
+    result = static_cast<uint8_t>(res);
+    return true;
 }
 
 /**

--- a/utility/convert.hpp
+++ b/utility/convert.hpp
@@ -119,37 +119,6 @@ static inline bool convertTo(const std::string &str, T &result)
 }
 
 /**
- * Specialization for int16_t of convertTo template function.
- *
- * This function follows the same paradigm than it's generic version.
- *
- * The specific implementation is made necessary because the stlport version of
- * string streams is bugged and does not fail when giving overflowed values.
- * This specialisation can be safely removed when stlport behaviour is fixed.
- *
- * @param[in]  str    the string to parse.
- * @param[out] result reference to object where to store the result.
- *
- * @return true if conversion was successful, false otherwise.
- */
-template<>
-inline bool convertTo<int16_t>(const std::string &str, int16_t &result)
-{
-    int64_t res;
-
-    if (!convertTo<int64_t>(str, res)) {
-        return false;
-    }
-
-    if (res > std::numeric_limits<int16_t>::max() || res < std::numeric_limits<int16_t>::min()) {
-        return false;
-    }
-
-    result = static_cast<int16_t>(res);
-    return true;
-}
-
-/**
  * Specialization for float of convertTo template function.
  *
  * This function follows the same paradigm than it's generic version and is


### PR DESCRIPTION
Add support to inport/export configurable element in binary format
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/261%23issuecomment-144425835%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23issuecomment-144466651%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23issuecomment-144467417%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40905649%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40918521%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40918555%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40918763%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40921579%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40921580%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40921582%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40922582%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/261%23issuecomment-144425835%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20%40OznOg%20%40cc6565%20%40dawagner%20please%20review%22%2C%20%22created_at%22%3A%20%222015-09-30T14%3A19%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%20is%20an%20asymmetry%20between%20how%20the%20data%20is%20printed%20and%20how%20it%20is%20read%3A%5Cr%5Cn%5Cr%5Cn-%20It%20is%20printed%20without%20any%20whitespace%20but%20the%20user%20is%20expected%20to%20pass%20each%20byte%20as%20a%20separate%20argument%20on%20the%20command%20line%5Cr%5Cn-%20A%20remote-process%20user%20will%20receive%20data%20on%20the%20standard%20output%20but%20can%27t%20pass%20data%20on%20the%20standard%20input%20%28this%20is%20not%20libparameter%27s%20fault%20but%20a%20more%20general%20issue%29%5Cr%5Cn-%20It%20is%20printed%20with%20a%20%5C%220x%5C%22%20but%20the%20user%20may%20pass%20it%20with%20or%20without%20a%20%5C%220x%5C%22%20%28this%20is%20maybe%20not%20an%20issue%20but%20feels%20a%20bit%20odd%29%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A24%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20%28I%20may%20have%20missed%20some%20bits%20but%20I%27ll%20review%20again%20once%20the%20current%20comments%20have%20been%20addressed%29%22%2C%20%22created_at%22%3A%20%222015-09-30T16%3A27%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206251fde8b484d9776a2faa6ee1a8837ef4bb4122%20parameter/ParameterBlackboard.h%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40918521%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20mention%20that%20the%20caller%20must%20reserve%20exactly%20as%20many%20elements%20as%20the%20amount%20to%20be%20read.%22%2C%20%22created_at%22%3A%20%222015-10-01T14%3A23%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-01T14%3A55%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12096004%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/miguelgaio%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterBlackboard.h%3AL52-85%22%7D%2C%20%22Pull%206251fde8b484d9776a2faa6ee1a8837ef4bb4122%20parameter/ParameterMgr.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40918555%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20are%20still%203%20%5C%22m%5C%22%20in%20these%20function%20names.%22%2C%20%22created_at%22%3A%20%222015-10-01T14%3A24%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-01T14%3A47%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL242-252%22%7D%2C%20%22Pull%206251fde8b484d9776a2faa6ee1a8837ef4bb4122%20parameter/ParameterMgr.cpp%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40918763%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20are%20putting%20a%20%60uint8_t%60%20in%20a%20stream%20--%3E%20it%20will%20get%20formatted%20as%20a%20character%20%28i.e.%20100%20-%3E%20%5C%22d%5C%22%20instead%20of%20%5C%2264%5C%22%29%22%2C%20%22created_at%22%3A%20%222015-10-01T14%3A25%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-01T14%3A47%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL1302-1413%22%7D%2C%20%22Pull%20c5a74ccf9fd152dedc9420b984a4de32d90a8031%20parameter/ParameterMgr.cpp%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/261%23discussion_r40905649%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20need%20to%20repeat%20%60%3C%3C%20std%3A%3Asetw%282%29%20%3C%3C%20std%3A%3Asetfill%28%270%27%29%60%3A%20you%20can%20set%20the%20format%20once%20for%20the%20whole%20stream.%22%2C%20%22created_at%22%3A%20%222015-10-01T12%3A07%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-01T14%3A47%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL1302-1413%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/261#issuecomment-144425835'>General Comment</a></b>
- <a href='https://github.com/miguelgaio'><img border=0 src='https://avatars.githubusercontent.com/u/12096004?v=3' height=16 width=16'></a> @krocard @OznOg @cc6565 @dawagner please review
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> There is an asymmetry between how the data is printed and how it is read:
- It is printed without any whitespace but the user is expected to pass each byte as a separate argument on the command line
- A remote-process user will receive data on the standard output but can't pass data on the standard input (this is not libparameter's fault but a more general issue)
- It is printed with a "0x" but the user may pass it with or without a "0x" (this is maybe not an issue but feels a bit odd)
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :-1: (I may have missed some bits but I'll review again once the current comments have been addressed)
- [x] <a href='#crh-comment-Pull c5a74ccf9fd152dedc9420b984a4de32d90a8031 parameter/ParameterMgr.cpp 60'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/261#discussion_r40905649'>File: parameter/ParameterMgr.cpp:L1302-1413</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> No need to repeat `<< std::setw(2) << std::setfill('0')`: you can set the format once for the whole stream.
- [x] <a href='#crh-comment-Pull 6251fde8b484d9776a2faa6ee1a8837ef4bb4122 parameter/ParameterBlackboard.h 22'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/261#discussion_r40918521'>File: parameter/ParameterBlackboard.h:L52-85</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Please mention that the caller must reserve exactly as many elements as the amount to be read.
- [x] <a href='#crh-comment-Pull 6251fde8b484d9776a2faa6ee1a8837ef4bb4122 parameter/ParameterMgr.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/261#discussion_r40918555'>File: parameter/ParameterMgr.cpp:L242-252</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> There are still 3 "m" in these function names.
- [x] <a href='#crh-comment-Pull 6251fde8b484d9776a2faa6ee1a8837ef4bb4122 parameter/ParameterMgr.cpp 60'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/261#discussion_r40918763'>File: parameter/ParameterMgr.cpp:L1302-1413</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> You are putting a `uint8_t` in a stream --> it will get formatted as a character (i.e. 100 -> "d" instead of "64")


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/261?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/261?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/261'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>