### PR TITLE
Print the file and line number context in libxml2 error messages

### DIFF
--- a/xmlserializer/XmlSerializingContext.cpp
+++ b/xmlserializer/XmlSerializingContext.cpp
@@ -57,5 +57,10 @@ void CXmlSerializingContext::appendLineToError(const std::string& strAppend)
 void CXmlSerializingContext::structuredErrorHandler(void* userData, xmlErrorPtr error)
 {
     CXmlSerializingContext *self = static_cast<CXmlSerializingContext *>(userData);
-    self->_strXmlError += error->message;
+
+    std::string filename = (error->file != NULL) ? error->file : "(user input)";
+    // xmlErrorPtr->int2 contains the column; see xmlerror.h
+    self->_strXmlError += filename + ":" +
+                          std::to_string(error->line) + ":" + std::to_string(error->int2) + ": " +
+                          error->message;
 }


### PR DESCRIPTION
This used to be done by libxml2 itself when using the "generic error handler"
but was lost when switching to the "structured error handler".

Unfortunately, we do not have as much context as with the generic handler,
which used to also print the incriminated content and point to the exact
location of the error. I didn't find any easy way to get it.

Signed-off-by: David Wagner <david.wagner@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/292%23issuecomment-149605716%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/292%23issuecomment-149631691%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/292%23issuecomment-149605716%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20Please%20review.%20I%20intend%20to%20publish%20RC3%20after%20this%20is%20merged.%22%2C%20%22created_at%22%3A%20%222015-10-20T15%3A35%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-20T16%3A55%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/292#issuecomment-149605716'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard Please review. I intend to publish RC3 after this is merged.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/292?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/292?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/292?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/292'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>