### PR TITLE
[review] Access elements as binary

### DIFF
--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -34,6 +34,7 @@
 #include "ConfigurationAccessContext.h"
 #include "ConfigurableElementAggregator.h"
 #include "AreaConfiguration.h"
+#include "Iterator.hpp"
 #include <assert.h>
 
 #define base CElement
@@ -153,6 +154,16 @@ bool CConfigurableElement::accessValue(CPathNavigator& pathNavigator, std::strin
     }
 
     return pChild->accessValue(pathNavigator, strValue, bSet, parameterAccessContext);
+}
+
+// Whole element access
+void CConfigurableElement::getSettingsAsBytes(std::vector<uint8_t>& bytes,
+                                              CParameterAccessContext& parameterAccessContext) const
+{
+    bytes.reserve(getFootPrint());
+
+    parameterAccessContext.getParameterBlackboard()->readBytes(
+            bytes, getOffset() - parameterAccessContext.getBaseOffset());
 }
 
 void CConfigurableElement::getListOfElementsWithMapping(

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -35,6 +35,7 @@
 #include "ConfigurableElementAggregator.h"
 #include "AreaConfiguration.h"
 #include "Iterator.hpp"
+#include "Utility.h"
 #include <assert.h>
 
 #define base CElement
@@ -164,6 +165,43 @@ void CConfigurableElement::getSettingsAsBytes(std::vector<uint8_t>& bytes,
 
     parameterAccessContext.getParameterBlackboard()->readBytes(
             bytes, getOffset() - parameterAccessContext.getBaseOffset());
+}
+
+bool CConfigurableElement::setSettingsAsBytes(const std::vector<uint8_t>& bytes,
+                                              CParameterAccessContext& parameterAccessContext) const
+{
+    CParameterBlackboard* pParameterBlackboard = parameterAccessContext.getParameterBlackboard();
+
+    // Size
+    size_t size = getFootPrint();
+
+    // Check sizes match
+    if (size != bytes.size()) {
+
+        parameterAccessContext.setError(std::string("Wrong size: Expected: ")
+                                        + std::to_string(size) + " Provided: "
+                                        + std::to_string(bytes.size()));
+
+        return false;
+    }
+
+    // Write bytes
+    pParameterBlackboard->writeBytes(bytes, getOffset() - parameterAccessContext.getBaseOffset());
+
+    if (not parameterAccessContext.getAutoSync()) {
+        // Auto sync is not activated, sync will be defered until an explicit request
+        return true;
+    }
+
+    CSyncerSet syncerSet;
+    fillSyncerSet(syncerSet);
+    core::Results res;
+    if (not syncerSet.sync(*parameterAccessContext.getParameterBlackboard(), true, &res)) {
+
+        parameterAccessContext.setError(utility::asString(res));
+        return false;
+    }
+    return true;
 }
 
 void CConfigurableElement::getListOfElementsWithMapping(

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -34,6 +34,7 @@
 #include "Element.h"
 
 #include <list>
+#include <vector>
 
 class CConfigurableDomain;
 class CSyncerSet;
@@ -98,6 +99,17 @@ public:
 
     // Parameter access
     virtual bool accessValue(CPathNavigator& pathNavigator, std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+
+    /** Gets the element as an array of bytes.
+     *
+     * This is like having a direct access to the blackboard.
+     *
+     * @param[out] bytes Where to store the result.
+     * @param[in] parameterAccessContext Context containing the blackboard to
+     *            read from.
+     */
+    void getSettingsAsBytes(std::vector<uint8_t>& bytes,
+                            CParameterAccessContext& parameterAccessContext) const;
 
     /**
      * Get the list of all the ancestors that have a mapping.

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -110,6 +110,16 @@ public:
      */
     void getSettingsAsBytes(std::vector<uint8_t>& bytes,
                             CParameterAccessContext& parameterAccessContext) const;
+    /** Sets the element as if it was an array of bytes.
+     *
+     * This is like having a direct access to the blackboard.
+     *
+     * @param[out] bytes The content to be set.
+     * @param[in] parameterAccessContext Context containing the blackboard to
+     *            write to.
+     */
+    bool setSettingsAsBytes(const std::vector<uint8_t>& bytes,
+                            CParameterAccessContext& parameterAccessContext) const;
 
     /**
      * Get the list of all the ancestors that have a mapping.

--- a/parameter/ParameterBlackboard.cpp
+++ b/parameter/ParameterBlackboard.cpp
@@ -94,6 +94,21 @@ void CParameterBlackboard::readBuffer(void* pvDstData, size_t size, size_t offse
     readInteger(pvDstData, size, offset);
 }
 
+// Element access
+void CParameterBlackboard::writeBytes(const std::vector<uint8_t>& bytes, uint32_t offset)
+{
+    assertValidAccess(offset, bytes.size());
+
+    std::copy(begin(bytes), end(bytes), atOffset(offset));
+}
+
+void CParameterBlackboard::readBytes(std::vector<uint8_t>& bytes, uint32_t offset) const
+{
+    assertValidAccess(offset, bytes.size());
+
+    std::copy_n(atOffset(offset), bytes.size(), begin(bytes));
+}
+
 // Access from/to subsystems
 uint8_t* CParameterBlackboard::getLocation(size_t offset)
 {

--- a/parameter/ParameterBlackboard.h
+++ b/parameter/ParameterBlackboard.h
@@ -52,6 +52,35 @@ public:
     void writeBuffer(const void* pvSrcData, size_t size, size_t offset);
     void readBuffer(void* pvDstData, size_t size, size_t offset) const;
 
+    /**
+     * Raw write the blackboard memory.
+     *
+     * May be used to write a configurable element's settings
+     *
+     * @param[in] bytes the source data bytes vector.
+     * @param[in] offset the destination offset in the blackboard.
+     *
+     * Notes:
+     *    - This function asserts that the input vector's size + the offset
+     *      does not exceed the size of the blackboard istelf.
+     */
+    void writeBytes(const std::vector<uint8_t>& bytes, uint32_t offset);
+
+    /**
+     * Raw read the blackboard memory.
+     *
+     * May be used to read a configurable element's settings
+     *
+     * @param[out] bytes the destination data bytes vector.
+     * @param[in] offset the source offset in the blackboard.
+     *
+     * Notes:
+     *    - This function asserts that the output vector's size + the offset
+     *      does not exceed the size of the blackboard itself.
+     *    - The user MUST reserve exactly as many elements as the amount to read
+     */
+    void readBytes(std::vector<uint8_t>& bytes, uint32_t offset) const;
+
     // Access from/to subsystems
     uint8_t* getLocation(size_t offset);
 

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -87,6 +87,7 @@
 #include <fstream>
 #include <algorithm>
 #include <mutex>
+#include <iomanip>
 
 #define base CElement
 
@@ -240,6 +241,8 @@ const CParameterMgr::SRemoteCommandParserItem CParameterMgr::gastRemoteCommandPa
             "<elem path>|/", "List parameters under element at given path or root" },
     { "getElementStructureXML", &CParameterMgr::getElementStructureXMLCommandProcess, 1,
             "<elem path>", "Get structure of element at given path in XML format" },
+    { "getElementBytes", &CParameterMgr::getElementBytesCommandProcess, 1,
+            "<elem path>", "Get settings of element at given path in Byte Array format" },
     { "dumpElement", &CParameterMgr::dumpElementCommandProcess, 1,
             "<elem path>", "Dump structure and content of element at given path" },
     { "getElementSize", &CParameterMgr::getElementSizeCommandProcess, 1,
@@ -1289,6 +1292,55 @@ CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::getElementStructure
     if (!exportElementToXMLString(pLocatedElement, pLocatedElement->getKind(), strResult)) {
 
         return CCommandHandler::EFailed;
+    }
+
+    return CCommandHandler::ESucceeded;
+}
+
+CParameterMgr::CCommandHandler::CommandStatus
+CParameterMgr::getElementBytesCommandProcess(const IRemoteCommand& remoteCommand,
+                                              std::string& strResult)
+{
+    CElementLocator elementLocator(getSystemClass());
+
+    CElement* pLocatedElement = NULL;
+
+    if (!elementLocator.locate(remoteCommand.getArgument(0), &pLocatedElement, strResult)) {
+
+        return CCommandHandler::EFailed;
+    }
+
+    const CConfigurableElement* pConfigurableElement =
+            static_cast<CConfigurableElement*>(pLocatedElement);
+
+    // Prepare parameter access context for main blackboard.
+    // Notes:
+    //     - No need to handle output raw format and value space as Byte arrays are hexa formatted
+    //     - Pasing strResult to parameterAccessContext is only necessary wrt to constructor definition:
+    //       since it's a get type of access, no error may occur
+    CParameterAccessContext parameterAccessContext(strResult);
+    parameterAccessContext.setParameterBlackboard(_pMainParameterBlackboard);
+
+    // Get the settings
+    vector<uint8_t> bytes;
+    pConfigurableElement->getSettingsAsBytes(bytes, parameterAccessContext);
+
+    // Hexa formatting
+    std::ostringstream ostream;
+    ostream << std::hex << std::setw(2) << std::setfill('0');
+
+    // Format bytes
+    for (auto byte : bytes) {
+
+        // Convert to an int in order to avoid the "char" overload that would
+        // print characters instead of numbers.
+        ostream << int{byte} << " ";
+    }
+
+    strResult = ostream.str();
+    if (not strResult.empty()) {
+        // Remove the trailing space
+        strResult.pop_back();
     }
 
     return CCommandHandler::ESucceeded;

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -422,6 +422,7 @@ private:
     CCommandHandler::CommandStatus listParametersCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementStructureXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus setElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus dumpElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementSizeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus showPropertiesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -421,6 +421,7 @@ private:
     CCommandHandler::CommandStatus listElementsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus listParametersCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementStructureXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus getElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus dumpElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementSizeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus showPropertiesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);

--- a/remote-processor/RemoteCommand.h
+++ b/remote-processor/RemoteCommand.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <vector>
 #include <string>
 
 class IRemoteCommand
@@ -42,6 +43,11 @@ public:
     virtual void addArgument(const std::string& strArgument) = 0;
     virtual size_t getArgumentCount() const = 0;
     virtual const std::string& getArgument(size_t argument) const = 0;
+    /** Get all the arguments in a vector
+     *
+     * @returns a reference to a vector containing all the arguments.
+     */
+    virtual const std::vector<std::string>& getArguments() const = 0;
     virtual const std::string packArguments(size_t startArgument, size_t nbArguments) const = 0;
 
 protected:

--- a/remote-processor/RequestMessage.cpp
+++ b/remote-processor/RequestMessage.cpp
@@ -69,6 +69,11 @@ size_t CRequestMessage::getArgumentCount() const
     return _argumentVector.size();
 }
 
+const std::vector<string>& CRequestMessage::getArguments() const
+{
+    return _argumentVector;
+}
+
 const string& CRequestMessage::getArgument(size_t argument) const
 {
     assert(argument < _argumentVector.size());

--- a/remote-processor/RequestMessage.h
+++ b/remote-processor/RequestMessage.h
@@ -50,6 +50,7 @@ public:
     virtual void addArgument(const std::string& strArgument);
     virtual size_t getArgumentCount() const;
     virtual const std::string& getArgument(size_t argument) const;
+    virtual const std::vector<std::string>& getArguments() const;
     virtual const std::string packArguments(size_t startArgument, size_t nbArguments) const;
 
 private:


### PR DESCRIPTION
Add support to inport/export configurable element in binary format.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/286%23issuecomment-149236897%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23issuecomment-149485787%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42240754%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42241771%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42242277%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42265729%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42369382%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42369388%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42392986%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42393767%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42393890%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42402894%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42405419%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42414475%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42414500%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42414705%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42414798%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42469096%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42469103%22%2C%20%22https%3A//github.com/01org/parameter-framework/commit/7d7d55c67c175fef4aad059fa3ec9ebaaac36539%23commitcomment-13868663%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/286%23issuecomment-149485983%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23issuecomment-149236897%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20all%20comments%20addressed.%20Please%20review.%20%40tcahuzax%20please%20review%20as%20well.%22%2C%20%22created_at%22%3A%20%222015-10-19T14%3A45%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-20T09%3A05%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-20T09%3A06%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20d0986173309370724bcb7908384c8384b36691f7%20parameter/ParameterMgr.cpp%2061%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42241771%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%20-%20Is%20this%200x%20prefix%20realy%20usefull%20%3F%20I%20must%20say%20that%20it%20is%20rather%20strange%5Cr%5Cn%20-%20No%20need%20to%20static_cast%2C%20use%20the%20unitary%20%60%2B%60%22%2C%20%22created_at%22%3A%20%222015-10-16T13%3A28%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agree%20about%20the%200x%2C%20cf.%20https%3A//github.com/01org/parameter-framework/pull/261%23issuecomment-144466651%22%2C%20%22created_at%22%3A%20%222015-10-16T17%3A09%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-19T19%3A27%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL1300-1411%22%7D%2C%20%22Pull%201a0da1408c4e7355c8db02ae7c406a78f3f3f632%20parameter/ConfigurableElement.h%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42393890%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22doxygen%2C%20maybe%3A%5Cr%5Cn%7E%7E%7Ecpp%5Cr%5Cn/%2A%2A%20Access%20the%20element%20and%20descendant%20as%20bytes.%5Cr%5Cn%20%2A%20%40%7B%5Cr%5Cn%20%2A/%5Cr%5Cn...%5Cr%5Cn/%2A%2A%20%40%7D%20%2A/%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A34%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20done%22%2C%20%22created_at%22%3A%20%222015-10-19T18%3A09%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElement.h%3AL100-111%22%7D%2C%20%22Commit%207d7d55c67c175fef4aad059fa3ec9ebaaac36539%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/commit/7d7d55c67c175fef4aad059fa3ec9ebaaac36539%23commitcomment-13868663%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-20T09%3A02%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22Commit%207d7d55c%20comments%22%7D%2C%20%22Pull%20d0986173309370724bcb7908384c8384b36691f7%20parameter/ParameterMgr.cpp%20118%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42242277%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20look%20very%20much%20like%20%60std%3A%3Atransform%60...%22%2C%20%22created_at%22%3A%20%222015-10-16T13%3A33%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20done%22%2C%20%22created_at%22%3A%20%222015-10-19T13%3A22%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL1300-1411%22%7D%2C%20%22Pull%20933a6335453494b31472401c1d6501fff0e1e9a6%20parameter/ParameterBlackboard.h%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42414475%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20function%20%2A%2Aasserts%2A%2A%20that%20size%20%2B%20offset%20exceeds%20the%20size%20of%20the%20blackboard%20iself%22%2C%20%22created_at%22%3A%20%222015-10-19T19%3A25%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20done%22%2C%20%22created_at%22%3A%20%222015-10-20T08%3A43%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterBlackboard.h%3AL52-86%22%7D%2C%20%22Pull%20d0986173309370724bcb7908384c8384b36691f7%20parameter/ConfigurableElement.cpp%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42240754%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22the%20pParameterBlackboard%20blackboard%20temporary%20variable%20does%20not%20seem%20very%20usefull.%22%2C%20%22created_at%22%3A%20%222015-10-16T13%3A18%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20done%22%2C%20%22created_at%22%3A%20%222015-10-19T13%3A22%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ConfigurableElement.cpp%3AL157-211%22%7D%2C%20%22Pull%201a0da1408c4e7355c8db02ae7c406a78f3f3f632%20remote-processor/RemoteCommand.h%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42393767%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22doxygen%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A33%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-19T19%3A28%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-processor/RemoteCommand.h%3AL43-50%22%7D%2C%20%22Pull%20933a6335453494b31472401c1d6501fff0e1e9a6%20parameter/ParameterBlackboard.h%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42414500%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20function%20%2A%2Aasserts%2A%2A%20that%20the%20bytes%20size%20%2B%20offset%20exceeds%20the%20size%20of%20the%20blackboard%20iself.%22%2C%20%22created_at%22%3A%20%222015-10-19T19%3A26%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20done%22%2C%20%22created_at%22%3A%20%222015-10-20T08%3A43%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterBlackboard.h%3AL52-86%22%7D%2C%20%22Pull%201a0da1408c4e7355c8db02ae7c406a78f3f3f632%20parameter/ParameterBlackboard.cpp%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/286%23discussion_r42392986%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20do%20not%20realy%20get%20why%20this%20intermediate%20variable%20is%20usefull.%20But%20if%20you%20like%20it%2C%20keep%20it.%20It%20is%20a%20mater%20of%20style.%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A26%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20done%22%2C%20%22created_at%22%3A%20%222015-10-19T17%3A50%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterBlackboard.cpp%3AL94-119%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull d0986173309370724bcb7908384c8384b36691f7 parameter/ConfigurableElement.cpp 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#discussion_r42240754'>File: parameter/ConfigurableElement.cpp:L157-211</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> the pParameterBlackboard blackboard temporary variable does not seem very usefull.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: done
- [x] <a href='#crh-comment-Pull d0986173309370724bcb7908384c8384b36691f7 parameter/ParameterMgr.cpp 61'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#discussion_r42241771'>File: parameter/ParameterMgr.cpp:L1300-1411</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - Is this 0x prefix realy usefull ? I must say that it is rather strange
- No need to static_cast, use the unitary `+`
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I agree about the 0x, cf. https://github.com/01org/parameter-framework/pull/261#issuecomment-144466651
- [x] <a href='#crh-comment-Pull d0986173309370724bcb7908384c8384b36691f7 parameter/ParameterMgr.cpp 118'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#discussion_r42242277'>File: parameter/ParameterMgr.cpp:L1300-1411</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> This look very much like `std::transform`...
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: done
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#issuecomment-149236897'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard all comments addressed. Please review. @tcahuzax please review as well.
- [x] <a href='#crh-comment-Pull 1a0da1408c4e7355c8db02ae7c406a78f3f3f632 parameter/ParameterBlackboard.cpp 9'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#discussion_r42392986'>File: parameter/ParameterBlackboard.cpp:L94-119</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I do not realy get why this intermediate variable is usefull. But if you like it, keep it. It is a mater of style.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: done
- [x] <a href='#crh-comment-Pull 1a0da1408c4e7355c8db02ae7c406a78f3f3f632 remote-processor/RemoteCommand.h 12'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#discussion_r42393767'>File: remote-processor/RemoteCommand.h:L43-50</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> doxygen
- [x] <a href='#crh-comment-Pull 1a0da1408c4e7355c8db02ae7c406a78f3f3f632 parameter/ConfigurableElement.h 12'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#discussion_r42393890'>File: parameter/ConfigurableElement.h:L100-111</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> doxygen, maybe:
~~~cpp
/** Access the element and descendant as bytes.
* @{
*/
...
/** @} */
~~~

- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: done
- [x] <a href='#crh-comment-Pull 933a6335453494b31472401c1d6501fff0e1e9a6 parameter/ParameterBlackboard.h 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#discussion_r42414475'>File: parameter/ParameterBlackboard.h:L52-86</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> This function **asserts** that size + offset exceeds the size of the blackboard iself
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: done
- [x] <a href='#crh-comment-Pull 933a6335453494b31472401c1d6501fff0e1e9a6 parameter/ParameterBlackboard.h 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/286#discussion_r42414500'>File: parameter/ParameterBlackboard.h:L52-86</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> This function **asserts** that the bytes size + offset exceeds the size of the blackboard iself.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: done


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/286?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/286?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/286?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/286'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>