### PR TITLE
Add get set element xml commands

### DIFF
--- a/parameter/ArrayParameter.cpp
+++ b/parameter/ArrayParameter.cpp
@@ -77,15 +77,16 @@ bool CArrayParameter::serializeXmlSettings(CXmlElement& xmlConfigurationSettings
     if (!configurationAccessContext.serializeOut()) {
 
         // Actually set values to blackboard
-        if (!setValues(0, configurationAccessContext.getBaseOffset(), xmlConfigurationSettingsElementContent.getTextContent(), configurationAccessContext)) {
-
+        if (!setValues(0, getOffset() - configurationAccessContext.getBaseOffset(),
+                       xmlConfigurationSettingsElementContent.getTextContent(),
+                       configurationAccessContext)) {
             return false;
         }
     } else {
 
         // Get string value
         string strValue = getValues(
-                configurationAccessContext.getBaseOffset(), // Whole array requested
+                getOffset() - configurationAccessContext.getBaseOffset(),
                 configurationAccessContext);
 
         // Populate value into xml text node
@@ -115,8 +116,8 @@ bool CArrayParameter::accessValue(CPathNavigator& pathNavigator, string& strValu
         }
 
         // Actually set values
-        if (!setValues(index, parameterAccessContext.getBaseOffset(), strValue, parameterAccessContext)) {
-
+        if (!setValues(index, getOffset() - parameterAccessContext.getBaseOffset(),
+                       strValue, parameterAccessContext)) {
             return false;
         }
 
@@ -131,7 +132,7 @@ bool CArrayParameter::accessValue(CPathNavigator& pathNavigator, string& strValu
         if (index == (size_t)-1) {
 
             // Whole array requested
-            strValue = getValues(parameterAccessContext.getBaseOffset(), parameterAccessContext);
+            strValue = getValues(getOffset() - parameterAccessContext.getBaseOffset(), parameterAccessContext);
 
         } else {
             // Scalar requested
@@ -250,7 +251,7 @@ bool CArrayParameter::getIndex(CPathNavigator& pathNavigator, size_t& index, CPa
 }
 
 // Common set value processing
-bool CArrayParameter::setValues(size_t uiStartIndex, size_t baseOffset, const string& strValue, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::setValues(size_t uiStartIndex, size_t offset, const string& strValue, CParameterAccessContext& parameterAccessContext) const
 {
     // Deal with value(s)
     Tokenizer tok(strValue, Tokenizer::defaultDelimiters + ",");
@@ -270,11 +271,11 @@ bool CArrayParameter::setValues(size_t uiStartIndex, size_t baseOffset, const st
     // Process
     size_t valueIndex;
     size_t size = getSize();
-    size_t offset = getOffset() + uiStartIndex * size - baseOffset;
+    size_t startOffset = offset + uiStartIndex * size;
 
     for (valueIndex = 0; valueIndex < nbValues; valueIndex++) {
 
-        if (!doSetValue(astrValues[valueIndex], offset, parameterAccessContext)) {
+        if (!doSetValue(astrValues[valueIndex], startOffset, parameterAccessContext)) {
 
             // Append parameter path to error
             parameterAccessContext.appendToError(" " + getPath() + "/" +
@@ -289,10 +290,9 @@ bool CArrayParameter::setValues(size_t uiStartIndex, size_t baseOffset, const st
 }
 
 // Common get value processing
-string CArrayParameter::getValues(size_t baseOffset, CParameterAccessContext& parameterAccessContext) const
+string CArrayParameter::getValues(size_t offset, CParameterAccessContext& parameterAccessContext) const
 {
     size_t size = getSize();
-    size_t offset = getOffset() - baseOffset;
     size_t arrayLength = getArrayLength();
 
     string output;

--- a/parameter/ArrayParameter.h
+++ b/parameter/ArrayParameter.h
@@ -67,7 +67,7 @@ private:
     // Array length
     size_t getArrayLength() const;
     // Common set value processing
-    bool setValues(size_t uiStartIndex, size_t baseOffset, const std::string& strValue, CParameterAccessContext& parameterAccessContext) const;
+    bool setValues(size_t uiStartIndex, size_t offset, const std::string& strValue, CParameterAccessContext& parameterAccessContext) const;
     // Log / get values common
     std::string getValues(size_t baseOffset, CParameterAccessContext& parameterAccessContext) const;
     std::string logValue(CParameterAccessContext &context) const override;

--- a/parameter/ArrayParameter.h
+++ b/parameter/ArrayParameter.h
@@ -39,9 +39,6 @@ public:
     // Instantiation, allocation
     virtual size_t getFootPrint() const;
 
-    // XML configuration settings parsing
-    virtual bool serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const;
-
     /// Value access
     using CBaseParameter::access;
     bool access(std::vector<bool>& abValues, bool bSet,
@@ -73,6 +70,17 @@ private:
     std::string logValue(CParameterAccessContext &context) const override;
     // Index retrieval from user set/get request
     bool getIndex(CPathNavigator& pathNavigator, size_t& index, CParameterAccessContext& parameterAccessContext) const;
+
+    /** Access whole array.
+     *
+     * @param[in] offset Offset of the array in the context blackboard.
+     * @{
+     */
+    bool doSetValue(const std::string& strValue, size_t offset,
+                    CParameterAccessContext& parameterAccessContext) const override;
+    void doGetValue(std::string& strValue, size_t offset,
+                    CParameterAccessContext& parameterAccessContext) const override;
+    /** @} */
 
     /// Value access
     // Generic Access

--- a/parameter/BaseParameter.cpp
+++ b/parameter/BaseParameter.cpp
@@ -174,7 +174,7 @@ bool CBaseParameter::accessValue(CPathNavigator& pathNavigator, string& strValue
     return access(strValue, bSet, parameterAccessContext);
 }
 
-void CBaseParameter::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CBaseParameter::structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
 {
 
     // Delegate to type element

--- a/parameter/BaseParameter.h
+++ b/parameter/BaseParameter.h
@@ -72,8 +72,7 @@ public:
     bool access(std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
     virtual bool access(std::vector<std::string>& astrValues, bool bSet, CParameterAccessContext& parameterAccessContext) const;
 
-    // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    void structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const override final;
 
 protected:
     // Parameter Access

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -48,6 +48,18 @@ CConfigurableElement::~CConfigurableElement()
 {
 }
 
+bool CConfigurableElement::fromXml(const CXmlElement &xmlElement,
+                                   CXmlSerializingContext &serializingContext)
+{
+    return structureFromXml(xmlElement, serializingContext);
+}
+
+void CConfigurableElement::toXml(CXmlElement &xmlElement,
+                                 CXmlSerializingContext &serializingContext) const
+{
+    structureToXml(xmlElement, serializingContext);
+}
+
 // XML configuration settings parsing
 bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const
 {

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -145,6 +145,36 @@ public:
 
     // XML configuration settings parsing
     virtual bool serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const;
+
+    bool fromXml(const CXmlElement &xmlElement,
+                         CXmlSerializingContext &serializingContext) override final;
+
+    void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const override final;
+
+    /** Deserialize the structure from xml. */
+    virtual bool structureFromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext)
+    {
+        // Forward to Element::fromXml.
+        // This is unfortunate as Element::fromXml will call back
+        // fromXml on each children.
+        // Thus on each non leaf node of the tree, the code will test if
+        // the setting or the structure are to be serialized.
+        // This test could be avoided by several ways including:
+        //  - split 2 roles fromXml in two function
+        //    1) construct the elements
+        //    2) recursive call on children
+        //  - dispatch in with a virtual method. This would not not remove
+        //    the branching rather hide it behind a virtual method override.
+        return CElement::fromXml(xmlElement, serializingContext);
+    }
+
+    /** Serialize the structure to xml. */
+    virtual void structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+    {
+        // See structureFromXml implementation comment.
+        CElement::toXml(xmlElement, serializingContext);
+    }
+
 protected:
     // Syncer (me or ascendant)
     virtual ISyncer* getSyncer() const;

--- a/parameter/ConfigurationAccessContext.cpp
+++ b/parameter/ConfigurationAccessContext.cpp
@@ -33,6 +33,16 @@
 
 using std::string;
 
+CConfigurationAccessContext::CConfigurationAccessContext(std::string& strError,
+                                                         CParameterBlackboard* pParameterBlackboard,
+                                                         bool bValueSpaceIsRaw,
+                                                         bool bOutputRawFormatIsHex,
+                                                         bool bSerializeOut) :
+    base(strError, pParameterBlackboard, bValueSpaceIsRaw, bOutputRawFormatIsHex),
+    _bSerializeOut(bSerializeOut)
+{
+}
+
 CConfigurationAccessContext::CConfigurationAccessContext(string& strError, bool bSerializeOut) :
     base(strError),
     _bSerializeOut(bSerializeOut)

--- a/parameter/ConfigurationAccessContext.h
+++ b/parameter/ConfigurationAccessContext.h
@@ -36,10 +36,18 @@
 class CConfigurationAccessContext : public CParameterAccessContext
 {
 public:
+    CConfigurationAccessContext(std::string& strError,
+                                CParameterBlackboard* pParameterBlackboard,
+                                bool bValueSpaceIsRaw,
+                                bool bOutputRawFormatIsHex,
+                                bool bSerializeOut);
+
     CConfigurationAccessContext(std::string& strError, bool bSerializeOut);
 
     // Serialization direction
     bool serializeOut() const;
+
+    bool serializeSettings() const override final { return true; }
 
 private:
     // Serialization direction

--- a/parameter/InstanceConfigurableElement.cpp
+++ b/parameter/InstanceConfigurableElement.cpp
@@ -217,9 +217,10 @@ bool CInstanceConfigurableElement::checkPathExhausted(CPathNavigator& pathNaviga
     return true;
 }
 
-void CInstanceConfigurableElement::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+void CInstanceConfigurableElement::structureToXml(CXmlElement &xmlElement,
+                                                  CXmlSerializingContext &serializingContext) const
 {
-    base::toXml(xmlElement, serializingContext);
+    base::structureToXml(xmlElement, serializingContext);
     // Since Description belongs to the Type of Element, delegate it to the type element.
     getTypeElement()->setXmlDescriptionAttribute(xmlElement);
 }

--- a/parameter/InstanceConfigurableElement.h
+++ b/parameter/InstanceConfigurableElement.h
@@ -105,7 +105,7 @@ public:
     virtual void getListOfElementsWithMapping(std::list<const CConfigurableElement*>&
                                                configurableElementPath) const;
 
-    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
+    virtual void structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
 protected:
     // Syncer

--- a/parameter/ParameterAccessContext.h
+++ b/parameter/ParameterAccessContext.h
@@ -56,6 +56,11 @@ public:
     void setValueSpaceRaw(bool bIsRaw);
     bool valueSpaceIsRaw() const;
 
+    /** @return true if setting serialization is requested,
+     *          false if structure serialization
+     */
+    virtual bool serializeSettings() const { return false; }
+
     /**
      * Assigns Output Raw Format for user get value interpretation.
      *

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -28,6 +28,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "ParameterMgr.h"
+#include "ConfigurationAccessContext.h"
 #include "XmlParameterSerializingContext.h"
 #include "XmlElementSerializingContext.h"
 #include "SystemClass.h"
@@ -530,7 +531,8 @@ bool CParameterMgr::loadStructure(string& strError)
     }
 
     // Parse Structure XML file
-    CXmlParameterSerializingContext parameterBuildContext(strError);
+    CParameterAccessContext accessContext(strError);
+    CXmlParameterSerializingContext parameterBuildContext(accessContext, strError);
 
     {
         // Get structure URI

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -423,6 +423,8 @@ private:
     CCommandHandler::CommandStatus getElementStructureXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus setElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus getElementXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus setElementXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus dumpElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus getElementSizeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
     CCommandHandler::CommandStatus showPropertiesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
@@ -548,6 +550,28 @@ private:
     // System class Structure loading
     bool loadSettings(std::string& strError);
     bool loadSettingsFromConfigFile(std::string& strError);
+
+    /** Assign settings to a configurable element in XML format.
+     *
+     * @param[in] configurableElement The element to set.
+     * @param[in] settings The settings to set.
+     * @param[out] error human readable error message filled in case of error,
+     *                   undefined in case of success.
+     * @return true in case of success, false otherwise
+     */
+    bool setSettingsAsXML(CConfigurableElement *configurableElement, const std::string &settings,
+                          std::string &error);
+
+    /** Get settings from a configurable element in XML format.
+     *
+     * @param[in] configurableElement The element to get settings from.
+     * @param[out] result on success: the exported setttings in XML
+     *                    on error: human readable error message
+     *
+     * @return true in case of success, false otherwise.
+     */
+    bool getSettingsAsXML(const CConfigurableElement *configurableElement,
+                          std::string &result) const;
 
     /** Parse an XML stream into an element
      *

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -93,8 +93,8 @@ bool CSubsystem::needResync(bool /*bClear*/)
     return false;
 }
 
-// From IXmlSink
-bool CSubsystem::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CSubsystem::structureFromXml(const CXmlElement& xmlElement,
+                                  CXmlSerializingContext& serializingContext)
 {
     // Subsystem class does not rely on generic fromXml algorithm of Element class.
     // So, setting here the description if found as XML attribute.

--- a/parameter/Subsystem.h
+++ b/parameter/Subsystem.h
@@ -64,8 +64,8 @@ public:
     CSubsystem(const std::string& strName, core::log::Logger& logger);
     virtual ~CSubsystem();
 
-    // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool structureFromXml(const CXmlElement& xmlElement,
+                                  CXmlSerializingContext& serializingContext);
 
     // Susbsystem sanity
     virtual bool isAlive() const;

--- a/parameter/XmlParameterSerializingContext.cpp
+++ b/parameter/XmlParameterSerializingContext.cpp
@@ -33,7 +33,10 @@
 
 using std::string;
 
-CXmlParameterSerializingContext::CXmlParameterSerializingContext(string& strError) : base(strError)
+CXmlParameterSerializingContext::CXmlParameterSerializingContext(CParameterAccessContext &context,
+                                                                 string& strError) :
+    base(strError),
+    mAccessContext(context)
 {
 }
 

--- a/parameter/XmlParameterSerializingContext.h
+++ b/parameter/XmlParameterSerializingContext.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "XmlElementSerializingContext.h"
+#include "ParameterAccessContext.h"
 
 #include <string>
 
@@ -38,11 +39,16 @@ class CComponentLibrary;
 class CXmlParameterSerializingContext : public CXmlElementSerializingContext
 {
 public:
-    CXmlParameterSerializingContext(std::string& strError);
+    CXmlParameterSerializingContext(CParameterAccessContext &context, std::string& strError);
 
     // ComponentLibrary
     void setComponentLibrary(const CComponentLibrary* pComponentLibrary);
     const CComponentLibrary* getComponentLibrary() const;
+
+    CParameterAccessContext &getAccessContext() const { return mAccessContext; }
+
 private:
     const CComponentLibrary* _pComponentLibrary;
+
+    CParameterAccessContext &mAccessContext;
 };

--- a/test/functional-tests-legacy/Util/PfwUnitTestLib.py
+++ b/test/functional-tests-legacy/Util/PfwUnitTestLib.py
@@ -50,7 +50,7 @@ class RemoteCli(object):
         """
         expectSuccess=kwargs.get("expectSuccess", True)
 
-        assert self.remoteProcess.poll() == None, "Can not send command to Test platform as it has died."
+        assert self.remoteProcess.poll() == None, "Can not send command to Test platform as it has died. Return code: %s" % self.remoteProcess.returncode
 
         sys_cmd = self.platform_command + [cmd]
         if args is not None:
@@ -86,7 +86,7 @@ class Hal(RemoteCli):
         self.setRemoteProcess(subprocess.Popen(cmd))
         # Wait for the test-platform listening socket
         while socket.socket().connect_ex(("localhost", self.testPlatformPort)) != 0:
-            assert self.remoteProcess.poll() == None, "Test platform has failed to start."
+            assert self.remoteProcess.poll() == None, "Test platform has failed to start. Return code: %s" % self.remoteProcess.returncode
             time.sleep(0.01)
 
     # Send command "stop" to the HAL


### PR DESCRIPTION
Get command returns current element values (from main blackboard)
in XML format.

Set command allows assigning a configurable element's settings directly in XML.
Notes:
  - Tuning mode must be on
  - In case of failure, all the subelements that have been successfully
    written along the access keep their new value
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/293%23discussion_r42720239%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/293%23issuecomment-150138854%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/293%23issuecomment-150162738%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/293%23discussion_r42743554%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/293%23issuecomment-150534846%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/293%23discussion_r42850275%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/293%23issuecomment-150561803%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/293%23issuecomment-150621815%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/293%23issuecomment-150138854%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%40dawagner%20%40tcahuzax%20please%20review%22%2C%20%22created_at%22%3A%20%222015-10-22T08%3A03%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-22T09%3A39%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dawagner%20please%20review%22%2C%20%22created_at%22%3A%20%222015-10-23T10%3A09%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A49%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-23T16%3A12%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ed1eb2abb9948d05d9af1d8be9914fae9239eadc%20parameter/ArrayParameter.cpp%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/293%23discussion_r42720239%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20have%20no%20idea%20why%20offset%20is%20not%20used%20instead%20of%20%60parameterAccessContext.getBaseOffset%28%29%60.%20If%20I%20forward%20offset%2C%20the%20regression%20tests%20are%20brocken.%20%40benaware%20do%20know%20have%20an%20idea%20%3F%20I%20must%20confess%20I%20do%20not%20understand%20all%20those%20offset%20manipulation.%22%2C%20%22created_at%22%3A%20%222015-10-22T07%3A57%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20base%20offset%20has%20been%20introduced%20to%20allow%20reusing%20access%20methods%20for%20both%20main%20and%20configuration%20blackboard.%5Cr%5CnHere%20there%27s%20a%20regression%20due%20to%20interface%20mismatch%20between%20doSetValue%20and%20setValue%20in%20Array%20parameter%20class%22%2C%20%22created_at%22%3A%20%222015-10-22T12%3A52%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461629%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/benaware%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-23T10%3A10%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ArrayParameter.cpp%3AL106-134%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull ed1eb2abb9948d05d9af1d8be9914fae9239eadc parameter/ArrayParameter.cpp 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/293#discussion_r42720239'>File: parameter/ArrayParameter.cpp:L106-134</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I have no idea why offset is not used instead of `parameterAccessContext.getBaseOffset()`. If I forward offset, the regression tests are brocken. @benaware do know have an idea ? I must confess I do not understand all those offset manipulation.
- <a href='https://github.com/benaware'><img border=0 src='https://avatars.githubusercontent.com/u/6461629?v=3' height=16 width=16'></a> The base offset has been introduced to allow reusing access methods for both main and configuration blackboard.
Here there's a regression due to interface mismatch between doSetValue and setValue in Array parameter class
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/293#issuecomment-150138854'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: @dawagner @tcahuzax please review
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :-1:
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> @dawagner please review


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/293?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/293?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/293'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>