### PR TITLE
Wrong XML "Name" attribute in enum value pairs

### DIFF
--- a/parameter/EnumValuePair.cpp
+++ b/parameter/EnumValuePair.cpp
@@ -85,5 +85,7 @@ void CEnumValuePair::toXml(CXmlElement& xmlElement, CXmlSerializingContext& seri
     // Numerical
     xmlElement.setAttribute("Numerical", getNumericalAsString());
 
-    base::toXml(xmlElement, serializingContext);
+    // Ask for children processing only so as to avoid setting the Name attribute
+    // which does not exist for this element
+    base::childrenToXml(xmlElement, serializingContext);
 }


### PR DESCRIPTION
When exporting an element's structure (via the C++ API or via the tuning
interface), a spurious "Name" attribute appears for EnumPair nodes, while
only "Literal" and "Numerical" attributes should be present. This is because
the XML import / export feature assummes the existence of a Name attribute
for all XML nodes. The Name default processing can however be skipped from the
toXml() methods by calling the base class' childrenToXml() method instead
of the toXml() one.

Signed-off-by: Patrick Benavoli <patrick.benavoli@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/279%23issuecomment-147700503%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/279%23issuecomment-147742896%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/279%23issuecomment-147751840%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/279%23issuecomment-147700503%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20%40tcahuzax%20please%20review%22%2C%20%22created_at%22%3A%20%222015-10-13T12%3A27%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20but%20this%20commit%20seems%20like%20a%20workarourd...%22%2C%20%22created_at%22%3A%20%222015-10-13T15%3A03%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-13T15%3A31%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/279#issuecomment-147700503'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard @tcahuzax please review
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: but this commit seems like a workarourd...


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/279?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/279?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/279'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>