### PR TITLE
[review] Wconversion enabler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (WIN32)
     # do that. A separated plugin interface would fix that.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /FIiso646.h -wd4127 -wd4251")
 else ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra -Wconversion -Wno-sign-conversion")
 endif ()
 
 # Hide symbols by default, then exposed symbols are the same in linux and windows

--- a/bindings/c/ParameterFramework.cpp
+++ b/bindings/c/ParameterFramework.cpp
@@ -195,7 +195,7 @@ bool PfwHandler::createCriteria(const PfwCriterion criteriaArray[], size_t crite
                 }
                 value = 1 << valueIndex;
             } else {
-                value = valueIndex;
+                value = static_cast<int>(valueIndex);
             }
             const char * valueName = criterion.values[valueIndex];
             string error;

--- a/parameter/BitParameterType.cpp
+++ b/parameter/BitParameterType.cpp
@@ -182,9 +182,9 @@ bool CBitParameterType::toBlackboard(uint64_t uiUserValue, uint64_t& uiValue, CP
     return true;
 }
 
-void CBitParameterType::fromBlackboard(uint32_t& uiUserValue, uint64_t uiValue, CParameterAccessContext& /*ctx*/) const
+void CBitParameterType::fromBlackboard(uint32_t& userValue, uint64_t value, CParameterAccessContext& /*ctx*/) const
 {
-    uiUserValue = (uiValue & getMask()) >> _bitPos;
+    userValue = static_cast<uint32_t>((value & getMask()) >> _bitPos);
 }
 
 // Access from area configuration

--- a/parameter/EnumParameterType.cpp
+++ b/parameter/EnumParameterType.cpp
@@ -124,51 +124,51 @@ int32_t CEnumParameterType::getMax() const {
     return getMaxValue<int32_t>();
 }
 
-bool CEnumParameterType::fromBlackboard(string& strValue, const uint32_t& uiValue, CParameterAccessContext& /*ctx*/) const
+bool CEnumParameterType::fromBlackboard(string& userValue, const uint32_t& value, CParameterAccessContext& /*ctx*/) const
 {
     // Convert the raw value from the blackboard
-    int32_t iValue = uiValue;
-    signExtend(iValue);
+    int32_t signedValue = static_cast<int32_t>(value);
+    signExtend(signedValue);
 
     // Convert from numerical space to literal space
-    return getLiteral(iValue, strValue);
+    return getLiteral(signedValue, userValue);
 }
 
 // Value access
