### PR TITLE
C++11 ctors and dtors features

### DIFF
--- a/parameter/AreaConfiguration.cpp
+++ b/parameter/AreaConfiguration.cpp
@@ -33,14 +33,14 @@
 #include <assert.h>
 
 CAreaConfiguration::CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet)
-    : _pConfigurableElement(pConfigurableElement), _pSyncerSet(pSyncerSet), _bValid(false)
+    : _pConfigurableElement(pConfigurableElement), _pSyncerSet(pSyncerSet)
 {
     // Size blackboard
     _blackboard.setSize(_pConfigurableElement->getFootPrint());
 }
 
 CAreaConfiguration::CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet, size_t size)
-    : _pConfigurableElement(pConfigurableElement), _pSyncerSet(pSyncerSet), _bValid(false)
+    : _pConfigurableElement(pConfigurableElement), _pSyncerSet(pSyncerSet)
 {
     // Size blackboard
     _blackboard.setSize(size);

--- a/parameter/AreaConfiguration.cpp
+++ b/parameter/AreaConfiguration.cpp
@@ -33,10 +33,8 @@
 #include <assert.h>
 
 CAreaConfiguration::CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet)
-    : _pConfigurableElement(pConfigurableElement), _pSyncerSet(pSyncerSet)
+    : CAreaConfiguration(pConfigurableElement, pSyncerSet, pConfigurableElement->getFootPrint())
 {
-    // Size blackboard
-    _blackboard.setSize(_pConfigurableElement->getFootPrint());
 }
 
 CAreaConfiguration::CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet, size_t size)

--- a/parameter/AreaConfiguration.h
+++ b/parameter/AreaConfiguration.h
@@ -42,8 +42,7 @@ class CAreaConfiguration
 public:
     CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet);
 
-    /* FIXME this was missing and probably buggy*/
-    virtual ~CAreaConfiguration() {}
+    virtual ~CAreaConfiguration() = default;
 
     // Save data from current
     void save(const CParameterBlackboard* pMainBlackboard);

--- a/parameter/AreaConfiguration.h
+++ b/parameter/AreaConfiguration.h
@@ -105,6 +105,6 @@ private:
     const CSyncerSet* _pSyncerSet;
 
     // Area configuration validity (invalid area configurations can't be restored)
-    bool _bValid;
+    bool _bValid{false};
 };
 

--- a/parameter/ArrayParameter.cpp
+++ b/parameter/ArrayParameter.cpp
@@ -41,10 +41,6 @@
 
 using std::string;
 
