### PR TITLE
WIP: only export symbols that are part of the API

### DIFF
--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -43,60 +43,79 @@ class CConfigurationAccessContext;
 class CParameterAccessContext;
 class CAreaConfiguration;
 
-class PARAMETER_EXPORT CConfigurableElement : public CElement
+class CConfigurableElement : public CElement
 {
     friend class CConfigurableDomain;
     friend class CDomainConfiguration;
     typedef std::list<const CConfigurableDomain*>::const_iterator ConfigurableDomainListConstIterator;
 public:
+    PARAMETER_EXPORT
     CConfigurableElement(const std::string& strName = "");
+    PARAMETER_EXPORT
     virtual ~CConfigurableElement();
 
     // Offset in main blackboard
+    PARAMETER_EXPORT
     void setOffset(size_t offset);
+    PARAMETER_EXPORT
     size_t getOffset() const;
 
     // Allocation
+    PARAMETER_EXPORT
     virtual size_t getFootPrint() const;
 
     // Syncer set (me, ascendant or descendant ones)
+    PARAMETER_EXPORT
     void fillSyncerSet(CSyncerSet& syncerSet) const;
 
     // Belonging domain
+    PARAMETER_EXPORT
     bool belongsTo(const CConfigurableDomain* pConfigurableDomain) const;
 
     // Belonging domains
+    PARAMETER_EXPORT
     void listBelongingDomains(std::string& strResult, bool bVertical = true) const;
 
     // Matching check for domain association
+    PARAMETER_EXPORT
     bool hasNoDomainAssociated() const;
 
     // Matching check for no valid associated domains
+    PARAMETER_EXPORT
     bool hasNoValidDomainAssociated() const;
 
     // Owning domains
+    PARAMETER_EXPORT
     void listAssociatedDomains(std::string& strResult, bool bVertical = true) const;
+    PARAMETER_EXPORT
     size_t getBelongingDomainCount() const;
 
     // Elements with no domains
+    PARAMETER_EXPORT
     void listRogueElements(std::string& strResult) const;
 
     // Belonging to no domains
+    PARAMETER_EXPORT
     bool isRogue() const;
 
     // Footprint as string
+    PARAMETER_EXPORT
     std::string getFootprintAsString() const;
 
     // Belonging subsystem
+    PARAMETER_EXPORT
     virtual const CSubsystem* getBelongingSubsystem() const;
 
     // Check element is a parameter
+    PARAMETER_EXPORT
     virtual bool isParameter() const;
 
     // AreaConfiguration creation
+    PARAMETER_EXPORT
     virtual CAreaConfiguration* createAreaConfiguration(const CSyncerSet* pSyncerSet) const;
 
     // Parameter access
+    PARAMETER_EXPORT
     virtual bool accessValue(CPathNavigator& pathNavigator, std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
 
     /**
@@ -112,23 +131,30 @@ public:
      * the last one.
      *
      */
+    PARAMETER_EXPORT
     virtual void getListOfElementsWithMapping(std::list<const CConfigurableElement*>&
                                                configurableElementPath) const;
 
     // Used for simulation and virtual subsystems
+    PARAMETER_EXPORT
     virtual void setDefaultValues(CParameterAccessContext& parameterAccessContext) const;
 
     // Element properties
+    PARAMETER_EXPORT
     virtual void showProperties(std::string& strResult) const;
 
     // XML configuration settings parsing
+    PARAMETER_EXPORT
     virtual bool serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const;
 protected:
     // Syncer (me or ascendant)
+    PARAMETER_EXPORT
     virtual ISyncer* getSyncer() const;
     // Syncer set (descendant)
+    PARAMETER_EXPORT
     virtual void fillSyncerSetFromDescendant(CSyncerSet& syncerSet) const;
     // Configuration Domain local search
+    PARAMETER_EXPORT
     bool containsConfigurableDomain(const CConfigurableDomain* pConfigurableDomain) const;
 
 private:

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -42,38 +42,58 @@
 class CXmlElementSerializingContext;
 class CErrorContext;
 
-class PARAMETER_EXPORT CElement : public IXmlSink, public IXmlSource
+class CElement : public IXmlSink, public IXmlSource
 {
 public:
+    PARAMETER_EXPORT
     CElement(const std::string& strName = "");
+    PARAMETER_EXPORT
     virtual ~CElement();
 
     // Description
+    PARAMETER_EXPORT
     void setDescription(const std::string& strDescription);
+    PARAMETER_EXPORT
     const std::string& getDescription() const;
 
     // Name / Path
+    PARAMETER_EXPORT
     const std::string& getName() const;
+    PARAMETER_EXPORT
     void setName(const std::string& strName);
+    PARAMETER_EXPORT
     bool rename(const std::string& strName, std::string& strError);
+    PARAMETER_EXPORT
     std::string getPath() const;
+    PARAMETER_EXPORT
     std::string getQualifiedPath() const;
 
     // Creation / build
+    PARAMETER_EXPORT
     virtual bool init(std::string& strError);
+    PARAMETER_EXPORT
     virtual void clean();
 
     // Children management
+    PARAMETER_EXPORT
     void addChild(CElement* pChild);
+    PARAMETER_EXPORT
     bool removeChild(CElement* pChild);
+    PARAMETER_EXPORT
     void listChildren(std::string& strChildList) const;
+    PARAMETER_EXPORT
     std::string listQualifiedPaths(bool bDive, size_t level = 0) const;
+    PARAMETER_EXPORT
     void listChildrenPaths(std::string& strChildPathList) const;
 
     // Hierarchy query
+    PARAMETER_EXPORT
     size_t getNbChildren() const;
+    PARAMETER_EXPORT
     CElement* findChildOfKind(const std::string& strKind);
+    PARAMETER_EXPORT
     const CElement* findChildOfKind(const std::string& strKind) const;
+    PARAMETER_EXPORT
     const CElement* getParent() const;
 
     /**
@@ -84,6 +104,7 @@ public:
      * @param[in] index the index of the child element from 0 to number of children - 1
      * @return the child element
      */
+    PARAMETER_EXPORT
     const CElement* getChild(size_t index) const;
 
     /**
@@ -94,18 +115,26 @@ public:
      * @param[in] index the index of the child element from 0 to number of children - 1
      * @return the child element
      */
+    PARAMETER_EXPORT
     CElement* getChild(size_t index);
 
+    PARAMETER_EXPORT
     const CElement* findChild(const std::string& strName) const;
+    PARAMETER_EXPORT
     CElement* findChild(const std::string& strName);
+    PARAMETER_EXPORT
     const CElement* findDescendant(CPathNavigator& pathNavigator) const;
+    PARAMETER_EXPORT
     CElement* findDescendant(CPathNavigator& pathNavigator);
+    PARAMETER_EXPORT
     bool isDescendantOf(const CElement* pCandidateAscendant) const;
 
     // From IXmlSink
+    PARAMETER_EXPORT
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
 
     // From IXmlSource
+    PARAMETER_EXPORT
     virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
 
     /**
@@ -119,16 +148,20 @@ public:
      *                object upon which this method is called)
      * @param[in,out] serializingContext information about the serialization
      */
+    PARAMETER_EXPORT
     virtual void childrenToXml(CXmlElement& xmlElement,
                                CXmlSerializingContext& serializingContext) const;
 
     // Content structure dump
+    PARAMETER_EXPORT
     void dumpContent(std::string& strContent, CErrorContext& errorContext, const size_t depth = 0) const;
 
     // Element properties
+    PARAMETER_EXPORT
     virtual void showProperties(std::string& strResult) const;
 
     // Class kind
+    PARAMETER_EXPORT
     virtual std::string getKind() const = 0;
 
     /**
@@ -136,6 +169,7 @@ public:
      *
      * @param[in,out] xmlElement to fill with the description
      */
+    PARAMETER_EXPORT
     void setXmlDescriptionAttribute(CXmlElement& xmlElement) const;
 
     /**
@@ -143,13 +177,16 @@ public:
      *
      * @param[out] strResult in which the description is wished to be appended.
      */
+    PARAMETER_EXPORT
     void showDescriptionProperty(std::string &strResult) const;
 
 protected:
     // Content dumping
+    PARAMETER_EXPORT
     virtual void logValue(std::string& strValue, CErrorContext& errorContext) const;
 
     // Hierarchy
+    PARAMETER_EXPORT
     CElement* getParent();
 
     /**
@@ -160,15 +197,18 @@ protected:
      *
      * @return child a pointer on the CElement object that has been added to the tree
      */
+    PARAMETER_EXPORT
     CElement* createChild(const CXmlElement& childElement,
                           CXmlSerializingContext& elementSerializingContext);
 
+    PARAMETER_EXPORT
     static const std::string gDescriptionPropertyName;
 
 private:
     // Returns Name or Kind if no Name
     std::string getPathName() const;
     // Returns true if children dynamic creation is to be dealt with
+    PARAMETER_EXPORT
     virtual bool childrenAreDynamic() const;
     // House keeping
     void removeChildren();

--- a/parameter/ElementLibrary.h
+++ b/parameter/ElementLibrary.h
@@ -38,14 +38,16 @@
 
 class CElementBuilder;
 
-class PARAMETER_EXPORT CElementLibrary
+class CElementLibrary
 {
     typedef std::map<std::string, const CElementBuilder*> ElementBuilderMap;
     typedef ElementBuilderMap::iterator ElementBuilderMapIterator;
     typedef ElementBuilderMap::const_iterator ElementBuilderMapConstIterator;
 
 public:
+    PARAMETER_EXPORT
     CElementLibrary();
+    PARAMETER_EXPORT
     virtual ~CElementLibrary();
 
     /** Add a xml tag and it's corresponding builder in the library.
@@ -54,10 +56,13 @@ public:
        *               create a new element.
        * @param[in] pElementBuilder is the tag associated element builder.
        */
+    PARAMETER_EXPORT
     void addElementBuilder(const std::string& type, const CElementBuilder *pElementBuilder);
+    PARAMETER_EXPORT
     void clean();
 
     // Instantiation
+    PARAMETER_EXPORT
     CElement* createElement(const CXmlElement& xmlElement) const;
 
 private:

--- a/parameter/InstanceConfigurableElement.h
+++ b/parameter/InstanceConfigurableElement.h
@@ -41,7 +41,7 @@ class IMapper;
 class CParameterBlackboard;
 class CParameterAccessContext;
 
-class PARAMETER_EXPORT CInstanceConfigurableElement : public CConfigurableElementWithMapping
+class CInstanceConfigurableElement : public CConfigurableElementWithMapping
 {
 public:
     enum Type {
@@ -53,11 +53,14 @@ public:
         EComponent
     };
 
+    PARAMETER_EXPORT
     CInstanceConfigurableElement(const std::string& strName, const CTypeElement* pTypeElement);
 
     // Instantiated type
+    PARAMETER_EXPORT
     const CTypeElement* getTypeElement() const;
 
+    PARAMETER_EXPORT
     virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const;
 
     /**
@@ -66,28 +69,37 @@ public:
      *
      * @return A std::string containing the formatted mapping
      */
+    PARAMETER_EXPORT
     std::string getFormattedMapping() const;
 
     // From CElement
+    PARAMETER_EXPORT
     virtual std::string getKind() const;
 
     // Syncer to/from HW
+    PARAMETER_EXPORT
     void setSyncer(ISyncer* pSyncer);
+    PARAMETER_EXPORT
     void unsetSyncer();
 
     // Type
+    PARAMETER_EXPORT
     virtual Type getType() const = 0;
 
     // Mapping execution
+    PARAMETER_EXPORT
     bool map(IMapper& mapper, std::string& strError);
 
     // Element properties
+    PARAMETER_EXPORT
     virtual void showProperties(std::string& strResult) const;
 
     // Scalar or Array?
+    PARAMETER_EXPORT
     bool isScalar() const;
 
     // Array Length
+    PARAMETER_EXPORT
     size_t getArrayLength() const;
 
     /**
@@ -102,9 +114,11 @@ public:
      * that have a mapping. Elements are added at the end of the list, so the root Element will be
      * the last one.
      */
+    PARAMETER_EXPORT
     virtual void getListOfElementsWithMapping(std::list<const CConfigurableElement*>&
                                                configurableElementPath) const;
 
+    PARAMETER_EXPORT
     virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
 protected:

--- a/parameter/MappingContext.h
+++ b/parameter/MappingContext.h
@@ -36,7 +36,7 @@
 #include <string>
 #include <vector>
 
-class PARAMETER_EXPORT CMappingContext
+class CMappingContext
 {
 private:
     // Item structure
@@ -47,6 +47,7 @@ private:
     };
 
 public:
+    PARAMETER_EXPORT
     CMappingContext(size_t uiNbItemTypes) : mItems(uiNbItemTypes) {}
 
     // Item access
@@ -59,8 +60,11 @@ public:
      *
      * @return False if already set, true else.
      */
+    PARAMETER_EXPORT
     bool setItem(size_t itemType, const std::string* pStrKey, const std::string* pStrItem);
+    PARAMETER_EXPORT
     const std::string& getItem(size_t itemType) const;
+    PARAMETER_EXPORT
     size_t getItemAsInteger(size_t itemType) const;
     /**
      * Get mapping item value from its key name.
@@ -69,7 +73,9 @@ public:
      *
      * @return Mapping item value pointer if found, NULL else.
      */
+    PARAMETER_EXPORT
     const std::string* getItem(const std::string& strKey) const;
+    PARAMETER_EXPORT
     bool iSet(size_t itemType) const;
 
 private:

--- a/parameter/ParameterType.h
+++ b/parameter/ParameterType.h
@@ -41,40 +41,57 @@
 class CParameterAccessContext;
 class CConfigurationAccessContext;
 
-class PARAMETER_EXPORT CParameterType : public CTypeElement
+class CParameterType : public CTypeElement
 {
 public:
+    PARAMETER_EXPORT
     CParameterType(const std::string& strName);
+    PARAMETER_EXPORT
     virtual ~CParameterType();
 
     // Size
+    PARAMETER_EXPORT
     size_t getSize() const;
 
     // Unit
+    PARAMETER_EXPORT
     std::string getUnit() const;
+    PARAMETER_EXPORT
     void setUnit(const std::string& strUnit);
 
     // From IXmlSink
+    PARAMETER_EXPORT
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
 
     // From IXmlSource
+    PARAMETER_EXPORT
     virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
 
     /// Conversions
     // String
+    PARAMETER_EXPORT
     virtual bool toBlackboard(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const = 0;
+    PARAMETER_EXPORT
     virtual bool fromBlackboard(std::string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const = 0;
     // Boolean
+    PARAMETER_EXPORT
     virtual bool toBlackboard(bool bUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    PARAMETER_EXPORT
     virtual bool fromBlackboard(bool& bUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
     // Integer
+    PARAMETER_EXPORT
     virtual bool toBlackboard(uint32_t uiUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    PARAMETER_EXPORT
     virtual bool fromBlackboard(uint32_t& uiUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
     // Signed Integer
+    PARAMETER_EXPORT
     virtual bool toBlackboard(int32_t iUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    PARAMETER_EXPORT
     virtual bool fromBlackboard(int32_t& iUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
     // Double
+    PARAMETER_EXPORT
     virtual bool toBlackboard(double dUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    PARAMETER_EXPORT
     virtual bool fromBlackboard(double& dUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
 
     /** Value space handling for settings import/export from/to XML
@@ -89,12 +106,15 @@ public:
      * @param[in,out] xmlConfigurableElementSettingsElement the element being imported or exported
      * @param[in,out] configurationAccessContext the import or export context
      */
+    PARAMETER_EXPORT
     virtual void handleValueSpaceAttribute(CXmlElement& xmlConfigurableElementSettingsElement, CConfigurationAccessContext& configurationAccessContext) const;
 
     // Element properties
+    PARAMETER_EXPORT
     virtual void showProperties(std::string& strResult) const;
 
     // Default value handling (simulation only)
+    PARAMETER_EXPORT
     virtual uint32_t getDefaultValue() const;
 
     /**
@@ -102,6 +122,7 @@ public:
      *
      * @param[in:out] iData the data which will be sign extended
      */
+    PARAMETER_EXPORT
     void signExtend(int32_t& iData) const;
 
     /**
@@ -109,6 +130,7 @@ public:
      *
      * @param[in:out] iData the data which will be sign extended
      */
+    PARAMETER_EXPORT
     void signExtend(int64_t& iData) const;
 
 protected:

--- a/parameter/SubsystemObjectCreator.h
+++ b/parameter/SubsystemObjectCreator.h
@@ -35,23 +35,29 @@
 #include "MappingContext.h"
 #include <string>
 
-class PARAMETER_EXPORT CSubsystemObjectCreator
+class CSubsystemObjectCreator
 {
 public:
+    PARAMETER_EXPORT
     CSubsystemObjectCreator(const std::string& strMappingKey, uint32_t uiAncestorIdMask, size_t maxConfigurableElementSize);
 
     // Accessors
+    PARAMETER_EXPORT
     const std::string& getMappingKey() const;
+    PARAMETER_EXPORT
     uint32_t getAncestorMask() const;
+    PARAMETER_EXPORT
     size_t getMaxConfigurableElementSize() const;
 
     // Object creation
+    PARAMETER_EXPORT
     virtual CSubsystemObject* objectCreate(
             const std::string& strMappingValue,
             CInstanceConfigurableElement* pInstanceConfigurableElement,
             const CMappingContext& context,
             core::log::Logger& logger) const = 0;
 
+    PARAMETER_EXPORT
     virtual ~CSubsystemObjectCreator() {}
 
 private:

--- a/parameter/TypeElement.h
+++ b/parameter/TypeElement.h
@@ -37,17 +37,22 @@
 class CMappingData;
 class CInstanceConfigurableElement;
 
-class PARAMETER_EXPORT CTypeElement : public CElement
+class CTypeElement : public CElement
 {
 public:
+    PARAMETER_EXPORT
     CTypeElement(const std::string& strName = "");
+    PARAMETER_EXPORT
     virtual ~CTypeElement();
 
     // Instantiation
+    PARAMETER_EXPORT
     CInstanceConfigurableElement* instantiate() const;
 
     // Mapping info
+    PARAMETER_EXPORT
     virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const;
+    PARAMETER_EXPORT
     virtual bool hasMappingData() const;
 
     /**
@@ -55,21 +60,27 @@ public:
      *
      * @return A std::string containing the mapping as a comma separated key value pairs
      */
+    PARAMETER_EXPORT
     virtual std::string getFormattedMapping() const;
 
     // Element properties
+    PARAMETER_EXPORT
     virtual void showProperties(std::string& strResult) const;
 
     // From IXmlSink
+    PARAMETER_EXPORT
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
 
     // From IXmlSource
+    PARAMETER_EXPORT
     virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
 
     // Scalar or Array?
+    PARAMETER_EXPORT
     bool isScalar() const;
 
     // Array Length
+    PARAMETER_EXPORT
     size_t getArrayLength() const;
 
     /**
@@ -79,6 +90,7 @@ public:
      *
      * @return the data with int type
      */
+    PARAMETER_EXPORT
     virtual int toPlainInteger(int iSizeOptimizedData) const;
 
 protected:

--- a/parameter/include/ParameterHandle.h
+++ b/parameter/include/ParameterHandle.h
@@ -38,22 +38,29 @@
 class CBaseParameter;
 class CParameterMgr;
 
-class PARAMETER_EXPORT CParameterHandle
+class CParameterHandle
 {
 public:
+    PARAMETER_EXPORT
     CParameterHandle(const CBaseParameter* pParameter, CParameterMgr* pParameterMgr);
 
     // Parameter features
+    PARAMETER_EXPORT
     bool isRogue() const;
+    PARAMETER_EXPORT
     bool isArray() const;
     // Array Length
+    PARAMETER_EXPORT
     size_t getArrayLength() const; // Returns 0 for scalar
     // Parameter path
+    PARAMETER_EXPORT
     std::string getPath() const;
     // Parameter kind
+    PARAMETER_EXPORT
     std::string getKind() const;
 
     // Boolean access
+    PARAMETER_EXPORT
     bool setAsBoolean(bool bValue, std::string& strError);
 
     /**
@@ -64,32 +71,51 @@ public:
      *
      * @return true on success, false otherwise
      */
+    PARAMETER_EXPORT
     bool getAsBoolean(bool& bValue, std::string& strError) const;
+    PARAMETER_EXPORT
     bool setAsBooleanArray(const std::vector<bool>& abValues, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsBooleanArray(std::vector<bool>& abValues, std::string& strError) const;
 
     // Integer Access
+    PARAMETER_EXPORT
     bool setAsInteger(uint32_t uiValue, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsInteger(uint32_t& uiValue, std::string& strError) const;
+    PARAMETER_EXPORT
     bool setAsIntegerArray(const std::vector<uint32_t>& auiValues, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsIntegerArray(std::vector<uint32_t>& auiValues, std::string& strError) const;
 
     // Signed Integer Access
+    PARAMETER_EXPORT
     bool setAsSignedInteger(int32_t iValue, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsSignedInteger(int32_t& iValue, std::string& strError) const;
+    PARAMETER_EXPORT
     bool setAsSignedIntegerArray(const std::vector<int32_t>& aiValues, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsSignedIntegerArray(std::vector<int32_t>& aiValues, std::string& strError) const;
 
     // Double Access
+    PARAMETER_EXPORT
     bool setAsDouble(double dValue, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsDouble(double& dValue, std::string& strError) const;
+    PARAMETER_EXPORT
     bool setAsDoubleArray(const std::vector<double>& adValues, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsDoubleArray(std::vector<double>& adValues, std::string& strError) const;
 
     // String Access
+    PARAMETER_EXPORT
     bool setAsString(const std::string& strValue, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsString(std::string& strValue, std::string& strError) const;
+    PARAMETER_EXPORT
     bool setAsStringArray(const std::vector<std::string>& astrValues, std::string& strError);
+    PARAMETER_EXPORT
     bool getAsStringArray(std::vector<std::string>& astrValues, std::string& strError) const;
 
 private:

--- a/parameter/include/ParameterMgrFullConnector.h
+++ b/parameter/include/ParameterMgrFullConnector.h
@@ -43,7 +43,7 @@
 
 class CParameterMgr;
 
-class PARAMETER_EXPORT CParameterMgrFullConnector
+class CParameterMgrFullConnector
 {
     friend class CParameterMgrLogger<CParameterMgrFullConnector>;
 
@@ -52,7 +52,9 @@ public:
     /** String list type which can hold list of error/info and can be presented to client */
     typedef std::list<std::string> Results;
 
+    PARAMETER_EXPORT
     CParameterMgrFullConnector(const std::string& strConfigurationFilePath);
+    PARAMETER_EXPORT
     ~CParameterMgrFullConnector();
 
     /** Interface to implement to provide a custom logger to the PF.
@@ -64,7 +66,7 @@ public:
       * Choice between the 2 is left to the client convenience.
       * @Note Errors are always returned synchronously. Never logged.
       */
-    class ILogger
+    class PARAMETER_EXPORT ILogger
     {
     public:
         virtual void info(const std::string& strLog) = 0;
@@ -74,21 +76,28 @@ public:
     };
     // Logging
     /** Should be called before start */
+    PARAMETER_EXPORT
     void setLogger(ILogger* pLogger);
 
 
+    PARAMETER_EXPORT
     bool start(std::string& strError);
 
     // Dynamic parameter handling
+    PARAMETER_EXPORT
     CParameterHandle* createParameterHandle(const std::string& strPath, std::string& strError);
 
+    PARAMETER_EXPORT
     ISelectionCriterionTypeInterface* createSelectionCriterionType(bool bIsInclusive);
+    PARAMETER_EXPORT
     ISelectionCriterionInterface* createSelectionCriterion(const std::string& strName,
             const ISelectionCriterionTypeInterface* pSelectionCriterionType);
+    PARAMETER_EXPORT
     ISelectionCriterionInterface* getSelectionCriterion(const std::string& strName);
 
     /** Is the remote interface forcefully disabled ?
      */
+    PARAMETER_EXPORT
     bool getForceNoRemoteInterface() const;
 
     /**
@@ -98,8 +107,10 @@ public:
      *
      * @param[in] bForceNoRemoteInterface disable the remote interface if true.
      */
+    PARAMETER_EXPORT
     void setForceNoRemoteInterface(bool bForceNoRemoteInterface);
 
+    PARAMETER_EXPORT
     void applyConfigurations();
 
     /** Should start fail in case of missing subsystems.
@@ -107,12 +118,14 @@ public:
       * @param[in] bFail: If set to true,  parameterMgr start will fail on missing subsystems.
       *                   If set to false, missing subsystems will fallback on virtual subsystem.
       */
+    PARAMETER_EXPORT
     void setFailureOnMissingSubsystem(bool bFail);
 
     /** Would start fail in case of missing subsystems.
       *
       * @return true if the subsystem will fail on missing subsystem, false otherwise.
       */
+    PARAMETER_EXPORT
     bool getFailureOnMissingSubsystem() const;
 
     /** Should start fail in failed settings load.
@@ -120,23 +133,27 @@ public:
       * @param[in] bFail: If set to true, parameterMgr start will fail on failed settings load.
       *                   If set to false, failed settings load will be ignored.
       */
+    PARAMETER_EXPORT
     void setFailureOnFailedSettingsLoad(bool bFail);
     /** Would start fail in case of failed settings load.
       *
       * @return failure on failed settings load policy state.
       */
+    PARAMETER_EXPORT
     bool getFailureOnFailedSettingsLoad() const;
 
     /** Get the XML Schemas URI
      *
      * @returns the XML Schemas URI
      */
+    PARAMETER_EXPORT
     const std::string& getSchemaUri() const;
 
     /** Override the XML Schemas URI
      *
      * @param[in] schemaUri the XML Schemas URI
      */
+    PARAMETER_EXPORT
     void setSchemaUri(const std::string& schemaUri);
 
     /** Should .xml files be validated on start ?
@@ -149,32 +166,45 @@ public:
      *
      * @return false if unable to set, true otherwise.
      */
+    PARAMETER_EXPORT
     void setValidateSchemasOnStart(bool bValidate);
 
     /** Would .xml files be validated on start?
      *
      * @return areSchemasValidated
      */
+    PARAMETER_EXPORT
     bool getValidateSchemasOnStart() const;
     //////////// Tuning /////////////
     // Tuning mode
+    PARAMETER_EXPORT
     bool setTuningMode(bool bOn, std::string& strError);
+    PARAMETER_EXPORT
     bool isTuningModeOn() const;
 
     // Current value space for user set/get value interpretation
+    PARAMETER_EXPORT
     void setValueSpace(bool bIsRaw);
+    PARAMETER_EXPORT
     bool isValueSpaceRaw() const;
 
     // Current Output Raw Format for user get value interpretation
+    PARAMETER_EXPORT
     void setOutputRawFormat(bool bIsHex);
+    PARAMETER_EXPORT
     bool isOutputRawFormatHex() const;
     // Automatic hardware synchronization control (during tuning session)
+    PARAMETER_EXPORT
     bool setAutoSync(bool bAutoSyncOn, std::string& strError);
+    PARAMETER_EXPORT
     bool isAutoSyncOn() const;
+    PARAMETER_EXPORT
     bool sync(std::string& strError);
 
     // User set/get parameters
+    PARAMETER_EXPORT
     bool accessParameterValue(const std::string& strPath, std::string& strValue, bool bSet, std::string& strError);
+    PARAMETER_EXPORT
     bool accessConfigurationValue(const std::string &strDomain, const std::string &strConfiguration, const std::string& strPath, std::string& strValue, bool bSet, std::string& strError);
 
     /**
@@ -185,17 +215,27 @@ public:
      *
      * @return true if a mapping was found for this element
      */
+    PARAMETER_EXPORT
     bool getParameterMapping(const std::string& strPath, std::string& strValue) const;
     ////////// Configuration/Domains handling //////////////
     // Creation/Deletion
+    PARAMETER_EXPORT
     bool createDomain(const std::string& strName, std::string& strError);
+    PARAMETER_EXPORT
     bool deleteDomain(const std::string& strName, std::string& strError);
+    PARAMETER_EXPORT
     bool renameDomain(const std::string& strName, const std::string& strNewName, std::string& strError);
+    PARAMETER_EXPORT
     bool deleteAllDomains(std::string& strError);
+    PARAMETER_EXPORT
     bool setSequenceAwareness(const std::string& strName, bool bSequenceAware, std::string& strResult);
+    PARAMETER_EXPORT
     bool getSequenceAwareness(const std::string& strName, bool& bSequenceAware, std::string& strResult);
+    PARAMETER_EXPORT
     bool createConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
+    PARAMETER_EXPORT
     bool deleteConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
+    PARAMETER_EXPORT
     bool renameConfiguration(const std::string& strDomain, const std::string& strConfiguration, const std::string& strNewConfiguration, std::string& strError);
 
     /** Restore a configuration
@@ -205,22 +245,31 @@ public:
      * @param[out] errors, errors encountered during restoration
      * @return true if success false otherwise
      */
+    PARAMETER_EXPORT
     bool restoreConfiguration(const std::string& strDomain,
                               const std::string& strConfiguration,
                               Results& errors);
 
+    PARAMETER_EXPORT
     bool saveConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
 
     // Configurable element - domain association
+    PARAMETER_EXPORT
     bool addConfigurableElementToDomain(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
+    PARAMETER_EXPORT
     bool removeConfigurableElementFromDomain(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
+    PARAMETER_EXPORT
     bool split(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
+    PARAMETER_EXPORT
     bool setElementSequence(const std::string& strDomain, const std::string& strConfiguration, const std::vector<std::string>& astrNewElementSequence, std::string& strError);
 
+    PARAMETER_EXPORT
     bool setApplicationRule(const std::string& strDomain, const std::string& strConfiguration,
                             const std::string& strApplicationRule, std::string& strError);
+    PARAMETER_EXPORT
     bool getApplicationRule(const std::string& strDomain, const std::string& strConfiguration,
                             std::string& strResult);
+    PARAMETER_EXPORT
     bool clearApplicationRule(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
 
     /**
@@ -235,6 +284,7 @@ public:
       *
       * @return false if any error occures
       */
+    PARAMETER_EXPORT
     bool importDomainsXml(const std::string& strXmlSource, bool bWithSettings, bool bFromFile,
                           std::string& strError);
     /**
@@ -251,6 +301,7 @@ public:
       *
       * @return false if any error occurs
       */
+    PARAMETER_EXPORT
     bool importSingleDomainXml(const std::string& xmlSource, bool overwrite, bool withSettings,
                                bool toFile, std::string& errorMsg);
     /**
@@ -266,6 +317,7 @@ public:
       *
       * @return false if any error occurs
       */
+    PARAMETER_EXPORT
     bool importSingleDomainXml(const std::string& strXmlSource, bool bOverwrite,
                                std::string& strError);
 
@@ -282,6 +334,7 @@ public:
       *
       * @return false if any error occures, true otherwise.
       */
+    PARAMETER_EXPORT
     bool exportDomainsXml(std::string& strXmlDest, bool bWithSettings, bool bToFile,
                           std::string& strError) const;
 
@@ -298,6 +351,7 @@ public:
       *
       * @return false if any error occurs, true otherwise.
       */
+    PARAMETER_EXPORT
     bool exportSingleDomainXml(std::string& strXmlDest, const std::string& strDomainName, bool bWithSettings,
                                bool bToFile, std::string& strError) const;
 

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -38,7 +38,7 @@
 
 class CParameterMgr;
 
-class PARAMETER_EXPORT CParameterMgrPlatformConnector
+class CParameterMgrPlatformConnector
 {
     friend class CParameterMgrLogger<CParameterMgrPlatformConnector>;
 public:
@@ -46,43 +46,56 @@ public:
     class ILogger
     {
     public:
+        PARAMETER_EXPORT
         virtual void info(const std::string& strLog) = 0;
+        PARAMETER_EXPORT
         virtual void warning(const std::string& strLog) = 0;
     protected:
         virtual ~ILogger() {}
     };
 
     // Construction
+    PARAMETER_EXPORT
     CParameterMgrPlatformConnector(const std::string& strConfigurationFilePath);
+    PARAMETER_EXPORT
     ~CParameterMgrPlatformConnector(); // Not virtual since not supposed to be derived!
 
     // Selection Criteria interface. Beware returned objects are lent, clients shall not delete them!
     // Should be called before start
+    PARAMETER_EXPORT
     ISelectionCriterionTypeInterface* createSelectionCriterionType(bool bIsInclusive = false);
+    PARAMETER_EXPORT
     ISelectionCriterionInterface* createSelectionCriterion(const std::string& strName, const ISelectionCriterionTypeInterface* pSelectionCriterionType);
     // Selection criterion retrieval
+    PARAMETER_EXPORT
     ISelectionCriterionInterface* getSelectionCriterion(const std::string& strName) const;
 
     // Logging
     // Should be called before start
+    PARAMETER_EXPORT
     void setLogger(ILogger* pLogger);
 
     // Start
+    PARAMETER_EXPORT
     bool start(std::string& strError);
 
     // Started state
+    PARAMETER_EXPORT
     bool isStarted() const;
 
     // Configuration application
+    PARAMETER_EXPORT
     void applyConfigurations();
 
     // Dynamic parameter handling
     // Returned objects are owned by clients
     // Must be cassed after successfull start
+    PARAMETER_EXPORT
     CParameterHandle* createParameterHandle(const std::string& strPath, std::string& strError) const;
 
     /** Is the remote interface forcefully disabled ?
      */
+    PARAMETER_EXPORT
     bool getForceNoRemoteInterface() const;
 
     /**
@@ -92,6 +105,7 @@ public:
      *
      * @param[in] bForceNoRemoteInterface disable the remote interface if true.
      */
+    PARAMETER_EXPORT
     void setForceNoRemoteInterface(bool bForceNoRemoteInterface);
 
     /** Should start fail in case of missing subsystems.
@@ -105,12 +119,14 @@ public:
       *
       * @return false if unable to set, true otherwise.
       */
+    PARAMETER_EXPORT
     bool setFailureOnMissingSubsystem(bool bFail, std::string& strError);
 
     /** Would start fail in case of missing subsystems.
       *
       * @return if the subsystem load will fail on missing subsystem.
       */
+    PARAMETER_EXPORT
     bool getFailureOnMissingSubsystem() const;
 
     /** Should start fail in failed settings load.
@@ -123,23 +139,27 @@ public:
       *
       * @return false if unable to set, true otherwise.
       */
+    PARAMETER_EXPORT
     bool setFailureOnFailedSettingsLoad(bool bFail, std::string& strError);
     /** Would start fail in case of failed settings load.
       *
       * @return failure on failed settings load policy state.
       */
+    PARAMETER_EXPORT
     bool getFailureOnFailedSettingsLoad() const;
 
     /** Get the XML Schemas URI
      *
      * @returns the XML Schemas URI
      */
+    PARAMETER_EXPORT
     const std::string& getSchemaUri() const;
 
     /** Override the XML Schemas URI
      *
      * @param[in] schemaUri the XML Schemas URI
      */
+    PARAMETER_EXPORT
     void setSchemaUri(const std::string& schemaUri);
 
     /** Should .xml files be validated on start ?
@@ -151,12 +171,14 @@ public:
      *
      * @return false if unable to set, true otherwise.
      */
+    PARAMETER_EXPORT
     bool setValidateSchemasOnStart(bool bValidate, std::string &strError);
 
     /** Would .xml files be validated on start?
      *
      * @return areSchemasValidated
      */
+    PARAMETER_EXPORT
     bool getValidateSchemasOnStart() const;
 
 private:


### PR DESCRIPTION
"private virtual" methods need to be exported because the plugins will need to
access them at runtime.

We can't do this selective export of classes that are to be derived by plugins
(i.e. Subsystem, SubsystemObject and FormattedSubsystemObject):
For some reason I don't understand, the plugins require the "typeinfo" symbol
of these classes at runtime. Disassembling the code show that this symbol isn't
even used in the generated code but merely required by the dynamic linker...

Strangely, this increases the size of the ".text" section of the generated
library (not much but this is not what I expected nevertheless).....
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/269%23issuecomment-161642834%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/269%23issuecomment-161642910%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/269%23issuecomment-173865578%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/269%23issuecomment-161642834%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20do%20not%20like%20this%20huge%20change%20for%20a%20minor%20gain%3A%20remove%20a%20warning.%20Should%20the%20warning%20not%20be%20disable%20until%20we%20have%20a%20true%20plugin%20api%20instead%20%3F%22%2C%20%22created_at%22%3A%20%222015-12-03T13%3A42%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dawagner%20If%20you%20agree%20consider%20closing%20the%20PR.%22%2C%20%22created_at%22%3A%20%222015-12-03T13%3A42%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dawagner%20Do%20you%20intend%20on%20finishing%20this%2C%20or%20should%20it%20be%20closed%20%3F%22%2C%20%22created_at%22%3A%20%222016-01-22T09%3A58%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/269#issuecomment-161642834'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I do not like this huge change for a minor gain: remove a warning. Should the warning not be disable until we have a true plugin api instead ?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> @dawagner If you agree consider closing the PR.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> @dawagner Do you intend on finishing this, or should it be closed ?


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/269?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/269?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/269'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>