-bool CEnumParameterType::toBlackboard(int32_t iUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CEnumParameterType::toBlackboard(int32_t userValue, uint32_t& value, CParameterAccessContext& parameterAccessContext) const
 {
-    if (!checkValueAgainstSpace(iUserValue)) {
+    if (!checkValueAgainstSpace(userValue)) {
 
-        parameterAccessContext.setError(std::to_string(iUserValue) +
+        parameterAccessContext.setError(std::to_string(userValue) +
                 " is not part of numerical space.");
 
         return false;
     }
 
-    if (iUserValue < getMin() or iUserValue > getMax()) {
+    if (userValue < getMin() or userValue > getMax()) {
 
         // FIXME: values provided as hexa (either on command line or in a config
         // file will appear in decimal base instead of hexa base...
         parameterAccessContext.setError(
-                "Value " + std::to_string(iUserValue) + " standing out of admitted range [" +
+                "Value " + std::to_string(userValue) + " standing out of admitted range [" +
                 std::to_string(getMin()) + ", " + std::to_string(getMax()) + "] for " + getKind()
                 );
         return false;
     }
 
-    uiValue = iUserValue;
+    value = static_cast<uint32_t>(userValue);
 
     return true;
 }
 
-bool CEnumParameterType::fromBlackboard(int32_t& iUserValue, uint32_t uiValue, CParameterAccessContext& /*ctx*/) const
+bool CEnumParameterType::fromBlackboard(int32_t& userValue, uint32_t value, CParameterAccessContext& /*ctx*/) const
 {
-    int32_t iValue = uiValue;
+    int32_t signedValue = static_cast<int32_t>(value);
 
     // Sign extend
-    signExtend(iValue);
+    signExtend(signedValue);
 
-    iUserValue = iValue;
+    userValue = signedValue;
 
     return true;
 }

--- a/parameter/FixedPointParameterType.cpp
+++ b/parameter/FixedPointParameterType.cpp
@@ -140,9 +140,9 @@ bool CFixedPointParameterType::toBlackboard(const string& strValue, uint32_t& ui
 
 void CFixedPointParameterType::setOutOfRangeError(const string& strValue, CParameterAccessContext& parameterAccessContext) const
 {
-    std::ostringstream strStream;
+    std::ostringstream stream;
 
-    strStream << "Value " << strValue << " standing out of admitted ";
+    stream << "Value " << strValue << " standing out of admitted ";
 
     if (!parameterAccessContext.valueSpaceIsRaw()) {
 
@@ -151,73 +151,75 @@ void CFixedPointParameterType::setOutOfRangeError(const string& strValue, CParam
         double dMax = 0;
         getRange(dMin, dMax);
 
-        strStream << std::fixed << std::setprecision(_uiFractional)
-                  << "real range [" << dMin << ", " << dMax << "]";
+        stream << std::fixed << std::setprecision(_uiFractional) <<
+               "real range [" << dMin << ", " << dMax << "]";
     } else {
 
         // Min/Max computation
         int32_t iMax = getMaxValue<uint32_t>();
         int32_t iMin = -iMax - 1;
 
-        strStream << "raw range [";
+        stream << "raw range [";
 
         if (utility::isHexadecimal(strValue)) {
 
+            stream << std::hex << std::uppercase <<
+                   std::setw(static_cast<int>(getSize()) * 2) << std::setfill('0');
+
             // Format Min
-            strStream << "0x" << std::hex << std::uppercase <<
-                std::setw(getSize() * 2) << std::setfill('0') << makeEncodable(iMin);
+            stream << "0x" << makeEncodable(iMin);
             // Format Max
-            strStream << ", 0x" << std::hex << std::uppercase <<
-                std::setw(getSize() * 2) << std::setfill('0') << makeEncodable(iMax);
+            stream << ", 0x" << makeEncodable(iMax);
 
         } else {
 
-            strStream << iMin << ", " << iMax;
+            stream << iMin << ", " << iMax;
         }
 
-        strStream << "]";
+        stream << "]";
     }
-    strStream << " for " << getKind();
+    stream << " for " << getKind();
 
-    parameterAccessContext.setError(strStream.str());
+    parameterAccessContext.setError(stream.str());
 }
 
-bool CFixedPointParameterType::fromBlackboard(string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CFixedPointParameterType::fromBlackboard(string& strValue, const uint32_t& value, CParameterAccessContext& parameterAccessContext) const
 {
-    int32_t iData = uiValue;
-
     // Check encodability
-    assert(isEncodable((uint32_t)iData, false));
+    assert(isEncodable(value, false));
 
     // Format
-    std::ostringstream strStream;
+    std::ostringstream stream;
 
     // Raw formatting?
     if (parameterAccessContext.valueSpaceIsRaw()) {
-
         // Hexa formatting?
         if (parameterAccessContext.outputRawFormatIsHex()) {
+            uint32_t data = static_cast<uint32_t>(value);
 
-            strStream << "0x" << std::hex << std::uppercase << std::setw(getSize()*2) << std::setfill('0') << (uint32_t)iData;
+            stream << "0x" << std::hex << std::uppercase <<
+                   std::setw(static_cast<int>(getSize() * 2)) <<
+                   std::setfill('0') << data;
         } else {
+            int32_t data = value;
 
             // Sign extend
-            signExtend(iData);
+            signExtend(data);
 
-            strStream << iData;
+            stream << data;
         }
     } else {
+        int32_t data = value;
 
         // Sign extend
-        signExtend(iData);
+        signExtend(data);
 
         // Conversion
-        double dData = binaryQnmToDouble(iData);
-
-        strStream << std::fixed << std::setprecision(_uiFractional) << dData;
+        stream << std::fixed << std::setprecision(_uiFractional) <<
+               binaryQnmToDouble(data);
     }
 
-    strValue = strStream.str();
+    strValue = stream.str();
 
     return true;
 }
@@ -269,8 +271,8 @@ size_t CFixedPointParameterType::getUtilSizeInBits() const
 // Compute the range for the type (minimum and maximum values)
 void CFixedPointParameterType::getRange(double& dMin, double& dMax) const
 {
-    dMax = (double)((1UL << (_uiIntegral + _uiFractional)) - 1) / (1UL << _uiFractional);
-    dMin = -(double)(1UL << (_uiIntegral + _uiFractional)) / (1UL << _uiFractional);
+    dMax = ((1U << (_uiIntegral + _uiFractional)) - 1) / double(1U << _uiFractional);
+    dMin = -((1U << (_uiIntegral + _uiFractional)) / double(1U << _uiFractional));
 }
 
 bool CFixedPointParameterType::convertFromHexadecimal(const string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
@@ -331,7 +333,7 @@ bool CFixedPointParameterType::checkValueAgainstRange(double dValue) const
 int32_t CFixedPointParameterType::doubleToBinaryQnm(double dValue) const
 {
     // For Qn.m number, multiply by 2^n and round to the nearest integer
-    int32_t iData = static_cast<int32_t>(round(dValue * (1UL << _uiFractional)));
+    int32_t iData = static_cast<int32_t>(round(dValue * double(1UL << _uiFractional)));
     // Left justify
     // For a Qn.m number, shift 32 - (n + m + 1) bits to the left (the rest of
     // the bits aren't used)
@@ -345,7 +347,7 @@ double CFixedPointParameterType::binaryQnmToDouble(int32_t iValue) const
 {
     // Unjustify
     iValue >>= getSize() * 8 - getUtilSizeInBits();
-    return static_cast<double>(iValue) / (1UL << _uiFractional);
+    return static_cast<double>(iValue) / double(1UL << _uiFractional);
 }
 
 // From IXmlSource

--- a/parameter/FloatingPointParameterType.cpp
+++ b/parameter/FloatingPointParameterType.cpp
@@ -201,7 +201,7 @@ void CFloatingPointParameterType::setOutOfRangeError(
         if (utility::isHexadecimal(strValue)) {
 
             ostrStream << std::showbase << std::hex
-                       << std::setw(getSize() * 2) << std::setfill('0');
+                       << std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0');
         }
 
         ostrStream << "raw range [" << uiMin << ", " << uiMax << "]";
@@ -223,7 +223,7 @@ bool CFloatingPointParameterType::fromBlackboard(
         if (parameterAccessContext.outputRawFormatIsHex()) {
 
             ostrStream << std::showbase << std::hex
-                       << std::setw(getSize() * 2) << std::setfill('0');
+                       << std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0');
         }
 
         ostrStream << uiValue;

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -176,36 +176,37 @@ bool CIntegerParameterType::toBlackboard(const string& strValue, uint32_t& uiVal
     return true;
 }
 
-bool CIntegerParameterType::fromBlackboard(string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CIntegerParameterType::fromBlackboard(string& strValue, const uint32_t& value, CParameterAccessContext& parameterAccessContext) const
 {
     // Check unsigned value is encodable
-    assert(isEncodable(uiValue, false));
+    assert(isEncodable(value, false));
 
     // Format
-    ostringstream strStream;
+    ostringstream stream;
 
     // Take care of format
     if (parameterAccessContext.valueSpaceIsRaw() && parameterAccessContext.outputRawFormatIsHex()) {
 
         // Hexa display with unecessary bits cleared out
-        strStream << "0x" << std::hex << std::uppercase << std::setw(getSize()*2) << std::setfill('0') << uiValue;
+        stream << "0x" << std::hex << std::uppercase <<
+               std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0') << value;
     } else {
 
         if (_bSigned) {
 
-            int32_t iValue = uiValue;
+            int32_t iValue = value;
 
             // Sign extend
             signExtend(iValue);
 
-            strStream << iValue;
+            stream << iValue;
         } else {
 
-            strStream << uiValue;
+            stream << value;
         }
     }
 
-    strValue = strStream.str();
+    strValue = stream.str();
 
     return true;
 }
@@ -385,25 +386,27 @@ template <typename type> bool CIntegerParameterType::checkValueAgainstRange(cons
 {
     if (value < minValue || value > maxValue) {
 
-        ostringstream strStream;
+        ostringstream stream;
 
-        strStream << "Value " << strValue << " standing out of admitted range [";
+        stream << "Value " << strValue << " standing out of admitted range [";
 
         if (bHexaValue) {
 
+            stream << "0x" << std::hex << std::uppercase <<
+                   std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0');
             // Format Min
-            strStream << "0x" << std::hex << std::uppercase << std::setw(getSize()*2) << std::setfill('0') << makeEncodable(minValue);
+            stream << minValue;
             // Format Max
-            strStream << ", 0x" << std::hex << std::uppercase << std::setw(getSize()*2) << std::setfill('0') << makeEncodable(maxValue);
+            stream << maxValue;
 
         } else {
 
-            strStream << minValue << ", " <<  maxValue;
+            stream << minValue << ", " <<  maxValue;
         }
 
-        strStream << "] for " << getKind();
+        stream << "] for " << getKind();
 
-        parameterAccessContext.setError(strStream.str());
+        parameterAccessContext.setError(stream.str());
 
         return false;
     }

--- a/parameter/LogarithmicParameterAdaptation.cpp
+++ b/parameter/LogarithmicParameterAdaptation.cpp
@@ -31,6 +31,7 @@
 #include "LogarithmicParameterAdaptation.h"
 #include <cmath>
 #include <limits>
+#include <algorithm>
 
 #define base CLinearParameterAdaptation
 
@@ -78,10 +79,10 @@ bool CLogarithmicParameterAdaptation::fromXml(const CXmlElement& xmlElement,
 }
 
 
-int64_t CLogarithmicParameterAdaptation::fromUserValue(double dValue) const
+int64_t CLogarithmicParameterAdaptation::fromUserValue(double value) const
 {
-    return fmax(round(base::fromUserValue(log(dValue) / log(_dLogarithmBase))),
-                        _dFloorValue);
+    return std::max(base::fromUserValue(log(value) / log(_dLogarithmBase)),
+                        static_cast<int64_t>(_dFloorValue));
 }
 
 double CLogarithmicParameterAdaptation::toUserValue(int64_t iValue) const

--- a/parameter/SubsystemObject.cpp
+++ b/parameter/SubsystemObject.cpp
@@ -34,6 +34,7 @@
 #include "ParameterAccessContext.h"
 #include "MappingContext.h"
 #include "ParameterType.h"
+#include "convert.hpp"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/parameter/SubsystemObjectFactory.h
+++ b/parameter/SubsystemObjectFactory.h
@@ -31,12 +31,13 @@
 
 #include "SubsystemObjectCreator.h"
 #include <string>
+#include <limits>
 
 template <class SubsystemObjectType>
 class TSubsystemObjectFactory : public CSubsystemObjectCreator
 {
 public:
-    TSubsystemObjectFactory(const std::string& strMappingKey, uint32_t uiAncestorIdMask, size_t maxConfigurableElementSize = -1) :
+    TSubsystemObjectFactory(const std::string& strMappingKey, uint32_t uiAncestorIdMask, size_t maxConfigurableElementSize = std::numeric_limits<size_t>::max()) :
         CSubsystemObjectCreator(strMappingKey, uiAncestorIdMask, maxConfigurableElementSize) {}
 
     // Object creation

--- a/remote-processor/Message.cpp
+++ b/remote-processor/Message.cpp
@@ -86,12 +86,12 @@ void CMessage::readData(void* pvData, size_t size)
 void CMessage::writeString(const string& strData)
 {
     // Size
-    uint32_t uiSize = strData.length();
+    uint32_t size = static_cast<uint32_t>(strData.length());
 
-    writeData(&uiSize, sizeof(uiSize));
+    writeData(&size, sizeof(size));
 
     // Content
-    writeData(strData.c_str(), uiSize);
+    writeData(strData.c_str(), size);
 }
 
 void CMessage::readString(string& strData)

--- a/skeleton-subsystem/CMakeLists.txt
+++ b/skeleton-subsystem/CMakeLists.txt
@@ -37,7 +37,7 @@ if (WIN32)
     # but doing so breaks compilation of windows headers...
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /FIiso646.h")
 else ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra -Wconversion")
 endif ()
 
 # Hide symbols by default, then exposed symbols are the same in linux and windows

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -215,16 +215,9 @@ CTestPlatform::CommandReturn CTestPlatform::setCriterionState(
 
     bool bSuccess;
 
-    const char* pcState = remoteCommand.getArgument(1).c_str();
+    uint32_t state;
 
-    char* pcStrEnd;
-
-    // Reset errno to check if it is updated during the conversion (strtol/strtoul)
-    errno = 0;
-
-    uint32_t state = strtoul(pcState, &pcStrEnd, 0);
-
-    if (!errno && (*pcStrEnd == '\0')) {
+    if (convertTo(remoteCommand.getArgument(1), state)) {
         // Sucessfull conversion, set criterion state by numerical state
         bSuccess = setCriterionState(remoteCommand.getArgument(0), state, strResult);
 
@@ -264,7 +257,8 @@ bool CTestPlatform::createExclusiveSelectionCriterionFromStateList(
 
         const std::string& strValue = remoteCommand.getArgument(state + 1);
 
-        if (!pCriterionType->addValuePair(state, strValue, strResult)) {
+        // FIXME state type vs addValuePair params
+        if (!pCriterionType->addValuePair(int(state), strValue, strResult)) {
 
             strResult = "Unable to add value: " + strValue + ": " + strResult;
 
@@ -322,8 +316,9 @@ bool CTestPlatform::createExclusiveSelectionCriterion(const string& strName,
         ostrValue << "State_";
         ostrValue << state;
 
+        // FIXME state type vs addValuePair params
         if (!pCriterionType->addValuePair(
-                    state, ostrValue.str(), strResult)) {
+                    int(state), ostrValue.str(), strResult)) {
 
             strResult = "Unable to add value: "
                 + ostrValue.str() + ": " + strResult;

--- a/test/test-subsystem/TESTSubsystemBinary.cpp
+++ b/test/test-subsystem/TESTSubsystemBinary.cpp
@@ -50,7 +50,7 @@ std::string CTESTSubsystemBinary::toString(const void* pvValue, size_t size) con
 
     assert(size <= sizeof(uiValue));
 
-    memcpy((void*)&uiValue, pvValue, size);
+    memcpy(&uiValue, pvValue, size);
 
     strStream << "0x" << std::hex << uiValue;
 
@@ -63,5 +63,5 @@ void CTESTSubsystemBinary::fromString(const std::string& strValue, void* pvValue
 
     assert(size <= sizeof(uiValue));
 
-    memcpy(pvValue, (const void*)&uiValue, size);
+    memcpy(pvValue, &uiValue, size);
 }

--- a/test/test-subsystem/TESTSubsystemBinary.cpp
+++ b/test/test-subsystem/TESTSubsystemBinary.cpp
@@ -27,10 +27,14 @@
 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+#include <convert.hpp>
 #include <string.h>
+#include <string>
 #include <sstream>
 #include <stdlib.h>
 #include <assert.h>
+#include <algorithm>
+#include <Iterator.hpp>
 #include "TESTSubsystemBinary.h"
 
 #define base CTESTSubsystemObject
@@ -59,9 +63,15 @@ std::string CTESTSubsystemBinary::toString(const void* pvValue, size_t size) con
 
 void CTESTSubsystemBinary::fromString(const std::string& strValue, void* pvValue, size_t size)
 {
-    uint32_t uiValue = strtoul(strValue.c_str(), NULL, 0);
+    uint32_t uiValue;
 
     assert(size <= sizeof(uiValue));
 
-    memcpy(pvValue, &uiValue, size);
+    if (!convertTo(strValue, uiValue)) {
+        throw std::runtime_error("Unable to convert \"" + strValue + "\" to uint32");
+    }
+
+    auto first = MAKE_ARRAY_ITERATOR(reinterpret_cast<const uint8_t *>(&uiValue), size);
+    auto destination = MAKE_ARRAY_ITERATOR(static_cast<uint8_t *>(pvValue), size);
+    std::copy_n(first, size, destination);
 }


### PR DESCRIPTION
taking over #272.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/285%23issuecomment-149236639%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42252361%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42253058%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42257573%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42263826%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42268460%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42268464%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391055%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391070%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391082%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391337%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391688%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42395782%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42401713%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42401719%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42401840%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42401842%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42401843%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42401844%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/285%23issuecomment-149304155%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23issuecomment-149236639%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20Please%20review%22%2C%20%22created_at%22%3A%20%222015-10-19T14%3A45%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20patch%20could%20be%20splited%20in%203%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20rename%20of%20fromXml%20to%20structureFromXml%5Cr%5Cn%20%20%20%20add%20a%20CParameterAccessContext%20in%20XmlParameterSerializerContext%5Cr%5Cn%20%20%20%20Add%20set%20and%20get%20ElementXML%20commands%22%2C%20%22created_at%22%3A%20%222015-10-19T18%3A23%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2058033a610f1bb5f30479a7533956f9a1cb66c246%20parameter/LogarithmicParameterAdaptation.cpp%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42257573%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%20-%20WTF%20%3F%20fromUserValue%20returns%20a%20uint64_t%20%2C%20why%20then%20casting%20it%20to%20double%20to%20round%20it%20%3F%20Seems%20that%20you%20can%20remove%20the%20double%20and%20the%20%5Cr%5Cn%20-%20fmap%20%3D%3E%20max%3Cint64_t%3E%20%3F%22%2C%20%22created_at%22%3A%20%222015-10-16T15%3A50%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-16T17%3A35%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/LogarithmicParameterAdaptation.cpp%3AL78-88%22%7D%2C%20%22Pull%2004c16d1da1ebff1c772b84bb9ec8f4fad6a0875c%20test/test-subsystem/TESTSubsystemBinary.cpp%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391337%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60std%3A%3Astring%28%60%20is%20useless.%20%60operator%2B%28const%20char%2A%2C%20std%3A%3Astring%29%60%20is%20defined.%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A13%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-19T17%3A41%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/test-subsystem/TESTSubsystemBinary.cpp%3AL61-74%22%7D%2C%20%22Pull%2004c16d1da1ebff1c772b84bb9ec8f4fad6a0875c%20test/test-subsystem/TESTSubsystemBinary.cpp%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391688%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22could%20use%20std%3A%3Acopy_n%20%26%20MAKE_ARRAY_ITERATOR%20instead%20of%20memcpy.%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A15%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-19T17%3A41%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/test-subsystem/TESTSubsystemBinary.cpp%3AL61-74%22%7D%2C%20%22Pull%2058033a610f1bb5f30479a7533956f9a1cb66c246%20test/test-subsystem/TESTSubsystemBinary.cpp%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42252361%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%20is%20dangerous%2C%20the%20PF%20is%20not%20exception%20safe.%20Where%20is%20the%20matching%20catch%20block%20%3F%22%2C%20%22created_at%22%3A%20%222015-10-16T15%3A02%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agree%20-%20but%20this%20is%20the%20test%20subsystem.%22%2C%20%22created_at%22%3A%20%222015-10-16T15%3A08%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22True%2C%20but%20you%20should%20not%20throw%20a%20%60std%3A%3Astring%60%2C%20throw%20a%20%60std%3A%3Aruntime_error%60%22%2C%20%22created_at%22%3A%20%222015-10-16T16%3A51%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-16T17%3A35%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/test-subsystem/TESTSubsystemBinary.cpp%3AL61-74%22%7D%2C%20%22Pull%2004c16d1da1ebff1c772b84bb9ec8f4fad6a0875c%20parameter/FixedPointParameterType.cpp%20120%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391055%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20use%20%60double%7B...%7D%60%20to%20highlight%20the%20fact%20that%20their%20is%20no%20precision%20loose%20%3F%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A10%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60%28double%29%60%20is%20not%20usefull%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A50%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-19T17%3A41%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/FixedPointParameterType.cpp%3AL271-279%22%7D%2C%20%22Pull%2004c16d1da1ebff1c772b84bb9ec8f4fad6a0875c%20parameter/FixedPointParameterType.cpp%20138%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391082%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22idem%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A10%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Ignore%20my%20remark%2C%20it%20does%20not%20work.%22%2C%20%22created_at%22%3A%20%222015-10-19T17%3A40%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/FixedPointParameterType.cpp%3AL347-354%22%7D%2C%20%22Pull%2058033a610f1bb5f30479a7533956f9a1cb66c246%20parameter/IntegerParameterType.cpp%2058%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42401844%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-19T17%3A41%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/IntegerParameterType.cpp%3AL386-413%22%7D%2C%20%22Pull%2004c16d1da1ebff1c772b84bb9ec8f4fad6a0875c%20parameter/FixedPointParameterType.cpp%20129%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/285%23discussion_r42391070%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22idem%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A10%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Ignore%20my%20remark%2C%20it%20does%20not%20work.%22%2C%20%22created_at%22%3A%20%222015-10-19T17%3A40%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/FixedPointParameterType.cpp%3AL333-340%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/285#issuecomment-149236639'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard Please review
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> This patch could be splited in 3:
rename of fromXml to structureFromXml
add a CParameterAccessContext in XmlParameterSerializerContext
Add set and get ElementXML commands
- [x] <a href='#crh-comment-Pull 58033a610f1bb5f30479a7533956f9a1cb66c246 test/test-subsystem/TESTSubsystemBinary.cpp 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/285#discussion_r42252361'>File: test/test-subsystem/TESTSubsystemBinary.cpp:L61-74</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> That is dangerous, the PF is not exception safe. Where is the matching catch block ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I agree - but this is the test subsystem.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> True, but you should not throw a `std::string`, throw a `std::runtime_error`
- [x] <a href='#crh-comment-Pull 58033a610f1bb5f30479a7533956f9a1cb66c246 parameter/LogarithmicParameterAdaptation.cpp 9'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/285#discussion_r42257573'>File: parameter/LogarithmicParameterAdaptation.cpp:L78-88</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - WTF ? fromUserValue returns a uint64_t , why then casting it to double to round it ? Seems that you can remove the double and the
- fmap => max<int64_t> ?
- [x] <a href='#crh-comment-Pull 04c16d1da1ebff1c772b84bb9ec8f4fad6a0875c parameter/FixedPointParameterType.cpp 120'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/285#discussion_r42391055'>File: parameter/FixedPointParameterType.cpp:L271-279</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Maybe use `double{...}` to highlight the fact that their is no precision loose ?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> `(double)` is not usefull
- [x] <a href='#crh-comment-Pull 04c16d1da1ebff1c772b84bb9ec8f4fad6a0875c parameter/FixedPointParameterType.cpp 129'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/285#discussion_r42391070'>File: parameter/FixedPointParameterType.cpp:L333-340</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> idem
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: Ignore my remark, it does not work.
- [x] <a href='#crh-comment-Pull 04c16d1da1ebff1c772b84bb9ec8f4fad6a0875c parameter/FixedPointParameterType.cpp 138'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/285#discussion_r42391082'>File: parameter/FixedPointParameterType.cpp:L347-354</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> idem
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: Ignore my remark, it does not work.
- [x] <a href='#crh-comment-Pull 04c16d1da1ebff1c772b84bb9ec8f4fad6a0875c test/test-subsystem/TESTSubsystemBinary.cpp 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/285#discussion_r42391337'>File: test/test-subsystem/TESTSubsystemBinary.cpp:L61-74</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> `std::string(` is useless. `operator+(const char*, std::string)` is defined.
- [x] <a href='#crh-comment-Pull 04c16d1da1ebff1c772b84bb9ec8f4fad6a0875c test/test-subsystem/TESTSubsystemBinary.cpp 33'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/285#discussion_r42391688'>File: test/test-subsystem/TESTSubsystemBinary.cpp:L61-74</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> could use std::copy_n & MAKE_ARRAY_ITERATOR instead of memcpy.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/285?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/285?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/285'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>