### PR TITLE
Fix type inconsistencies in ParameterBlakcboard API

### DIFF
--- a/parameter/ParameterBlackboard.cpp
+++ b/parameter/ParameterBlackboard.cpp
@@ -95,14 +95,14 @@ void CParameterBlackboard::readBuffer(void* pvDstData, size_t size, size_t offse
 }
 
 // Element access
-void CParameterBlackboard::writeBytes(const std::vector<uint8_t>& bytes, uint32_t offset)
+void CParameterBlackboard::writeBytes(const std::vector<uint8_t>& bytes, size_t offset)
 {
     assertValidAccess(offset, bytes.size());
 
     std::copy(begin(bytes), end(bytes), atOffset(offset));
 }
 
-void CParameterBlackboard::readBytes(std::vector<uint8_t>& bytes, uint32_t offset) const
+void CParameterBlackboard::readBytes(std::vector<uint8_t>& bytes, size_t offset) const
 {
     assertValidAccess(offset, bytes.size());
 

--- a/parameter/ParameterBlackboard.h
+++ b/parameter/ParameterBlackboard.h
@@ -64,7 +64,7 @@ public:
      *    - This function asserts that the input vector's size + the offset
      *      does not exceed the size of the blackboard istelf.
      */
-    void writeBytes(const std::vector<uint8_t>& bytes, uint32_t offset);
+    void writeBytes(const std::vector<uint8_t>& bytes, size_t offset);
 
     /**
      * Raw read the blackboard memory.
@@ -79,7 +79,7 @@ public:
      *      does not exceed the size of the blackboard itself.
      *    - The user MUST reserve exactly as many elements as the amount to read
      */
-    void readBytes(std::vector<uint8_t>& bytes, uint32_t offset) const;
+    void readBytes(std::vector<uint8_t>& bytes, size_t offset) const;
 
     // Access from/to subsystems
     uint8_t* getLocation(size_t offset);


### PR DESCRIPTION
The recently-introduced methods readBytes() and writeBytes() where using a
uint32_t for the 'offset' argument whereas all other methods use a size_t. This
is inconsistent and also will trigger a conversion warning with -Wconversion.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/291%23issuecomment-149497620%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/291%23issuecomment-149497942%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/291%23issuecomment-149508390%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/291%23issuecomment-149567296%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/291%23issuecomment-149567335%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/291%23issuecomment-149497620%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20please%20review.%20We%20missed%20this%20is%20the%20previous%20review%20%3A%28%22%2C%20%22created_at%22%3A%20%222015-10-20T09%3A42%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20was%20the%20build%20not%20failing%20with%20-Wconversion%20%3F%22%2C%20%22created_at%22%3A%20%222015-10-20T09%3A44%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20that%20flag%20was%20added%20on%20the%20master%20branch.%20I%20detected%20the%20error%20when%20trying%20to%20merge%20master%20into%20serialization_api.%22%2C%20%22created_at%22%3A%20%222015-10-20T10%3A07%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-20T13%3A23%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-20T13%3A24%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/291#issuecomment-149497620'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard please review. We missed this is the previous review :(
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Why was the build not failing with -Wconversion ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Because that flag was added on the master branch. I detected the error when trying to merge master into serialization_api.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/291?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/291?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/291?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/291'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>