### PR TITLE
[review] Fix {structure,setting} {import,export}

### DIFF
--- a/parameter/BitParameterBlock.h
+++ b/parameter/BitParameterBlock.h
@@ -47,5 +47,12 @@ public:
 
     // Used for simulation and virtual subsystems
     virtual void setDefaultValues(CParameterAccessContext& parameterAccessContext) const;
+
+    void structureToXml(CXmlElement &xmlElement,
+                        CXmlSerializingContext &serializingContext) const
+    {
+        xmlElement.setAttribute("Size", getSize() * 8);
+        CInstanceConfigurableElement::structureToXml(xmlElement, serializingContext);
+    }
 };
 

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -241,7 +241,7 @@ bool CConfigurableElement::setSettingsAsBytes(const std::vector<uint8_t>& bytes,
     CSyncerSet syncerSet;
     fillSyncerSet(syncerSet);
     core::Results res;
-    if (not syncerSet.sync(*parameterAccessContext.getParameterBlackboard(), true, &res)) {
+    if (not syncerSet.sync(*parameterAccessContext.getParameterBlackboard(), false, &res)) {
 
         parameterAccessContext.setError(utility::asString(res));
         return false;

--- a/parameter/ElementHandle.cpp
+++ b/parameter/ElementHandle.cpp
@@ -30,6 +30,7 @@
 #include "ElementHandle.h"
 #include "ParameterAccessContext.h"
 #include "BaseParameter.h"
+#include "XmlParameterSerializingContext.h"
 #include "Subsystem.h"
 #include <assert.h>
 #include "ParameterMgr.h"
@@ -124,13 +125,12 @@ bool ElementHandle::getMappingData(const string& strKey, string& strValue) const
 
 bool ElementHandle::getStructureAsXML(std::string &xmlSettings, std::string &error) const
 {
-    string result;
-    if (not mParameterMgr.exportElementToXMLString(&mElement, mElement.getXmlElementName(), result)) {
-        error = result;
-        return false;
-    }
-    xmlSettings = result;
-    return true;
+    // Use default access context for structure export
+    CParameterAccessContext accessContext(error);
+    return mParameterMgr.exportElementToXMLString(
+                &mElement, mElement.getXmlElementName(),
+                CXmlParameterSerializingContext{accessContext, error},
+                xmlSettings);
 }
 
 template <class T>

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -1510,7 +1510,7 @@ bool CParameterMgr::setSettingsAsXML(CConfigurableElement *configurableElement,
         CSyncerSet syncerSet;
         static_cast<CConfigurableElement *>(configurableElement)->fillSyncerSet(syncerSet);
         core::Results results;
-        if(not syncerSet.sync(*_pMainParameterBlackboard, true, &results)) {
+        if(not syncerSet.sync(*_pMainParameterBlackboard, false, &results)) {
             result = utility::asString(results);
 
             return false;

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -1082,6 +1082,7 @@ CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::listCriteriaCommand
         const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition = getConstSelectionCriteria()->getSelectionCriteriaDefinition();
 
         if (!exportElementToXMLString(pSelectionCriteriaDefinition, "SelectionCriteria",
+                                      CXmlSerializingContext{strResult},
                                       strResult)) {
 
             return CCommandHandler::EFailed;
@@ -1356,7 +1357,11 @@ CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::getElementStructure
         return CCommandHandler::EFailed;
     }
 
-    if (!exportElementToXMLString(pLocatedElement, pLocatedElement->getXmlElementName(), strResult)) {
+    // Use default access context for structure export
+    CParameterAccessContext accessContext(strResult);
+    if (!exportElementToXMLString(pLocatedElement, pLocatedElement->getXmlElementName(),
+                                  CXmlParameterSerializingContext{accessContext, strResult},
+                                  strResult)) {
 
         return CCommandHandler::EFailed;
     }
@@ -1860,8 +1865,11 @@ CParameterMgr::CCommandHandler::CommandStatus
     // Get Root element where to export from
     const CSystemClass* pSystemClass = getSystemClass();
 
-    if (!exportElementToXMLString(pSystemClass, pSystemClass->getXmlElementName(), strResult)) {
-
+    // Use default access context for structure export
+    CParameterAccessContext accessContext(strResult);
+    if (!exportElementToXMLString(pSystemClass, pSystemClass->getXmlElementName(),
+                                  CXmlParameterSerializingContext{accessContext, strResult},
+                                  strResult)) {
         return CCommandHandler::EFailed;
     }
     // Succeeded
@@ -2814,12 +2822,9 @@ void CParameterMgr::doApplyConfigurations(bool bForce)
 // Export to XML string
 bool CParameterMgr::exportElementToXMLString(const IXmlSource* pXmlSource,
                                              const string& strRootElementType,
+                                             CXmlSerializingContext &&xmlSerializingContext,
                                              string& strResult) const
 {
-    string strError;
-
-    CXmlSerializingContext xmlSerializingContext(strError);
-
     // Use a doc source by loading data from instantiated Configurable Domains
     CXmlMemoryDocSource memorySource(pXmlSource, false, strRootElementType);
 
@@ -2830,11 +2835,7 @@ bool CParameterMgr::exportElementToXMLString(const IXmlSource* pXmlSource,
     // Do the export
     bool bProcessSuccess = streamSink.process(memorySource, xmlSerializingContext);
 
-    if (bProcessSuccess) {
-        strResult = output.str();
-    } else {
-        strResult = strError;
-    }
+    strResult = output.str();
 
     return bProcessSuccess;
 }

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -370,12 +370,18 @@ public:
       *
       * @param[in] pXmlSource The source element to export
       * @param[in] strRootElementType The XML root element name of the exported instance document
+      * @param[in] xmlSerializingContext the context to use for serialization
+      *                                  Is an rvalue as it must be destructed after this function
+      *                                  call to set the error.
+      *                                  Additionally, using it for an other serialization would
+      *                                  override the error.
       * @param[out] strResult contains the xml description or the error description in case false is returned
       *
       * @return true for success, false if any error occurs during the creation of the xml description (validation or encoding)
       */
     bool exportElementToXMLString(const IXmlSource* pXmlSource,
                                   const std::string& strRootElementType,
+                                  CXmlSerializingContext &&xmlSerializingContext,
                                   std::string& strResult) const;
 
     // CElement


### PR DESCRIPTION
- element export could have a wrong context, leading to incorrect down cast
 - set xml and binary element were back sync rather than forward sync
 - size of bitParameter was not exported
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/304%23issuecomment-154024806%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23issuecomment-154062068%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23issuecomment-155013478%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23issuecomment-155021283%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23issuecomment-155021371%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23discussion_r43999804%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23discussion_r43999837%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23discussion_r44007279%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23discussion_r44160692%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23discussion_r44160703%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/304%23issuecomment-155021807%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/304%23issuecomment-154024806%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%40dawagner%20%40tcahuzax%20please%20reviwe%22%2C%20%22created_at%22%3A%20%222015-11-05T10%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%22%2C%20%22created_at%22%3A%20%222015-11-05T13%3A45%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20all%20comments%20answered%2C%20%40tcahuzax%20%40dawagner%20please%20review%20again.%22%2C%20%22created_at%22%3A%20%222015-11-09T09%3A48%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-09T10%3A20%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-11-09T10%3A20%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-09T10%3A23%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b845207a1ef4cd7bb6a1c3ca4949eac65fa1ca3c%20parameter/ParameterMgr.cpp%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/304%23discussion_r43999837%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ditto%22%2C%20%22created_at%22%3A%20%222015-11-05T11%3A06%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22ditto%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-06T17%3A04%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.cpp%3AL1357-1368%22%7D%2C%20%22Pull%20b845207a1ef4cd7bb6a1c3ca4949eac65fa1ca3c%20parameter/ParameterMgr.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/304%23discussion_r44007279%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22input%20parameter%20only.%22%2C%20%22created_at%22%3A%20%222015-11-05T12%3A44%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.h%3AL370-384%22%7D%2C%20%22Pull%20b845207a1ef4cd7bb6a1c3ca4949eac65fa1ca3c%20parameter/ElementHandle.cpp%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/304%23discussion_r43999804%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Coding%20style%20inconsistencies%3A%20you%20define%20%60accessContext%60%20a%29%20in%20its%20own%20line%20and%20b%29%20using%20parentheses%20but%20you%20define%20the%20serializing%20context%20a%29%20in%20the%20argument%20list%20and%20b%29%20using%20braces.%22%2C%20%22created_at%22%3A%20%222015-11-05T11%3A05%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22answered%20in%20doxygen%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-06T17%3A04%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ElementHandle.cpp%3AL125-137%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/dawagner%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%7D%2C%20%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/dawagner'><img src='https://avatars.githubusercontent.com/u/6430928?v=3' width=34 height=34></a><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull b845207a1ef4cd7bb6a1c3ca4949eac65fa1ca3c parameter/ParameterMgr.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/304#discussion_r44007279'>File: parameter/ParameterMgr.h:L370-384</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> input parameter only.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/304#issuecomment-154024806'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: @dawagner @tcahuzax please reviwe
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :-1:
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: all comments answered, @tcahuzax @dawagner please review again.
- [x] <a href='#crh-comment-Pull b845207a1ef4cd7bb6a1c3ca4949eac65fa1ca3c parameter/ElementHandle.cpp 23'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/304#discussion_r43999804'>File: parameter/ElementHandle.cpp:L125-137</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Coding style inconsistencies: you define `accessContext` a) in its own line and b) using parentheses but you define the serializing context a) in the argument list and b) using braces.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> answered in doxygen :+1:
- [x] <a href='#crh-comment-Pull b845207a1ef4cd7bb6a1c3ca4949eac65fa1ca3c parameter/ParameterMgr.cpp 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/304#discussion_r43999837'>File: parameter/ParameterMgr.cpp:L1357-1368</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> ditto
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> ditto :+1:


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/304?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/304?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/304?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/304'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>