### PR TITLE
[review] Catch an uncaught exception in remote-process's main

### DIFF
--- a/remote-process/main.cpp
+++ b/remote-process/main.cpp
@@ -94,13 +94,12 @@ int main(int argc, char *argv[])
 
     tcp::socket connectionSocket(io_service);
 
-    asio::error_code ec;
-    asio::connect(connectionSocket, resolver.resolve(tcp::resolver::query(argv[1], (argv[2]))), ec);
-
-    if (ec) {
-
-        cerr << "Connexion failed: " << ec.message() << endl;
-
+    string host{argv[1]};
+    string port{argv[2]};
+    try {
+        asio::connect(connectionSocket, resolver.resolve(tcp::resolver::query(host, port)));
+    } catch (const asio::system_error &e) {
+        cerr << "Connection to '" << host << ":"<< port << "' failed: " << e.what() << endl;
         return 1;
     }
 


### PR DESCRIPTION
Errors thrown by the name/service resolver were not properly caught and were
escaping main().

Wrap resolution and connection in a try-catch block and unify error detection
in both steps (one was using an output argument, the other was using
exceptions).

@tcahuzax @krocard Please review.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/301%23issuecomment-152131224%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/301%23issuecomment-152579348%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/301%23discussion_r43499307%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/301%23discussion_r43508830%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/301%23issuecomment-152131224%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-29T09%3A51%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-30T16%3A31%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2009d4070dd80d6f8cfa01aaf07a26916384ce0499%20remote-process/main.cpp%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/301%23discussion_r43499307%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20add%20the%20port%20and%20host%20in%20the%20message.%5Cr%5Cn%20%20%20%20%20cerr%20%3C%3C%20%5C%22Connection%20failed%20to%20%5C%22%20%3C%3C%20host%20%3C%3C%20%5C%22%20%5C%22%20port%20%3C%3C%20%5C%22%3A%20%5C%22%20%3C%3C%20%20e.what%28%29%20%3C%3C%20endl%3B%22%2C%20%22created_at%22%3A%20%222015-10-30T13%3A03%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20done%22%2C%20%22created_at%22%3A%20%222015-10-30T14%3A40%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20remote-process/main.cpp%3AL94-106%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull 09d4070dd80d6f8cfa01aaf07a26916384ce0499 remote-process/main.cpp 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/301#discussion_r43499307'>File: remote-process/main.cpp:L94-106</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> maybe add the port and host in the message.
cerr << "Connection failed to " << host << " " port << ": " <<  e.what() << endl;
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> :+1: done


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/301?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/301?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/301?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/301'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>