-CArrayParameter::CArrayParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
-{
-}
-
 size_t CArrayParameter::getFootPrint() const
 {
     return getSize() * getArrayLength();

--- a/parameter/ArrayParameter.h
+++ b/parameter/ArrayParameter.h
@@ -34,7 +34,7 @@
 class CArrayParameter : public CParameter
 {
 public:
-    CArrayParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    using CParameter::CParameter;
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;

--- a/parameter/BackSynchronizer.h
+++ b/parameter/BackSynchronizer.h
@@ -49,7 +49,7 @@ public:
 
     // Back synchronization
     virtual void sync() = 0;
-    virtual ~CBackSynchronizer() {}
+    virtual ~CBackSynchronizer() = default;
 
 protected:
     // Aggregate list

--- a/parameter/BaseParameter.cpp
+++ b/parameter/BaseParameter.cpp
@@ -38,10 +38,6 @@
 
 using std::string;
 
-CBaseParameter::CBaseParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
-{
-}
-
 // XML configuration settings parsing/composing
 bool CBaseParameter::serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const
 {

--- a/parameter/BaseParameter.h
+++ b/parameter/BaseParameter.h
@@ -40,7 +40,7 @@ class CConfigurationAccessContext;
 class CBaseParameter : public CInstanceConfigurableElement
 {
 public:
-    CBaseParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    using CInstanceConfigurableElement::CInstanceConfigurableElement;
 
     // XML configuration settings parsing/composing
     virtual bool serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const;

--- a/parameter/BitParameter.cpp
+++ b/parameter/BitParameter.cpp
@@ -39,10 +39,6 @@
 
 using std::string;
 
-CBitParameter::CBitParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
-{
-}
-
 // Type
 CInstanceConfigurableElement::Type CBitParameter::getType() const
 {

--- a/parameter/BitParameter.h
+++ b/parameter/BitParameter.h
@@ -36,7 +36,7 @@
 class CBitParameter : public CBaseParameter
 {
 public:
-    CBitParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    using CBaseParameter::CBaseParameter;
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;

--- a/parameter/BitParameterBlock.cpp
+++ b/parameter/BitParameterBlock.cpp
@@ -36,10 +36,6 @@
 
 using std::string;
 
-CBitParameterBlock::CBitParameterBlock(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
-{
-}
-
 CInstanceConfigurableElement::Type CBitParameterBlock::getType() const
 {
     return EBitParameterBlock;

--- a/parameter/BitParameterBlock.h
+++ b/parameter/BitParameterBlock.h
@@ -34,7 +34,7 @@
 class CBitParameterBlock : public CInstanceConfigurableElement
 {
 public:
-    CBitParameterBlock(const std::string& strName, const CTypeElement* pTypeElement);
+    using CInstanceConfigurableElement::CInstanceConfigurableElement;
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;

--- a/parameter/BitParameterBlockType.cpp
+++ b/parameter/BitParameterBlockType.cpp
@@ -35,10 +35,6 @@
 
 using std::string;
 
-CBitParameterBlockType::CBitParameterBlockType(const string& strName) : base(strName)
-{
-}
-
 string CBitParameterBlockType::getKind() const
 {
     return "BitParameterBlock";

--- a/parameter/BitParameterBlockType.cpp
+++ b/parameter/BitParameterBlockType.cpp
@@ -35,7 +35,7 @@
 
 using std::string;
 
-CBitParameterBlockType::CBitParameterBlockType(const string& strName) : base(strName), _size(0)
+CBitParameterBlockType::CBitParameterBlockType(const string& strName) : base(strName)
 {
 }
 

--- a/parameter/BitParameterBlockType.h
+++ b/parameter/BitParameterBlockType.h
@@ -36,7 +36,7 @@
 class CBitParameterBlockType : public CTypeElement
 {
 public:
-    CBitParameterBlockType(const std::string& strName);
+    using CTypeElement::CTypeElement;
 
     // Size
     size_t getSize() const;

--- a/parameter/BitParameterBlockType.h
+++ b/parameter/BitParameterBlockType.h
@@ -55,6 +55,6 @@ private:
     virtual CInstanceConfigurableElement* doInstantiate() const;
 
     // Size in bytes
-    size_t _size;
+    size_t _size{0};
 };
 

--- a/parameter/BitParameterType.cpp
+++ b/parameter/BitParameterType.cpp
@@ -39,7 +39,7 @@
 
 using std::string;
 
-CBitParameterType::CBitParameterType(const string& strName) : base(strName), _bitPos(0), _uiBitSize(0), _uiMax(uint64_t(-1))
+CBitParameterType::CBitParameterType(const string& strName) : base(strName)
 {
 }
 

--- a/parameter/BitParameterType.cpp
+++ b/parameter/BitParameterType.cpp
@@ -39,10 +39,6 @@
 
 using std::string;
 
-CBitParameterType::CBitParameterType(const string& strName) : base(strName)
-{
-}
-
 // CElement
 string CBitParameterType::getKind() const
 {

--- a/parameter/BitParameterType.h
+++ b/parameter/BitParameterType.h
@@ -40,7 +40,7 @@ class CParameterAccessContext;
 class CBitParameterType : public CTypeElement
 {
 public:
-    CBitParameterType(const std::string& strName);
+    using CTypeElement::CTypeElement;
 
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);

--- a/parameter/BitParameterType.h
+++ b/parameter/BitParameterType.h
@@ -84,9 +84,9 @@ private:
     bool isEncodable(uint64_t uiData) const;
 
     // Pos in bits
-    size_t _bitPos;
+    size_t _bitPos{0};
     // Size in bits
-    size_t _uiBitSize;
+    size_t _uiBitSize{0};
     // Max value
-    uint64_t _uiMax;
+    uint64_t _uiMax{uint64_t(-1)};
 };

--- a/parameter/BooleanParameterType.cpp
+++ b/parameter/BooleanParameterType.cpp
@@ -38,10 +38,6 @@ CBooleanParameterType::CBooleanParameterType(const std::string& strName) : base(
     setSize(1);
 }
 
-CBooleanParameterType::~CBooleanParameterType()
-{
-}
-
 std::string CBooleanParameterType::getKind() const
 {
     return "BooleanParameter";

--- a/parameter/BooleanParameterType.h
+++ b/parameter/BooleanParameterType.h
@@ -37,7 +37,7 @@ class CBooleanParameterType : public CParameterType
 {
 public:
     CBooleanParameterType(const std::string& strName);
-    virtual ~CBooleanParameterType();
+    virtual ~CBooleanParameterType() = default;
 
     // Kind
     virtual std::string getKind() const;

--- a/parameter/ComponentInstance.cpp
+++ b/parameter/ComponentInstance.cpp
@@ -35,10 +35,6 @@
 
 #define base CTypeElement
 
-CComponentInstance::CComponentInstance(const std::string& strName) : base(strName)
-{
-}
-
 std::string CComponentInstance::getKind() const
 {
     return "Component";

--- a/parameter/ComponentInstance.cpp
+++ b/parameter/ComponentInstance.cpp
@@ -35,7 +35,7 @@
 
 #define base CTypeElement
 
-CComponentInstance::CComponentInstance(const std::string& strName) : base(strName), _pComponentType(NULL)
+CComponentInstance::CComponentInstance(const std::string& strName) : base(strName)
 {
 }
 

--- a/parameter/ComponentInstance.h
+++ b/parameter/ComponentInstance.h
@@ -38,7 +38,7 @@ class CComponentType;
 class CComponentInstance : public CTypeElement
 {
 public:
-    CComponentInstance(const std::string& strName);
+    using CTypeElement::CTypeElement;
 
     // Mapping info
     virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const;

--- a/parameter/ComponentInstance.h
+++ b/parameter/ComponentInstance.h
@@ -61,6 +61,6 @@ private:
     virtual void populate(CElement* pElement) const;
 
     // Related component type
-    const CComponentType* _pComponentType;
+    const CComponentType* _pComponentType{nullptr};
 };
 

--- a/parameter/ComponentLibrary.cpp
+++ b/parameter/ComponentLibrary.cpp
@@ -31,10 +31,6 @@
 #include "ComponentType.h"
 #include <assert.h>
 
-CComponentLibrary::CComponentLibrary()
-{
-}
-
 bool CComponentLibrary::childrenAreDynamic() const
 {
     return true;

--- a/parameter/ComponentLibrary.h
+++ b/parameter/ComponentLibrary.h
@@ -40,8 +40,6 @@ class CComponentType;
 class CComponentLibrary : public CElement
 {
 public:
-    CComponentLibrary();
-
     const CComponentType* getComponentType(const std::string& strName) const;
 
     virtual std::string getKind() const;

--- a/parameter/ComponentType.cpp
+++ b/parameter/ComponentType.cpp
@@ -35,7 +35,7 @@
 
 #define base CTypeElement
 
-CComponentType::CComponentType(const std::string& strName) : base(strName), _pExtendsComponentType(NULL)
+CComponentType::CComponentType(const std::string& strName) : base(strName)
 {
 }
 

--- a/parameter/ComponentType.cpp
+++ b/parameter/ComponentType.cpp
@@ -35,10 +35,6 @@
 
 #define base CTypeElement
 
-CComponentType::CComponentType(const std::string& strName) : base(strName)
-{
-}
-
 std::string CComponentType::getKind() const
 {
     return "ComponentType";

--- a/parameter/ComponentType.h
+++ b/parameter/ComponentType.h
@@ -64,5 +64,5 @@ private:
     virtual CInstanceConfigurableElement* doInstantiate() const;
 
     // Ref
-    const CComponentType* _pExtendsComponentType;
+    const CComponentType* _pExtendsComponentType{nullptr};
 };

--- a/parameter/ComponentType.h
+++ b/parameter/ComponentType.h
@@ -38,7 +38,7 @@ class CInstanceConfigurableElement;
 class CComponentType : public CTypeElement
 {
 public:
-    CComponentType(const std::string& strName);
+    using CTypeElement::CTypeElement;
 
     // Object creation
     virtual void populate(CElement* pElement) const;

--- a/parameter/CompoundRule.cpp
+++ b/parameter/CompoundRule.cpp
@@ -40,7 +40,7 @@ const char* CCompoundRule::_apcTypes[2] = {
     "All"
 };
 
-CCompoundRule::CCompoundRule() : _bTypeAll(false)
+CCompoundRule::CCompoundRule()
 {
 }
 

--- a/parameter/CompoundRule.cpp
+++ b/parameter/CompoundRule.cpp
@@ -40,10 +40,6 @@ const char* CCompoundRule::_apcTypes[2] = {
     "All"
 };
 
-CCompoundRule::CCompoundRule()
-{
-}
-
 // Class kind
 string CCompoundRule::getKind() const
 {

--- a/parameter/CompoundRule.h
+++ b/parameter/CompoundRule.h
@@ -36,8 +36,6 @@
 class CCompoundRule : public CRule
 {
 public:
-    CCompoundRule();
-
     // Parse
     virtual bool parse(CRuleParser& ruleParser, std::string& strError);
 

--- a/parameter/CompoundRule.h
+++ b/parameter/CompoundRule.h
@@ -63,7 +63,7 @@ private:
     virtual bool childrenAreDynamic() const;
 
     // Type
-    bool _bTypeAll;
+    bool _bTypeAll{false};
 
     // Types
     static const char* _apcTypes[];

--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -42,12 +42,11 @@
 
 using std::string;
 
-CConfigurableDomain::CConfigurableDomain() :
-    _bSequenceAware(false), _pLastAppliedConfiguration(NULL)
+CConfigurableDomain::CConfigurableDomain()
 {
 }
 
-CConfigurableDomain::CConfigurableDomain(const string& strName) : base(strName), _bSequenceAware(false), _pLastAppliedConfiguration(NULL)
+CConfigurableDomain::CConfigurableDomain(const string& strName) : base(strName)
 {
 }
 

--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -42,10 +42,6 @@
 
 using std::string;
 
-CConfigurableDomain::CConfigurableDomain()
-{
-}
-
 CConfigurableDomain::CConfigurableDomain(const string& strName) : base(strName)
 {
 }

--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -42,10 +42,6 @@
 
 using std::string;
 
-CConfigurableDomain::CConfigurableDomain(const string& strName) : base(strName)
-{
-}
-
 CConfigurableDomain::~CConfigurableDomain()
 {
     // Remove all configurable elements

--- a/parameter/ConfigurableDomain.h
+++ b/parameter/ConfigurableDomain.h
@@ -49,7 +49,7 @@ class CConfigurableDomain : public CElement
     typedef std::list<CConfigurableElement*>::const_iterator ConfigurableElementListIterator;
     typedef std::map<const CConfigurableElement*, CSyncerSet*>::const_iterator ConfigurableElementToSyncerSetMapIterator;
 public:
-    CConfigurableDomain();
+    CConfigurableDomain() = default;
     CConfigurableDomain(const std::string& strName);
     virtual ~CConfigurableDomain();
 

--- a/parameter/ConfigurableDomain.h
+++ b/parameter/ConfigurableDomain.h
@@ -49,8 +49,7 @@ class CConfigurableDomain : public CElement
     typedef std::list<CConfigurableElement*>::const_iterator ConfigurableElementListIterator;
     typedef std::map<const CConfigurableElement*, CSyncerSet*>::const_iterator ConfigurableElementToSyncerSetMapIterator;
 public:
-    CConfigurableDomain() = default;
-    CConfigurableDomain(const std::string& strName);
+    using CElement::CElement;
     virtual ~CConfigurableDomain();
 
     // Sequence awareness

--- a/parameter/ConfigurableDomain.h
+++ b/parameter/ConfigurableDomain.h
@@ -264,12 +264,12 @@ private:
     std::map<const CConfigurableElement*, CSyncerSet*> _configurableElementToSyncerSetMap;
 
     // Sequence awareness
-    bool _bSequenceAware;
+    bool _bSequenceAware{false};
 
     // Syncer set used to ensure propoer synchronization of restored configurable elements
     CSyncerSet _syncerSet;
 
     // Last applied configuration
-    mutable const CDomainConfiguration* _pLastAppliedConfiguration;
+    mutable const CDomainConfiguration* _pLastAppliedConfiguration{nullptr};
 };
 

--- a/parameter/ConfigurableDomains.cpp
+++ b/parameter/ConfigurableDomains.cpp
@@ -36,10 +36,6 @@
 
 using std::string;
 
-CConfigurableDomains::CConfigurableDomains()
-{
-}
-
 string CConfigurableDomains::getKind() const
 {
     return "ConfigurableDomains";

--- a/parameter/ConfigurableDomains.h
+++ b/parameter/ConfigurableDomains.h
@@ -44,8 +44,6 @@ class CSelectionCriteriaDefinition;
 class CConfigurableDomains : public CElement
 {
 public:
-    CConfigurableDomains();
-
     // Configuration/Domains handling
     /// Domains
     bool createDomain(const std::string& strName, std::string& strError);

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -38,7 +38,7 @@
 
 #define base CElement
 
-CConfigurableElement::CConfigurableElement(const std::string& strName) : base(strName), _offset(0)
+CConfigurableElement::CConfigurableElement(const std::string& strName) : base(strName)
 {
 }
 

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -38,11 +38,8 @@
 
 #define base CElement
 
+// TODO: delegate
 CConfigurableElement::CConfigurableElement(const std::string& strName) : base(strName)
-{
-}
-
-CConfigurableElement::~CConfigurableElement()
 {
 }
 

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -50,7 +50,7 @@ class PARAMETER_EXPORT CConfigurableElement : public CElement
     typedef std::list<const CConfigurableDomain*>::const_iterator ConfigurableDomainListConstIterator;
 public:
     CConfigurableElement(const std::string& strName = "");
-    virtual ~CConfigurableElement();
+    virtual ~CConfigurableElement() = default;
 
     // Offset in main blackboard
     void setOffset(size_t offset);

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -154,7 +154,7 @@ private:
     bool isOfConfigurableElementType(const CElement* pParent) const;
 
     // Offset in main blackboard
-    size_t _offset;
+    size_t _offset{0};
 
     // Associated configurable domains
     std::list<const CConfigurableDomain*> _configurableDomainList;

--- a/parameter/ConfigurableElementWithMapping.h
+++ b/parameter/ConfigurableElementWithMapping.h
@@ -41,7 +41,7 @@
 class CConfigurableElementWithMapping : public CConfigurableElement {
 public:
     CConfigurableElementWithMapping(const std::string& strName) : CConfigurableElement(strName) {}
-    virtual ~CConfigurableElementWithMapping() {}
+    virtual ~CConfigurableElementWithMapping() = default;
 
     /**
      * Get the value associated to a mapping key in the object's mapping

--- a/parameter/DefaultElementLibrary.h
+++ b/parameter/DefaultElementLibrary.h
@@ -48,7 +48,7 @@ class CDefaultElementLibrary: public CElementLibrary
 {
 public:
 
-    virtual ~CDefaultElementLibrary() {}
+    virtual ~CDefaultElementLibrary() = default;
 
     /** Set the default builder used in fallback mechanism.
       * @see createElement() for more detail on this mechanism.

--- a/parameter/DomainConfiguration.cpp
+++ b/parameter/DomainConfiguration.cpp
@@ -46,10 +46,6 @@
 
 using std::string;
 
-CDomainConfiguration::CDomainConfiguration(const string& strName) : base(strName)
-{
-}
-
 // Class kind
 string CDomainConfiguration::getKind() const
 {

--- a/parameter/DomainConfiguration.h
+++ b/parameter/DomainConfiguration.h
@@ -51,7 +51,7 @@ class CDomainConfiguration : public CElement
         ECompoundRule
     };
 public:
-    CDomainConfiguration(const std::string& strName);
+    using CElement::CElement;
 
     // Configurable Elements association
     void addConfigurableElement(const CConfigurableElement *configurableElement, const CSyncerSet *syncerSet);

--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -41,7 +41,7 @@ using std::string;
 
 const std::string CElement::gDescriptionPropertyName = "Description";
 
-CElement::CElement(const string& strName) : _strName(strName), _pParent(NULL)
+CElement::CElement(const string& strName) : _strName(strName)
 {
 }
 

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -189,5 +189,5 @@ private:
     // Children
     std::vector<CElement*> _childArray;
     // Parent
-    CElement* _pParent;
+    CElement* _pParent{nullptr};
 };

--- a/parameter/ElementBuilder.h
+++ b/parameter/ElementBuilder.h
@@ -35,7 +35,7 @@
 class CElementBuilder : private utility::NonCopyable
 {
 public:
-    virtual ~CElementBuilder() {}
+    virtual ~CElementBuilder() = default;
 
     virtual CElement* createElement(const CXmlElement& xmlElement) const = 0;
 };

--- a/parameter/ElementLibrary.cpp
+++ b/parameter/ElementLibrary.cpp
@@ -31,10 +31,6 @@
 #include "ElementBuilder.h"
 
 
-CElementLibrary::CElementLibrary()
-{
-}
-
 CElementLibrary::~CElementLibrary()
 {
     clean();

--- a/parameter/ElementLibrary.h
+++ b/parameter/ElementLibrary.h
@@ -45,7 +45,6 @@ class PARAMETER_EXPORT CElementLibrary
     typedef ElementBuilderMap::const_iterator ElementBuilderMapConstIterator;
 
 public:
-    CElementLibrary();
     virtual ~CElementLibrary();
 
     /** Add a xml tag and it's corresponding builder in the library.

--- a/parameter/ElementLibrarySet.cpp
+++ b/parameter/ElementLibrarySet.cpp
@@ -30,10 +30,6 @@
 #include "ElementLibrarySet.h"
 #include <assert.h>
 
-CElementLibrarySet::CElementLibrarySet()
-{
-}
-
 CElementLibrarySet::~CElementLibrarySet()
 {
     // FIXME: use an array of unique_ptr

--- a/parameter/ElementLibrarySet.h
+++ b/parameter/ElementLibrarySet.h
@@ -41,6 +41,5 @@ public:
     CElementLibrary* getElementLibrary(size_t index) const;
 
 private:
-    typedef std::vector<CElementLibrary*>::iterator CElementLibraryArrayIterator;
     std::vector<CElementLibrary*> _elementLibraryArray;
 };

--- a/parameter/ElementLibrarySet.h
+++ b/parameter/ElementLibrarySet.h
@@ -34,7 +34,6 @@
 class CElementLibrarySet
 {
 public:
-    CElementLibrarySet();
     ~CElementLibrarySet();
 
     void addElementLibrary(CElementLibrary* pElementLibrary);

--- a/parameter/EnumParameterType.cpp
+++ b/parameter/EnumParameterType.cpp
@@ -36,10 +36,6 @@
 
 using std::string;
 
-CEnumParameterType::CEnumParameterType(const string& strName) : base(strName)
-{
-}
-
 string CEnumParameterType::getKind() const
 {
     return "EnumParameter";

--- a/parameter/EnumParameterType.h
+++ b/parameter/EnumParameterType.h
@@ -36,7 +36,7 @@
 class CEnumParameterType : public CParameterType
 {
 public:
-    CEnumParameterType(const std::string& strName);
+    using CParameterType::CParameterType;
 
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);

--- a/parameter/EnumValuePair.cpp
+++ b/parameter/EnumValuePair.cpp
@@ -33,7 +33,7 @@
 
 using std::string;
 
-CEnumValuePair::CEnumValuePair() : _iNumerical(0)
+CEnumValuePair::CEnumValuePair()
 {
 }
 

--- a/parameter/EnumValuePair.cpp
+++ b/parameter/EnumValuePair.cpp
@@ -33,10 +33,6 @@
 
 using std::string;
 
-CEnumValuePair::CEnumValuePair()
-{
-}
-
 // CElement
 string CEnumValuePair::getKind() const
 {

--- a/parameter/EnumValuePair.h
+++ b/parameter/EnumValuePair.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -53,6 +53,6 @@ protected:
     std::string logValue(utility::ErrorContext& errorContext) const override;
 private:
     // Numerical
-    int32_t _iNumerical;
+    int32_t _iNumerical{0};
 };
 

--- a/parameter/EnumValuePair.h
+++ b/parameter/EnumValuePair.h
@@ -34,8 +34,6 @@
 class CEnumValuePair : public CElement
 {
 public:
-    CEnumValuePair();
-
     // Numerical
     int32_t getNumerical() const;
     std::string getNumericalAsString() const;

--- a/parameter/FixedPointParameterType.cpp
+++ b/parameter/FixedPointParameterType.cpp
@@ -44,10 +44,6 @@
 
 using std::string;
 
-CFixedPointParameterType::CFixedPointParameterType(const string& strName) : base(strName)
-{
-}
-
 string CFixedPointParameterType::getKind() const
 {
     return "FixedPointParameter";

--- a/parameter/FixedPointParameterType.cpp
+++ b/parameter/FixedPointParameterType.cpp
@@ -44,7 +44,7 @@
 
 using std::string;
 
-CFixedPointParameterType::CFixedPointParameterType(const string& strName) : base(strName), _uiIntegral(0), _uiFractional(0)
+CFixedPointParameterType::CFixedPointParameterType(const string& strName) : base(strName)
 {
 }
 

--- a/parameter/FixedPointParameterType.h
+++ b/parameter/FixedPointParameterType.h
@@ -142,7 +142,7 @@ private:
     double binaryQnmToDouble(int32_t iValue) const;
 
     // Integral part in Q notation
-    uint32_t _uiIntegral;
+    uint32_t _uiIntegral{0};
     // Fractional part in Q notation
-    uint32_t _uiFractional;
+    uint32_t _uiFractional{0};
 };

--- a/parameter/FixedPointParameterType.h
+++ b/parameter/FixedPointParameterType.h
@@ -36,7 +36,7 @@
 class CFixedPointParameterType : public CParameterType
 {
 public:
-    CFixedPointParameterType(const std::string& strName);
+    using CParameterType::CParameterType;
 
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);

--- a/parameter/FloatingPointParameterType.cpp
+++ b/parameter/FloatingPointParameterType.cpp
@@ -39,11 +39,6 @@
 
 using std::string;
 
-CFloatingPointParameterType::CFloatingPointParameterType(const string& strName)
-    : base(strName)
-{
-}
-
 string CFloatingPointParameterType::getKind() const
 {
     return "FloatingPointParameter";

--- a/parameter/FloatingPointParameterType.cpp
+++ b/parameter/FloatingPointParameterType.cpp
@@ -40,9 +40,7 @@
 using std::string;
 
 CFloatingPointParameterType::CFloatingPointParameterType(const string& strName)
-    : base(strName),
-      _fMin(std::numeric_limits<float>::lowest()),
-      _fMax(std::numeric_limits<float>::max())
+    : base(strName)
 {
 }
 

--- a/parameter/FloatingPointParameterType.h
+++ b/parameter/FloatingPointParameterType.h
@@ -88,6 +88,6 @@ private:
     bool checkValueAgainstRange(double dValue) const;
 
     /** Bounds */
-    float _fMin;
-    float _fMax;
+    float _fMin{std::numeric_limits<float>::lowest()};
+    float _fMax{std::numeric_limits<float>::max()};
 };

--- a/parameter/FloatingPointParameterType.h
+++ b/parameter/FloatingPointParameterType.h
@@ -35,7 +35,7 @@
 class CFloatingPointParameterType : public CParameterType
 {
 public:
-    CFloatingPointParameterType(const std::string& strName);
+    using CParameterType::CParameterType;
 
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
     virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;

--- a/parameter/FormattedSubsystemObject.cpp
+++ b/parameter/FormattedSubsystemObject.cpp
@@ -39,18 +39,11 @@ using std::string;
 
 CFormattedSubsystemObject::CFormattedSubsystemObject(
         CInstanceConfigurableElement* pInstanceConfigurableElement,
-        core::log::Logger& logger)
-    : base(pInstanceConfigurableElement, logger)
-{
-}
-
-CFormattedSubsystemObject::CFormattedSubsystemObject(
-        CInstanceConfigurableElement* pInstanceConfigurableElement,
         core::log::Logger& logger,
         const string& strMappingValue)
-    : base(pInstanceConfigurableElement, logger), _strFormattedMappingValue(strMappingValue)
+    : base(pInstanceConfigurableElement, logger),
+      _strFormattedMappingValue(strMappingValue)
 {
-
 }
 
 
@@ -61,7 +54,7 @@ CFormattedSubsystemObject::CFormattedSubsystemObject(
         size_t firstAmendKey,
         size_t nbAmendKeys,
         const CMappingContext& context)
-    : base(pInstanceConfigurableElement, logger), _strFormattedMappingValue(strMappingValue)
+    : CFormattedSubsystemObject(pInstanceConfigurableElement, logger, strMappingValue)
 {
     // Cope with quotes in the name
     if (strMappingValue[0] == '\'' && strMappingValue.length() >= 2) {

--- a/parameter/FormattedSubsystemObject.cpp
+++ b/parameter/FormattedSubsystemObject.cpp
@@ -72,10 +72,6 @@ CFormattedSubsystemObject::CFormattedSubsystemObject(
                                                    nbAmendKeys, context);
 }
 
-CFormattedSubsystemObject::~CFormattedSubsystemObject()
-{
-}
-
 string CFormattedSubsystemObject::getFormattedMappingValue() const
 {
     return _strFormattedMappingValue;

--- a/parameter/FormattedSubsystemObject.h
+++ b/parameter/FormattedSubsystemObject.h
@@ -74,7 +74,7 @@ public:
                               size_t firstAmendKey,
                               size_t nbAmendKeys,
                               const CMappingContext& context);
-    virtual ~CFormattedSubsystemObject();
+    virtual ~CFormattedSubsystemObject() = default;
 
     /**
      * Returns the formatted mapping value associated to the element.

--- a/parameter/FormattedSubsystemObject.h
+++ b/parameter/FormattedSubsystemObject.h
@@ -37,15 +37,6 @@ class PARAMETER_EXPORT CFormattedSubsystemObject : public CSubsystemObject
 {
 public:
     /**
-     * Builds a new CFormattedSubsystemObject instance, without any mapping information.
-     *
-     * @param[in] pInstanceConfigurableElement Instance of the element linked to the SubsytemObject.
-     * @param[in] logger the logger provided by the client
-     */
-    CFormattedSubsystemObject(CInstanceConfigurableElement* pInstanceConfigurableElement,
-                              core::log::Logger& logger);
-
-    /**
      * Builds a new CFormattedSubsystemObject instance, using a simple mapping value without Amends.
      *
      * @param[in] pInstanceConfigurableElement Instance of the element linked to the SubsytemObject.
@@ -55,7 +46,7 @@ public:
      */
     CFormattedSubsystemObject(CInstanceConfigurableElement* pInstanceConfigurableElement,
                               core::log::Logger& logger,
-                              const std::string& strFormattedMapping);
+                              const std::string& strFormattedMapping = "");
 
     /**
      * Builds a new CFormattedSubsystemObject instance, using a mapping value containing Amends.

--- a/parameter/FrameworkConfigurationLocation.cpp
+++ b/parameter/FrameworkConfigurationLocation.cpp
@@ -33,10 +33,6 @@
 
 #define base CKindElement
 
-CFrameworkConfigurationLocation::CFrameworkConfigurationLocation(const std::string& strName, const std::string& strKind) : base(strName, strKind)
-{
-}
-
 // From IXmlSink
 bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
 {

--- a/parameter/FrameworkConfigurationLocation.h
+++ b/parameter/FrameworkConfigurationLocation.h
@@ -36,7 +36,7 @@
 class CFrameworkConfigurationLocation : public CKindElement
 {
 public:
-    CFrameworkConfigurationLocation(const std::string& strName, const std::string& strKind);
+    using CKindElement::CKindElement;
 
     /** Get Configuration file URI
      */

--- a/parameter/InstanceConfigurableElement.cpp
+++ b/parameter/InstanceConfigurableElement.cpp
@@ -37,7 +37,7 @@
 
 #define base CConfigurableElementWithMapping
 
-CInstanceConfigurableElement::CInstanceConfigurableElement(const std::string& strName, const CTypeElement* pTypeElement) : base(strName), _pTypeElement(pTypeElement), _pSyncer(NULL)
+CInstanceConfigurableElement::CInstanceConfigurableElement(const std::string& strName, const CTypeElement* pTypeElement) : base(strName), _pTypeElement(pTypeElement)
 {
 }
 

--- a/parameter/InstanceConfigurableElement.h
+++ b/parameter/InstanceConfigurableElement.h
@@ -131,6 +131,6 @@ private:
     const CTypeElement* _pTypeElement;
 
     // Sync to HW
-    ISyncer* _pSyncer;
+    ISyncer* _pSyncer{nullptr};
 };
 

--- a/parameter/InstanceDefinition.cpp
+++ b/parameter/InstanceDefinition.cpp
@@ -32,10 +32,6 @@
 
 #define base CTypeElement
 
-CInstanceDefinition::CInstanceDefinition()
-{
-}
-
 std::string CInstanceDefinition::getKind() const
 {
     return "InstanceDefinition";

--- a/parameter/InstanceDefinition.h
+++ b/parameter/InstanceDefinition.h
@@ -36,8 +36,6 @@
 class CInstanceDefinition : public CTypeElement
 {
 public:
-    CInstanceDefinition();
-
     void createInstances(CElement* pFatherElement);
 
     virtual std::string getKind() const;

--- a/parameter/InstanceDefinition.h
+++ b/parameter/InstanceDefinition.h
@@ -36,6 +36,8 @@
 class CInstanceDefinition : public CTypeElement
 {
 public:
+    using CTypeElement::CTypeElement;
+
     void createInstances(CElement* pFatherElement);
 
     virtual std::string getKind() const;

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -42,10 +42,6 @@
 using std::string;
 using std::ostringstream;
 
-CIntegerParameterType::CIntegerParameterType(const string& strName) : base(strName)
-{
-}
-
 // Kind
 string CIntegerParameterType::getKind() const
 {

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -42,7 +42,7 @@
 using std::string;
 using std::ostringstream;
 
-CIntegerParameterType::CIntegerParameterType(const string& strName) : base(strName), _uiMin(0), _uiMax(uint32_t(-1))
+CIntegerParameterType::CIntegerParameterType(const string& strName) : base(strName)
 {
 }
 

--- a/parameter/IntegerParameterType.h
+++ b/parameter/IntegerParameterType.h
@@ -86,7 +86,7 @@ private:
     const CParameterAdaptation* getParameterAdaptation() const;
 
     // Signing
-    bool _bSigned;
+    bool _bSigned{false};
     // Range
     uint32_t _uiMin{0};
     uint32_t _uiMax{uint32_t(-1)};

--- a/parameter/IntegerParameterType.h
+++ b/parameter/IntegerParameterType.h
@@ -88,6 +88,6 @@ private:
     // Signing
     bool _bSigned;
     // Range
-    uint32_t _uiMin;
-    uint32_t _uiMax;
+    uint32_t _uiMin{0};
+    uint32_t _uiMax{uint32_t(-1)};
 };

--- a/parameter/IntegerParameterType.h
+++ b/parameter/IntegerParameterType.h
@@ -38,7 +38,7 @@ class CParameterAdaptation;
 class CIntegerParameterType : public CParameterType
 {
 public:
-    CIntegerParameterType(const std::string& strName);
+    using CParameterType::CParameterType;
 
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);

--- a/parameter/LinearParameterAdaptation.cpp
+++ b/parameter/LinearParameterAdaptation.cpp
@@ -33,12 +33,12 @@
 
 using std::string;
 
-CLinearParameterAdaptation::CLinearParameterAdaptation() : base("Linear"), _dSlopeNumerator(1), _dSlopeDenominator(1)
+CLinearParameterAdaptation::CLinearParameterAdaptation() : base("Linear")
 {
 }
 
 CLinearParameterAdaptation::CLinearParameterAdaptation(const string& strType) :
-    base(strType), _dSlopeNumerator(1), _dSlopeDenominator(1)
+    base(strType)
 {
 }
 

--- a/parameter/LinearParameterAdaptation.h
+++ b/parameter/LinearParameterAdaptation.h
@@ -50,6 +50,6 @@ public:
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
 private:
     // Slope attributes
-    double _dSlopeNumerator;
-    double _dSlopeDenominator;
+    double _dSlopeNumerator{1};
+    double _dSlopeDenominator{1};
 };

--- a/parameter/LogarithmicParameterAdaptation.cpp
+++ b/parameter/LogarithmicParameterAdaptation.cpp
@@ -35,12 +35,7 @@
 
 #define base CLinearParameterAdaptation
 
-CLogarithmicParameterAdaptation::CLogarithmicParameterAdaptation() : base("Logarithmic"),
-    // std::exp(1) == e^1 == e == natural logarithm base
-    // Make sure there is no precision lose by using std::exp overload that
-    // return the same type as _dLogarithmBase
-    _dLogarithmBase{std::exp(decltype(_dLogarithmBase){1})},
-    _dFloorValue(-std::numeric_limits<double>::infinity())
+CLogarithmicParameterAdaptation::CLogarithmicParameterAdaptation() : base("Logarithmic")
 {
     static_assert(std::numeric_limits<double>::is_iec559,
             "Only double-precision floating points that are compliant with"

--- a/parameter/LogarithmicParameterAdaptation.h
+++ b/parameter/LogarithmicParameterAdaptation.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include "LinearParameterAdaptation.h"
+#include <cmath>
+#include <limits>
 
 /**
  * This class is used to perform a logarithmic adapation of type:
@@ -62,10 +64,14 @@ private:
      * _dLogarithmBase characterizes the new logarithm logB(x) with
      * the following property: logB(x) = log(x) / log(_dLogarithmBase).
      * log being the base-e logarithm.
+     *
+     * std::exp(1) == e^1 == e == natural logarithm base
+     * Make sure there is no precision lose by using std::exp overload that
+     * return the same type as _dLogarithmBase
      */
-    double _dLogarithmBase;
+    double _dLogarithmBase{std::exp(decltype(_dLogarithmBase){1})};
     /**
      * _dFloorValue reflects the lower bound for volume attenuation
      */
-    double _dFloorValue;
+    double _dFloorValue{-std::numeric_limits<double>::infinity()};
 };

--- a/parameter/Mapper.h
+++ b/parameter/Mapper.h
@@ -40,5 +40,5 @@ public:
     virtual void mapEnd() = 0;
 
 protected:
-    virtual ~IMapper() {}
+    virtual ~IMapper() = default;
 };

--- a/parameter/MappingData.cpp
+++ b/parameter/MappingData.cpp
@@ -32,10 +32,6 @@
 #include "Utility.h"
 #include <assert.h>
 
-CMappingData::CMappingData()
-{
-}
-
 bool CMappingData::init(const std::string &rawMapping, std::string &error)
 {
     Tokenizer mappingTok(rawMapping, ",");

--- a/parameter/MappingData.h
+++ b/parameter/MappingData.h
@@ -36,8 +36,6 @@ class CMappingData
 {
     typedef std::map<std::string, std::string>::const_iterator KeyToValueMapConstIterator;
 public:
-    CMappingData();
-
     /** Initialize mapping data through a raw value
      *
      * @param[in] rawMapping the raw mapping data which has to be parsed.

--- a/parameter/NamedElementBuilderTemplate.h
+++ b/parameter/NamedElementBuilderTemplate.h
@@ -35,8 +35,6 @@ template <class ElementType>
 class TNamedElementBuilderTemplate : public CElementBuilder
 {
 public:
-    TNamedElementBuilderTemplate() : CElementBuilder() {}
-
     virtual CElement* createElement(const CXmlElement& xmlElement) const
     {
         return new ElementType(xmlElement.getNameAttribute());

--- a/parameter/Parameter.cpp
+++ b/parameter/Parameter.cpp
@@ -37,10 +37,6 @@
 
 using std::string;
 
-CParameter::CParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
-{
-}
-
 CInstanceConfigurableElement::Type CParameter::getType() const
 {
     return EParameter;

--- a/parameter/Parameter.h
+++ b/parameter/Parameter.h
@@ -38,7 +38,7 @@
 class CParameter : public CBaseParameter
 {
 public:
-    CParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    using CBaseParameter::CBaseParameter;
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;

--- a/parameter/ParameterAccessContext.cpp
+++ b/parameter/ParameterAccessContext.cpp
@@ -45,14 +45,7 @@ CParameterAccessContext::CParameterAccessContext(std::string& strError,
 CParameterAccessContext::CParameterAccessContext(std::string& strError,
                                                  CParameterBlackboard* pParameterBlackboard,
                                                  size_t baseOffset)
-    : base(strError), _pParameterBlackboard(pParameterBlackboard), _bValueSpaceIsRaw(false),
-    _bOutputRawFormatIsHex(false), _uiBaseOffset(baseOffset)
-{
-}
-
-CParameterAccessContext::CParameterAccessContext(std::string& strError)
-    : base(strError), _pParameterBlackboard(NULL), _bValueSpaceIsRaw(false),
-    _bOutputRawFormatIsHex(false), _uiBaseOffset(0)
+    : base(strError), _pParameterBlackboard(pParameterBlackboard), _uiBaseOffset(baseOffset)
 {
 }
 

--- a/parameter/ParameterAccessContext.cpp
+++ b/parameter/ParameterAccessContext.cpp
@@ -38,7 +38,7 @@ CParameterAccessContext::CParameterAccessContext(std::string& strError,
                                                  size_t baseOffset)
     : base(strError), _pParameterBlackboard(pParameterBlackboard),
     _bValueSpaceIsRaw(bValueSpaceIsRaw), _bOutputRawFormatIsHex(bOutputRawFormatIsHex),
-    _bAutoSync(true), _uiBaseOffset(baseOffset)
+    _uiBaseOffset(baseOffset)
 {
 }
 
@@ -46,13 +46,13 @@ CParameterAccessContext::CParameterAccessContext(std::string& strError,
                                                  CParameterBlackboard* pParameterBlackboard,
                                                  size_t baseOffset)
     : base(strError), _pParameterBlackboard(pParameterBlackboard), _bValueSpaceIsRaw(false),
-    _bOutputRawFormatIsHex(false), _bAutoSync(true), _uiBaseOffset(baseOffset)
+    _bOutputRawFormatIsHex(false), _uiBaseOffset(baseOffset)
 {
 }
 
 CParameterAccessContext::CParameterAccessContext(std::string& strError)
     : base(strError), _pParameterBlackboard(NULL), _bValueSpaceIsRaw(false),
-    _bOutputRawFormatIsHex(false), _bAutoSync(true), _uiBaseOffset(0)
+    _bOutputRawFormatIsHex(false), _uiBaseOffset(0)
 {
 }
 

--- a/parameter/ParameterAccessContext.h
+++ b/parameter/ParameterAccessContext.h
@@ -38,6 +38,7 @@ class CParameterBlackboard;
 class CParameterAccessContext : public utility::ErrorContext
 {
 public:
+    using utility::ErrorContext::ErrorContext;
     CParameterAccessContext(std::string& strError,
                             CParameterBlackboard* pParameterBlackboard,
                             bool bValueSpaceIsRaw,
@@ -46,7 +47,6 @@ public:
     CParameterAccessContext(std::string& strError,
                             CParameterBlackboard* pParameterBlackboard,
                             size_t offsetBase = 0);
-    CParameterAccessContext(std::string& strError);
 
     // ParameterBlackboard
     CParameterBlackboard* getParameterBlackboard();
@@ -81,14 +81,14 @@ public:
 
 private:
     // Blackboard
-    CParameterBlackboard* _pParameterBlackboard;
+    CParameterBlackboard* _pParameterBlackboard{nullptr};
     // Value space
-    bool _bValueSpaceIsRaw;
+    bool _bValueSpaceIsRaw{false};
     // Output Raw Format
-    bool _bOutputRawFormatIsHex;
+    bool _bOutputRawFormatIsHex{false};
     // Automatic synchronization to HW
     bool _bAutoSync{true};
     // Base offset where parameters are stored in configuration blackboards
-    size_t _uiBaseOffset;
+    size_t _uiBaseOffset{0};
 };
 

--- a/parameter/ParameterAccessContext.h
+++ b/parameter/ParameterAccessContext.h
@@ -87,7 +87,7 @@ private:
     // Output Raw Format
     bool _bOutputRawFormatIsHex;
     // Automatic synchronization to HW
-    bool _bAutoSync;
+    bool _bAutoSync{true};
     // Base offset where parameters are stored in configuration blackboards
     size_t _uiBaseOffset;
 };

--- a/parameter/ParameterAdaptation.cpp
+++ b/parameter/ParameterAdaptation.cpp
@@ -33,7 +33,7 @@
 
 using std::string;
 
-CParameterAdaptation::CParameterAdaptation(const string& strType) : base(strType), _iOffset(0)
+CParameterAdaptation::CParameterAdaptation(const string& strType) : base(strType)
 {
 }
 // CElement

--- a/parameter/ParameterAdaptation.cpp
+++ b/parameter/ParameterAdaptation.cpp
@@ -33,9 +33,6 @@
 
 using std::string;
 
-CParameterAdaptation::CParameterAdaptation(const string& strType) : base(strType)
-{
-}
 // CElement
 string CParameterAdaptation::getKind() const
 {

--- a/parameter/ParameterAdaptation.h
+++ b/parameter/ParameterAdaptation.h
@@ -36,7 +36,7 @@
 class CParameterAdaptation : public CElement
 {
 public:
-    CParameterAdaptation(const std::string& strType);
+    using CElement::CElement;
 
     // Element properties
     virtual void showProperties(std::string& strResult) const;

--- a/parameter/ParameterAdaptation.h
+++ b/parameter/ParameterAdaptation.h
@@ -56,6 +56,6 @@ protected:
 
 private:
     // Offset
-    int32_t _iOffset;
+    int32_t _iOffset{0};
 };
 

--- a/parameter/ParameterBlockType.h
+++ b/parameter/ParameterBlockType.h
@@ -46,7 +46,5 @@ private:
     virtual CInstanceConfigurableElement* doInstantiate() const;
     // Population
     virtual void populate(CElement* pElement) const;
-    // Creating sub blocks with indexes
-    static std::string computeChildName(size_t uiChild);
 };
 

--- a/parameter/ParameterFrameworkConfiguration.cpp
+++ b/parameter/ParameterFrameworkConfiguration.cpp
@@ -32,7 +32,6 @@
 #define base CElement
 
 CParameterFrameworkConfiguration::CParameterFrameworkConfiguration()
-    : _bTuningAllowed(false), _uiServerPort(0)
 {
 }
 

--- a/parameter/ParameterFrameworkConfiguration.cpp
+++ b/parameter/ParameterFrameworkConfiguration.cpp
@@ -31,10 +31,6 @@
 
 #define base CElement
 
-CParameterFrameworkConfiguration::CParameterFrameworkConfiguration()
-{
-}
-
 std::string CParameterFrameworkConfiguration::getKind() const
 {
     return "ParameterFrameworkConfiguration";

--- a/parameter/ParameterFrameworkConfiguration.h
+++ b/parameter/ParameterFrameworkConfiguration.h
@@ -56,7 +56,7 @@ private:
     // System class name
     std::string _strSystemClassName;
     // Tuning allowed
-    bool _bTuningAllowed;
+    bool _bTuningAllowed{false};
     // Server port
-    uint16_t _uiServerPort;
+    uint16_t _uiServerPort{0};
 };

--- a/parameter/ParameterFrameworkConfiguration.h
+++ b/parameter/ParameterFrameworkConfiguration.h
@@ -36,8 +36,6 @@
 class CParameterFrameworkConfiguration : public CElement
 {
 public:
-    CParameterFrameworkConfiguration();
-
     // System class name
     const std::string& getSystemClassName() const;
 

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -320,22 +320,10 @@ const CParameterMgr::SRemoteCommandParserItem CParameterMgr::gastRemoteCommandPa
 
 // Remote command parsers array Size
 CParameterMgr::CParameterMgr(const string& strConfigurationFilePath, log::ILogger& logger) :
-    _bTuningModeIsOn(false),
-    _bValueSpaceIsRaw(false),
-    _bOutputRawFormatIsHex(false),
-    _bAutoSyncOn(true),
     _pMainParameterBlackboard(new CParameterBlackboard),
     _pElementLibrarySet(new CElementLibrarySet),
     _xmlConfigurationUri(CXmlDocSource::mkUri(strConfigurationFilePath, "")),
-    _pSubsystemPlugins(NULL),
-    _pRemoteProcessorServer(NULL),
-    _maxCommandUsageLength(0),
-    _logger(logger),
-    _bForceNoRemoteInterface(false),
-    _bFailOnMissingSubsystem(true),
-    _bFailOnFailedSettingsLoad(true),
-    _bValidateSchemasOnStart(false)
-
+    _logger(logger)
 {
     // Deal with children
     addChild(new CParameterFrameworkConfiguration);

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -687,16 +687,16 @@ private:
     inline core::log::details::Warning warning();
 
     // Tuning
-    bool _bTuningModeIsOn;
+    bool _bTuningModeIsOn{false};
 
     // Value Space
-    bool _bValueSpaceIsRaw;
+    bool _bValueSpaceIsRaw{false};
 
     // Output Raw Format
-    bool _bOutputRawFormatIsHex;
+    bool _bOutputRawFormatIsHex{false};
 
     // Automatic synchronization to HW during Tuning session
-    bool _bAutoSyncOn;
+    bool _bAutoSyncOn{true};
 
     // Current Parameter Settings
     CParameterBlackboard* _pMainParameterBlackboard;
@@ -709,16 +709,16 @@ private:
     std::string _schemaUri; // Place where schemas stand
 
     // Subsystem plugin location
-    const CSubsystemPlugins* _pSubsystemPlugins;
+    const CSubsystemPlugins* _pSubsystemPlugins{nullptr};
 
     // Remote Processor Server
-    IRemoteProcessorServerInterface* _pRemoteProcessorServer;
+    IRemoteProcessorServerInterface* _pRemoteProcessorServer{nullptr};
 
     // Parser description array
     static const SRemoteCommandParserItem gastRemoteCommandParserItems[];
 
     // Maximum command usage length
-    size_t _maxCommandUsageLength;
+    size_t _maxCommandUsageLength{0};
 
     // Blackboard access mutex
     std::mutex _blackboardMutex;
@@ -730,23 +730,23 @@ private:
      * If set to true - the default - it has no impact on the policy for
      * starting the remote interface.
      */
-    bool _bForceNoRemoteInterface;
+    bool _bForceNoRemoteInterface{false};
 
     /** If set to true, missing subsystem will abort parameterMgr start.
       * If set to false, missing subsystem will fallback on virtual subsystem.
       */
-    bool _bFailOnMissingSubsystem;
+    bool _bFailOnMissingSubsystem{true};
     /** If set to true, unparsable or discording domains will abort parameterMgr start.
       * If set to false, unparsable or discording domains
       *                 will continue the parameterMgr start with no domains.
       */
-    bool _bFailOnFailedSettingsLoad;
+    bool _bFailOnFailedSettingsLoad{true};
 
     /**
      * If set to true, parameterMgr will report an error
      *     when being unable to validate .xml files
      * If set to false, no .xml/xsd validation will happen (default behaviour)
      */
-    bool _bValidateSchemasOnStart;
+    bool _bValidateSchemasOnStart{false};
 };
 

--- a/parameter/ParameterType.cpp
+++ b/parameter/ParameterType.cpp
@@ -40,10 +40,6 @@ using std::string;
 
 const std::string CParameterType::gUnitPropertyName = "Unit";
 
-CParameterType::CParameterType(const string& strName) : base(strName)
-{
-}
-
 // Object creation
 void CParameterType::populate(CElement* /*elem*/) const
 {

--- a/parameter/ParameterType.cpp
+++ b/parameter/ParameterType.cpp
@@ -44,10 +44,6 @@ CParameterType::CParameterType(const string& strName) : base(strName)
 {
 }
 
-CParameterType::~CParameterType()
-{
-}
-
 // Object creation
 void CParameterType::populate(CElement* /*elem*/) const
 {

--- a/parameter/ParameterType.cpp
+++ b/parameter/ParameterType.cpp
@@ -40,7 +40,7 @@ using std::string;
 
 const std::string CParameterType::gUnitPropertyName = "Unit";
 
-CParameterType::CParameterType(const string& strName) : base(strName), _size(0)
+CParameterType::CParameterType(const string& strName) : base(strName)
 {
 }
 

--- a/parameter/ParameterType.h
+++ b/parameter/ParameterType.h
@@ -45,7 +45,7 @@ class PARAMETER_EXPORT CParameterType : public CTypeElement
 {
 public:
     CParameterType(const std::string& strName);
-    virtual ~CParameterType();
+    virtual ~CParameterType() = default;
 
     // Size
     size_t getSize() const;

--- a/parameter/ParameterType.h
+++ b/parameter/ParameterType.h
@@ -145,7 +145,7 @@ private:
     bool doIsEncodable(type data, bool bIsSigned) const;
 
     // Size in bytes
-    size_t _size;
+    size_t _size{0};
     // Unit
     std::string _strUnit;
 

--- a/parameter/ParameterType.h
+++ b/parameter/ParameterType.h
@@ -44,7 +44,7 @@ class CConfigurationAccessContext;
 class PARAMETER_EXPORT CParameterType : public CTypeElement
 {
 public:
-    CParameterType(const std::string& strName);
+    using CTypeElement::CTypeElement;
     virtual ~CParameterType() = default;
 
     // Size

--- a/parameter/PathNavigator.cpp
+++ b/parameter/PathNavigator.cpp
@@ -30,7 +30,7 @@
 #include "PathNavigator.h"
 #include "Tokenizer.h"
 
-CPathNavigator::CPathNavigator(const std::string& strPath) : _currentIndex(0)
+CPathNavigator::CPathNavigator(const std::string& strPath)
 {
     init(strPath);
 }

--- a/parameter/PathNavigator.h
+++ b/parameter/PathNavigator.h
@@ -56,5 +56,5 @@ private:
 
     bool _bValid;
     std::vector<std::string> _astrItems;
-    size_t _currentIndex;
+    size_t _currentIndex{0};
 };

--- a/parameter/PluginLocation.cpp
+++ b/parameter/PluginLocation.cpp
@@ -31,11 +31,6 @@
 
 #define base CKindElement
 
-CPluginLocation::CPluginLocation(const std::string& strName, const std::string& strKind) : base(strName, strKind)
-{
-
-}
-
 const std::string& CPluginLocation::getFolder() const
 {
     return _strFolder;

--- a/parameter/PluginLocation.h
+++ b/parameter/PluginLocation.h
@@ -36,7 +36,7 @@ class CPluginLocation : public CKindElement
 {
 
 public:
-    CPluginLocation(const std::string& strName, const std::string& strKind);
+    using CKindElement::CKindElement;
 
     // From IXmlSink
     virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);

--- a/parameter/RuleParser.cpp
+++ b/parameter/RuleParser.cpp
@@ -47,11 +47,7 @@ const char* CRuleParser::_acDelimiters[CRuleParser::ENbStatuses] = {
 
 CRuleParser::CRuleParser(const string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition) :
     _strApplicationRule(strApplicationRule),
-    _pSelectionCriteriaDefinition(pSelectionCriteriaDefinition),
-    _uiCurrentPos(0),
-    _currentDeepness(0),
-    _eStatus(CRuleParser::EInit),
-    _pRootRule(NULL)
+    _pSelectionCriteriaDefinition(pSelectionCriteriaDefinition)
 {
 }
 

--- a/parameter/RuleParser.h
+++ b/parameter/RuleParser.h
@@ -79,15 +79,15 @@ private:
     // Criteria defintion
     const CSelectionCriteriaDefinition* _pSelectionCriteriaDefinition;
     /** String iterator */
-    std::string::size_type _uiCurrentPos;
+    std::string::size_type _uiCurrentPos{0};
     // Deepness
-    size_t _currentDeepness;
+    size_t _currentDeepness{0};
     // Current Type
     std::string _strRuleType;
     // Status
-    Status _eStatus;
+    Status _eStatus{EInit};
     // Root rule
-    CCompoundRule* _pRootRule;
+    CCompoundRule* _pRootRule{nullptr};
     // Matches
     static const char* _acDelimiters[ENbStatuses];
 };

--- a/parameter/SelectionCriteriaDefinition.cpp
+++ b/parameter/SelectionCriteriaDefinition.cpp
@@ -30,10 +30,6 @@
 #include "SelectionCriteriaDefinition.h"
 #include "SelectionCriterion.h"
 
-CSelectionCriteriaDefinition::CSelectionCriteriaDefinition()
-{
-}
-
 std::string CSelectionCriteriaDefinition::getKind() const
 {
     return "SelectionCriteriaDefinition";

--- a/parameter/SelectionCriteriaDefinition.h
+++ b/parameter/SelectionCriteriaDefinition.h
@@ -38,8 +38,6 @@ class ISelectionCriterionObserver;
 class CSelectionCriteriaDefinition : public CElement
 {
 public:
-    CSelectionCriteriaDefinition();
-
     // Selection Criterion creation
     CSelectionCriterion* createSelectionCriterion(const std::string& strName,
                                                   const CSelectionCriterionType* pType,

--- a/parameter/SelectionCriterion.cpp
+++ b/parameter/SelectionCriterion.cpp
@@ -39,7 +39,7 @@ using namespace core;
 CSelectionCriterion::CSelectionCriterion(const std::string& strName,
                                          const CSelectionCriterionType* pType,
                                          core::log::Logger& logger)
-    : base(strName), _iState(0), _pType(pType), _uiNbModifications(0), _logger(logger)
+    : base(strName), _pType(pType), _logger(logger)
 {
 }
 

--- a/parameter/SelectionCriterion.h
+++ b/parameter/SelectionCriterion.h
@@ -79,12 +79,12 @@ public:
     virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
 private:
     // Current state
-    int _iState;
+    int _iState{0};
     // Type
     const CSelectionCriterionType* _pType;
 
     /** Counter to know how many modifications have been applied to this criterion */
-    uint32_t _uiNbModifications;
+    uint32_t _uiNbModifications{0};
 
     /** Application logger */
     core::log::Logger& _logger;

--- a/parameter/SelectionCriterionLibrary.cpp
+++ b/parameter/SelectionCriterionLibrary.cpp
@@ -31,10 +31,6 @@
 
 #define base CElement
 
-CSelectionCriterionLibrary::CSelectionCriterionLibrary()
-{
-}
-
 std::string CSelectionCriterionLibrary::getKind() const
 {
     return "SelectionCriterionLibrary";

--- a/parameter/SelectionCriterionLibrary.h
+++ b/parameter/SelectionCriterionLibrary.h
@@ -35,8 +35,6 @@
 class CSelectionCriterionLibrary : public CElement
 {
 public:
-    CSelectionCriterionLibrary();
-
     // Type creation
     CSelectionCriterionType* createSelectionCriterionType(bool bIsInclusive);
 

--- a/parameter/SelectionCriterionRule.cpp
+++ b/parameter/SelectionCriterionRule.cpp
@@ -47,7 +47,7 @@ const CSelectionCriterionRule::SMatchingRuleDescription CSelectionCriterionRule:
     { "Excludes", false }
 };
 
-CSelectionCriterionRule::CSelectionCriterionRule() : _pSelectionCriterion(NULL), _eMatchesWhen(CSelectionCriterionRule::EIs), _iMatchValue(0)
+CSelectionCriterionRule::CSelectionCriterionRule()
 {
 }
 

--- a/parameter/SelectionCriterionRule.cpp
+++ b/parameter/SelectionCriterionRule.cpp
@@ -47,10 +47,6 @@ const CSelectionCriterionRule::SMatchingRuleDescription CSelectionCriterionRule:
     { "Excludes", false }
 };
 
-CSelectionCriterionRule::CSelectionCriterionRule()
-{
-}
-
 // Class kind
 string CSelectionCriterionRule::getKind() const
 {

--- a/parameter/SelectionCriterionRule.h
+++ b/parameter/SelectionCriterionRule.h
@@ -81,13 +81,13 @@ private:
     bool setMatchesWhen(const std::string& strMatchesWhen, std::string& strError);
 
     // Selection criterion
-    const CSelectionCriterion* _pSelectionCriterion;
+    const CSelectionCriterion* _pSelectionCriterion{nullptr};
 
     // MatchesWhen
-    MatchesWhen _eMatchesWhen;
+    MatchesWhen _eMatchesWhen{EIs};
 
     // Value
-    int32_t _iMatchValue;
+    int32_t _iMatchValue{0};
 
     // Used for XML MatchesWhen attribute parsing
     static const SMatchingRuleDescription _astMatchesWhen[ENbMatchesWhen];

--- a/parameter/SelectionCriterionRule.h
+++ b/parameter/SelectionCriterionRule.h
@@ -54,8 +54,6 @@ class CSelectionCriterionRule : public CRule
     };
 
 public:
-    CSelectionCriterionRule();
-
     // Parse
     virtual bool parse(CRuleParser& ruleParser, std::string& strError);
 

--- a/parameter/StringParameter.cpp
+++ b/parameter/StringParameter.cpp
@@ -37,10 +37,6 @@
 
 using std::string;
 
-CStringParameter::CStringParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
-{
-}
-
 CInstanceConfigurableElement::Type CStringParameter::getType() const
 {
     return EStringParameter;

--- a/parameter/StringParameter.h
+++ b/parameter/StringParameter.h
@@ -36,7 +36,7 @@
 class CStringParameter : public CBaseParameter
 {
 public:
-    CStringParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    using CBaseParameter::CBaseParameter;
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;

--- a/parameter/StringParameterType.cpp
+++ b/parameter/StringParameterType.cpp
@@ -35,7 +35,7 @@
 
 using std::string;
 
-CStringParameterType::CStringParameterType(const string& strName) : base(strName), _maxLength(0)
+CStringParameterType::CStringParameterType(const string& strName) : base(strName)
 {
 }
 

--- a/parameter/StringParameterType.cpp
+++ b/parameter/StringParameterType.cpp
@@ -35,10 +35,6 @@
 
 using std::string;
 
-CStringParameterType::CStringParameterType(const string& strName) : base(strName)
-{
-}
-
 // CElement
 string CStringParameterType::getKind() const
 {

--- a/parameter/StringParameterType.h
+++ b/parameter/StringParameterType.h
@@ -38,7 +38,7 @@
 class CStringParameterType : public CTypeElement
 {
 public:
-    CStringParameterType(const std::string& strName);
+    using CTypeElement::CTypeElement;
 
     // Max length
     size_t getMaxLength() const;

--- a/parameter/StringParameterType.h
+++ b/parameter/StringParameterType.h
@@ -59,5 +59,5 @@ private:
     virtual CInstanceConfigurableElement* doInstantiate() const;
 
     // Max length in bytes
-    size_t _maxLength;
+    size_t _maxLength{0};
 };

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -46,8 +46,7 @@ using std::ostringstream;
 
 CSubsystem::CSubsystem(const string& strName, core::log::Logger& logger)
     : base(strName), _pComponentLibrary(new CComponentLibrary),
-      _pInstanceDefinition(new CInstanceDefinition), _pMappingData(NULL),
-      _logger(logger)
+      _pInstanceDefinition(new CInstanceDefinition), _logger(logger)
 {
     // Note: A subsystem contains instance components
     // InstanceDefintion and ComponentLibrary objects are then not chosen to be children

--- a/parameter/Subsystem.h
+++ b/parameter/Subsystem.h
@@ -248,7 +248,7 @@ private:
     CInstanceDefinition* _pInstanceDefinition;
 
     //! Contains the mapping info at Subsystem level
-    CMappingData* _pMappingData;
+    CMappingData* _pMappingData{nullptr};
 
     /** Logger which has to be provided to subsystem objects */
     core::log::Logger& _logger;

--- a/parameter/SubsystemObject.cpp
+++ b/parameter/SubsystemObject.cpp
@@ -47,9 +47,7 @@ CSubsystemObject::CSubsystemObject(CInstanceConfigurableElement* pInstanceConfig
                                    core::log::Logger& logger)
     : _logger(logger),
       _pInstanceConfigurableElement(pInstanceConfigurableElement),
-      _dataSize(pInstanceConfigurableElement->getFootPrint()),
-      _blackboard(NULL),
-      _accessedIndex(0)
+      _dataSize(pInstanceConfigurableElement->getFootPrint())
 {
     // Syncer
     _pInstanceConfigurableElement->setSyncer(this);

--- a/parameter/SubsystemObject.h
+++ b/parameter/SubsystemObject.h
@@ -122,8 +122,8 @@ private:
     // Data size
     size_t _dataSize;
     // Blackboard data location
-    CParameterBlackboard* _blackboard;
+    CParameterBlackboard* _blackboard{nullptr};
     // Accessed index for Subsystem read/write from/to blackboard
-    size_t _accessedIndex;
+    size_t _accessedIndex{0};
 };
 

--- a/parameter/SubsystemObjectCreator.h
+++ b/parameter/SubsystemObjectCreator.h
@@ -52,7 +52,7 @@ public:
             const CMappingContext& context,
             core::log::Logger& logger) const = 0;
 
-    virtual ~CSubsystemObjectCreator() {}
+    virtual ~CSubsystemObjectCreator() = default;
 
 private:
     // Mapping key

--- a/parameter/Syncer.h
+++ b/parameter/Syncer.h
@@ -39,5 +39,5 @@ public:
     virtual bool sync(CParameterBlackboard& parameterBlackboard, bool bBack, std::string& strError) = 0;
 
 protected:
-    virtual ~ISyncer() {}
+    virtual ~ISyncer() = default;
 };

--- a/parameter/SyncerSet.cpp
+++ b/parameter/SyncerSet.cpp
@@ -30,10 +30,6 @@
 #include "SyncerSet.h"
 #include "Syncer.h"
 
-CSyncerSet::CSyncerSet()
-{
-}
-
 const CSyncerSet& CSyncerSet::operator+=(ISyncer* pRightSyncer)
 {
     _syncerSet.insert(pRightSyncer);

--- a/parameter/SyncerSet.h
+++ b/parameter/SyncerSet.h
@@ -39,8 +39,6 @@ class CSyncerSet
 {
     typedef std::set<ISyncer*>::const_iterator SyncerSetConstIterator;
 public:
-    CSyncerSet();
-
     // Filling
     const CSyncerSet& operator+=(ISyncer* pRightSyncer);
     const CSyncerSet& operator+=(const CSyncerSet& rightSyncerSet);

--- a/parameter/TypeElement.cpp
+++ b/parameter/TypeElement.cpp
@@ -35,10 +35,6 @@
 
 #define base CElement
 
-CTypeElement::CTypeElement(const std::string& strName) : base(strName)
-{
-}
-
 CTypeElement::~CTypeElement()
 {
     delete _pMappingData;

--- a/parameter/TypeElement.cpp
+++ b/parameter/TypeElement.cpp
@@ -35,7 +35,7 @@
 
 #define base CElement
 
-CTypeElement::CTypeElement(const std::string& strName) : base(strName), _arrayLength(0), _pMappingData(NULL)
+CTypeElement::CTypeElement(const std::string& strName) : base(strName)
 {
 }
 

--- a/parameter/TypeElement.h
+++ b/parameter/TypeElement.h
@@ -40,7 +40,8 @@ class CInstanceConfigurableElement;
 class PARAMETER_EXPORT CTypeElement : public CElement
 {
 public:
-    CTypeElement(const std::string& strName = "");
+    using CElement::CElement;
+    CTypeElement() = default;
     virtual ~CTypeElement();
 
     // Instantiation

--- a/parameter/TypeElement.h
+++ b/parameter/TypeElement.h
@@ -94,8 +94,8 @@ private:
     CMappingData* getMappingData();
 
     // For Arrays. 0 means scalar
-    size_t _arrayLength;
+    size_t _arrayLength{0};
 
     // Mapping info
-    CMappingData* _pMappingData;
+    CMappingData* _pMappingData{nullptr};
 };

--- a/parameter/XmlDomainImportContext.h
+++ b/parameter/XmlDomainImportContext.h
@@ -39,7 +39,7 @@ class CXmlDomainImportContext : public CXmlDomainSerializingContext
 {
 public:
     CXmlDomainImportContext(std::string& strError, bool bWithSettings, CSystemClass& systemClass):
-        base(strError, bWithSettings), _systemClass(systemClass), _bAutoValidationRequired(true) {}
+        base(strError, bWithSettings), _systemClass(systemClass) {}
 
     // System Class
     CSystemClass& getSystemClass() const
@@ -80,6 +80,6 @@ private:
     const CSelectionCriteriaDefinition* _pSelectionCriteriaDefinition;
 
     // Auto validation of configurations
-    bool _bAutoValidationRequired;
+    bool _bAutoValidationRequired{true};
 };
 

--- a/parameter/XmlDomainImportContext.h
+++ b/parameter/XmlDomainImportContext.h
@@ -77,7 +77,7 @@ private:
     CSystemClass& _systemClass;
 
     // Criteria defintion
-    const CSelectionCriteriaDefinition* _pSelectionCriteriaDefinition;
+    const CSelectionCriteriaDefinition* _pSelectionCriteriaDefinition{nullptr};
 
     // Auto validation of configurations
     bool _bAutoValidationRequired{true};

--- a/parameter/XmlElementSerializingContext.cpp
+++ b/parameter/XmlElementSerializingContext.cpp
@@ -33,10 +33,6 @@
 
 using std::string;
 
-CXmlElementSerializingContext::CXmlElementSerializingContext(string& strError) : base(strError)
-{
-}
-
 // Init
 void CXmlElementSerializingContext::set(const CElementLibrary* pElementLibrary, const string& xmlUri)
 {

--- a/parameter/XmlElementSerializingContext.cpp
+++ b/parameter/XmlElementSerializingContext.cpp
@@ -33,7 +33,7 @@
 
 using std::string;
 
-CXmlElementSerializingContext::CXmlElementSerializingContext(string& strError) : base(strError), _pElementLibrary(NULL)
+CXmlElementSerializingContext::CXmlElementSerializingContext(string& strError) : base(strError)
 {
 }
 

--- a/parameter/XmlElementSerializingContext.h
+++ b/parameter/XmlElementSerializingContext.h
@@ -38,7 +38,7 @@ class CElementLibrary;
 class CXmlElementSerializingContext : public CXmlSerializingContext
 {
 public:
-    CXmlElementSerializingContext(std::string& strError);
+    using CXmlSerializingContext::CXmlSerializingContext;
 
     // Init
     void set(const CElementLibrary* pElementLibrary, const std::string& xmlUri);

--- a/parameter/XmlElementSerializingContext.h
+++ b/parameter/XmlElementSerializingContext.h
@@ -49,6 +49,6 @@ public:
     // Xml URI
     const std::string& getXmlUri() const;
 private:
-    const CElementLibrary* _pElementLibrary;
+    const CElementLibrary* _pElementLibrary{nullptr};
     std::string _xmlUri;
 };

--- a/parameter/XmlParameterSerializingContext.cpp
+++ b/parameter/XmlParameterSerializingContext.cpp
@@ -33,10 +33,6 @@
 
 using std::string;
 
-CXmlParameterSerializingContext::CXmlParameterSerializingContext(string& strError) : base(strError)
-{
-}
-
 // ComponentLibrary
 void CXmlParameterSerializingContext::setComponentLibrary(const CComponentLibrary* pComponentLibrary)
 {

--- a/parameter/XmlParameterSerializingContext.h
+++ b/parameter/XmlParameterSerializingContext.h
@@ -44,5 +44,5 @@ public:
     void setComponentLibrary(const CComponentLibrary* pComponentLibrary);
     const CComponentLibrary* getComponentLibrary() const;
 private:
-    const CComponentLibrary* _pComponentLibrary;
+    const CComponentLibrary* _pComponentLibrary{nullptr};
 };

--- a/parameter/XmlParameterSerializingContext.h
+++ b/parameter/XmlParameterSerializingContext.h
@@ -38,7 +38,7 @@ class CComponentLibrary;
 class CXmlParameterSerializingContext : public CXmlElementSerializingContext
 {
 public:
-    CXmlParameterSerializingContext(std::string& strError);
+    using CXmlElementSerializingContext::CXmlElementSerializingContext;
 
     // ComponentLibrary
     void setComponentLibrary(const CComponentLibrary* pComponentLibrary);


### PR DESCRIPTION
Follows and contains part of #296.

Use C++11 features for ctors and dtors:
- defaulted methods;
- inheriting ctors;
- delegating ctors.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/297?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/297'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>