### PR TITLE
Allows exportDomainsWithSettingsXML command with no file path

### DIFF
--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -1502,8 +1502,11 @@ CParameterMgr::CCommandHandler::CommandStatus
         destinationUri = remoteCommand.getArgument(0);
     }
 
-    return exportDomainsXml(destinationUri, true, true, strResult) ?
-            CCommandHandler::EDone : CCommandHandler::EFailed;
+    if (not exportDomainsXml(destinationUri, true, true, strResult)) {
+            return CCommandHandler::EFailed;
+    }
+    strResult = "Exported domains with settings to \"" + destinationUri + '"';
+    return CCommandHandler::ESucceeded;
 }
 
 CParameterMgr::CCommandHandler::CommandStatus

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -2331,15 +2331,22 @@ bool CParameterMgr::wrapLegacyXmlExportToFile(string& xmlDest,
                                               const CElement& element,
                                               CXmlDomainExportContext &context) const
 {
-    std::ofstream output(xmlDest.c_str());
+    try {
+        std::ofstream output;
+        // Force stream to throw instead of using fail/bad bit
+        // in order to retreive an error message.
+        output.exceptions(~std::ifstream::goodbit);
 
-    if (output.fail()) {
-        context.setError("Failed to open \"" + xmlDest + "\" for writing.");
+        output.open(xmlDest.c_str());
+        bool status = serializeElement(output, context, element);
+        output.close(); // Explicit close to detect errors
+
+        return status;
+
+    } catch (std::ofstream::failure& e) {
+        context.setError("Failed to open \"" + xmlDest + "\" for writing: " + e.what());
         return false;
     }
-
-    return serializeElement(output, context, element);
-
 }
 
 bool CParameterMgr::wrapLegacyXmlExportToString(string& xmlDest,

--- a/test/functional-tests-legacy/PfwTestCase/Functions/tFunction_Export_Import_Domains.py
+++ b/test/functional-tests-legacy/PfwTestCase/Functions/tFunction_Export_Import_Domains.py
@@ -70,6 +70,9 @@ class TestCases(PfwTestCase):
         self.temp_config="f_Config_Backup"
         self.temp_domain="f_Domains_Backup"
         self.temp_xml=pfw_test_tools+"/f_temp.xml"
+        self.test_domain_path = os.path.abspath(
+                os.path.join(os.path.dirname(os.environ["PFW_TEST_CONFIGURATION"]),
+                             "Settings/Test/TestConfigurableDomains.xml"))
 
         self.nb_domains_in_reference_xml=3
         self.nb_conf_per_domains_in_reference_xml=[2,2,2]
@@ -259,9 +262,14 @@ class TestCases(PfwTestCase):
 
         #Export in a temp XML file
         log.I("Export Domains with initial settings in %s"%(self.temp_xml))
-        out, err = self.pfw.sendCmd("exportDomainsWithSettingsXML",self.temp_xml, "")
-        assert err == None, log.E("Command [exportDomainsWithSettingsXML %s] : %s"%(self.temp_xml,err))
-        assert out == "Done", log.F("When using function exportDomainsWithSettingsXML %s]"%(self.temp_xml))
+        self.pfw.sendCmd("exportDomainsWithSettingsXML", "/path/that/does/not/exist", expectSuccess=False)
+
+        def testSuccessExportDomainsWithSettingsXml(path, *args):
+            out, err = self.pfw.sendCmd("exportDomainsWithSettingsXML", *args)
+            self.assertEqual(out, "Exported domains with settings to \"%s\"" % path)
+
+        testSuccessExportDomainsWithSettingsXml(self.temp_xml, self.temp_xml)
+        testSuccessExportDomainsWithSettingsXml(self.test_domain_path)
 
         #Change the value of checked parameters
         self.pfw.sendCmd("setTuningMode", "on","")


### PR DESCRIPTION
The exportDomainsWIthSettingsXML command requested a parameter specifing the destination file path.

Remove this limitation. If the destination file is not specified, the command will export to the file the domains were initially loaded from (`<ConfigurableDomainsFileLocation>`).

Also add a test for the new code.

<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/284?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/284'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>