### PR TITLE
[review] Fix and test structure & settings export

### DIFF
--- a/bindings/python/pfw.i
+++ b/bindings/python/pfw.i
@@ -91,16 +91,16 @@ public:
     bool getForceNoRemoteInterface() const;
     void setForceNoRemoteInterface(bool bForceNoRemoteInterface);
 
-    void setFailureOnMissingSubsystem(bool bFail);
+    bool setFailureOnMissingSubsystem(bool bFail, std::string& strError);
     bool getFailureOnMissingSubsystem() const;
 
-    void setFailureOnFailedSettingsLoad(bool bFail);
+    bool setFailureOnFailedSettingsLoad(bool bFail, std::string& strError);
     bool getFailureOnFailedSettingsLoad() const;
 
     void setSchemaUri(const std::string& schemaUri);
     const std::string& getSchemaUri() const;
 
-    void setValidateSchemasOnStart(bool bValidate);
+    bool setValidateSchemasOnStart(bool bValidate, std::string &strError);
     bool getValidateSchemasOnStart() const;
 
     // Tuning mode

--- a/parameter/BaseParameter.cpp
+++ b/parameter/BaseParameter.cpp
@@ -66,7 +66,7 @@ bool CBaseParameter::serializeXmlSettings(CXmlElement& xmlConfigurationSettingsE
     }
 
     // Done
-    return true;
+    return base::serializeXmlSettings(xmlConfigurationSettingsElementContent, configurationAccessContext);
 }
 
 // Dump

--- a/parameter/BitParameterBlock.cpp
+++ b/parameter/BitParameterBlock.cpp
@@ -60,8 +60,11 @@ size_t CBitParameterBlock::getSize() const
 // Used for simulation and virtual subsystems
 void CBitParameterBlock::setDefaultValues(CParameterAccessContext& parameterAccessContext) const
 {
-    // Get default value from type
-    uint32_t uiDefaultValue = 0;
+    // Default value is 0 as their is no min bound for bit parameters,
+    // thus 0 is always a valid value.
+    // BitParameterBlock can be as long a 64 bit, thus an 64 bit long variable
+    // is necessary to initialize it.
+    uint64_t uiDefaultValue = 0;
 
     // Write blackboard
     CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -96,7 +96,10 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
             if (!it.next(xmlChildConfigurableElementSettingsElement)) {
 
                 // Structure error
-                configurationAccessContext.setError("Configuration settings parsing: Settings don't conform to structure of configurable element " + getName());
+                configurationAccessContext.setError(
+                        "Configuration settings parsing: missing child node " +
+                        pChildConfigurableElement->getXmlElementName() +
+                        " (name:" + pChildConfigurableElement->getName() + ") in " + getName());
 
                 return false;
             }
@@ -119,7 +122,7 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
 
                     // Type error
                     configurationAccessContext.setError("Configuration settings parsing: Settings "
-                        "for configurable element " + pChildConfigurableElement->getName() +
+                        "for configurable element " + pChildConfigurableElement->getQualifiedPath() +
                         " does not match expected type: " +
                         xmlChildConfigurableElementSettingsElement.getType() + " instead of " +
                         pChildConfigurableElement->getKind());
@@ -131,7 +134,11 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
             if (xmlChildConfigurableElementSettingsElement.getNameAttribute() != pChildConfigurableElement->getName()) {
 
                 // Name error
-                configurationAccessContext.setError("Configuration settings parsing: Under configurable elememnt " + getName() + ", expected element name " + pChildConfigurableElement->getName() + " but found " + xmlChildConfigurableElementSettingsElement.getNameAttribute() + " instead");
+                configurationAccessContext.setError(
+                        "Configuration settings parsing: Under configurable element " +
+                        getQualifiedPath() + ", expected element name " +
+                        pChildConfigurableElement->getName() + " but found " +
+                        xmlChildConfigurableElementSettingsElement.getNameAttribute() + " instead");
 
                 return false;
             }
@@ -146,7 +153,10 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
         if (it.next(xmlChildConfigurableElementSettingsElement)) {
 
             // Structure error
-            configurationAccessContext.setError("Configuration settings parsing: Settings don't conform to structure of configurable element " + getName());
+            configurationAccessContext.setError(
+                    "Configuration settings parsing: Unexpected xml element node " +
+                    xmlChildConfigurableElementSettingsElement.getType() +
+                    " in " + getQualifiedPath());
 
             return false;
         }

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -151,6 +151,9 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
             return false;
         }
     } else {
+        // Handle element name attribute
+        xmlConfigurationSettingsElementContent.setNameAttribute(getName());
+
         // Propagate to children
         for (size_t index = 0; index < uiNbChildren; index++) {
 
@@ -160,9 +163,6 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
             CXmlElement xmlChildConfigurableElementSettingsElement;
 
             xmlConfigurationSettingsElementContent.createChild(xmlChildConfigurableElementSettingsElement, pChildConfigurableElement->getXmlElementName());
-
-            // Handle element name attribute
-            xmlChildConfigurableElementSettingsElement.setNameAttribute(pChildConfigurableElement->getName());
 
             // Propagate
             pChildConfigurableElement->serializeXmlSettings(xmlChildConfigurableElementSettingsElement, configurationAccessContext);

--- a/parameter/DomainConfiguration.cpp
+++ b/parameter/DomainConfiguration.cpp
@@ -196,7 +196,6 @@ bool CDomainConfiguration::exportOneConfigurableElementSettings(
     // Create child XML element
     CXmlElement xmlConfigurableElementSettingsElementContent;
     xmlConfigurableElementSettingsElement.createChild(xmlConfigurableElementSettingsElementContent, source->getXmlElementName());
-    xmlConfigurableElementSettingsElementContent.setNameAttribute(source->getName());
 
     // Create configuration access context
     string error;

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -1487,9 +1487,8 @@ bool CParameterMgr::getSettingsAsXML(const CConfigurableElement *configurableEle
 }
 
 bool CParameterMgr::setSettingsAsXML(CConfigurableElement *configurableElement,
-        const string &settings, string &result)
+        const string &settings, string &error)
 {
-    string error;
     CConfigurationAccessContext configContext(error, _pMainParameterBlackboard,
                                               _bValueSpaceIsRaw, _bOutputRawFormatIsHex, false);
 
@@ -1509,9 +1508,9 @@ bool CParameterMgr::setSettingsAsXML(CConfigurableElement *configurableElement,
     if (_bAutoSyncOn) {
         CSyncerSet syncerSet;
         static_cast<CConfigurableElement *>(configurableElement)->fillSyncerSet(syncerSet);
-        core::Results results;
-        if(not syncerSet.sync(*_pMainParameterBlackboard, false, &results)) {
-            result = utility::asString(results);
+        core::Results errors;
+        if(not syncerSet.sync(*_pMainParameterBlackboard, false, &errors)) {
+            error = utility::asString(errors);
 
             return false;
         }

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -626,13 +626,15 @@ private:
      * @param[in] input the input XML stream
      * @param[in] baseUri the XML input file URI or ""
      * @param[in] eElementLibrary which element library to be used
+     * @param[in] replace Should the element be overridden or modified in place
      * @param[in] strNameAttributeName the name of the element's XML "name" attribute
      *
      * @returns true if parsing succeeded, false otherwise
      */
     bool xmlParse(CXmlElementSerializingContext& elementSerializingContext, CElement* pRootElement,
                   _xmlDoc* doc, const std::string& baseUri,
-                  ElementLibrary eElementLibrary, const std::string& strNameAttributeName = "Name");
+                  ElementLibrary eElementLibrary, bool replace = true,
+                  const std::string& strNameAttributeName = "Name");
 
     /** Wrapper for converting public APIs semantics to internal API
      *

--- a/parameter/ParameterMgrFullConnector.cpp
+++ b/parameter/ParameterMgrFullConnector.cpp
@@ -35,127 +35,25 @@
 
 using std::string;
 
-CParameterMgrFullConnector::CParameterMgrFullConnector(const string& strConfigurationFilePath) :
-    _pParameterMgrLogger(new CParameterMgrLogger<CParameterMgrFullConnector>(*this)),
-    _pParameterMgr(new CParameterMgr(strConfigurationFilePath, *_pParameterMgrLogger)),
-    _pLogger(NULL)
-{
-}
-
-CParameterMgrFullConnector::~CParameterMgrFullConnector()
-{
-    delete _pParameterMgr;
-    delete _pParameterMgrLogger;
-}
-
-
-bool CParameterMgrFullConnector::start(string& strError)
-{
-    // Create data structure & Init flow
-    return _pParameterMgr->load(strError);
-}
-
-void CParameterMgrFullConnector::setLogger(CParameterMgrFullConnector::ILogger* pLogger)
-{
-    _pLogger = pLogger;
-}
-
-// Private logging
-void CParameterMgrFullConnector::info(const string& log)
-{
-    if (_pLogger) {
-
-        _pLogger->info(log);
-    }
-}
-
-void CParameterMgrFullConnector::warning(const string& log)
-{
-    if (_pLogger) {
-
-        _pLogger->warning(log);
-    }
-}
-
-CParameterHandle* CParameterMgrFullConnector::createParameterHandle(const string& strPath,
-                                                                    string& strError)
-{
-    return _pParameterMgr->createParameterHandle(strPath, strError);
-}
-
-ISelectionCriterionTypeInterface* CParameterMgrFullConnector::createSelectionCriterionType(
-        bool bIsInclusive)
-{
-    return _pParameterMgr->createSelectionCriterionType(bIsInclusive);
-}
-
-ISelectionCriterionInterface* CParameterMgrFullConnector::createSelectionCriterion(
-        const string& strName,
-        const ISelectionCriterionTypeInterface* pSelectionCriterionType)
-{
-    return _pParameterMgr->createSelectionCriterion(strName,
-            static_cast<const CSelectionCriterionType*>(pSelectionCriterionType));
-}
-
-ISelectionCriterionInterface* CParameterMgrFullConnector::getSelectionCriterion(
-        const string& strName)
-{
-    return _pParameterMgr->getSelectionCriterion(strName);
-}
-
-bool CParameterMgrFullConnector::getForceNoRemoteInterface() const
-{
-    return _pParameterMgr->getForceNoRemoteInterface();
-}
-
-void CParameterMgrFullConnector::setForceNoRemoteInterface(bool bForceNoRemoteInterface)
-{
-    _pParameterMgr->setForceNoRemoteInterface(bForceNoRemoteInterface);
-}
-
-void CParameterMgrFullConnector::applyConfigurations()
-{
-    return _pParameterMgr->applyConfigurations();
-}
+CParameterMgrFullConnector::CParameterMgrFullConnector(const string& strConfigurationFilePath)
+    : CParameterMgrPlatformConnector(strConfigurationFilePath) {}
 
 void CParameterMgrFullConnector::setFailureOnMissingSubsystem(bool bFail)
 {
-    _pParameterMgr->setFailureOnMissingSubsystem(bFail);
-}
-
-bool CParameterMgrFullConnector::getFailureOnMissingSubsystem() const
-{
-    return _pParameterMgr->getFailureOnMissingSubsystem();
+    std::string error;
+    setFailureOnMissingSubsystem(bFail, error);
 }
 
 void CParameterMgrFullConnector::setFailureOnFailedSettingsLoad(bool bFail)
 {
-    _pParameterMgr->setFailureOnFailedSettingsLoad(bFail);
-}
-
-bool CParameterMgrFullConnector::getFailureOnFailedSettingsLoad() const
-{
-    return _pParameterMgr->getFailureOnFailedSettingsLoad();
-}
-
-const string& CParameterMgrFullConnector::getSchemaUri() const
-{
-    return _pParameterMgr->getSchemaUri();
-}
-
-void CParameterMgrFullConnector::setSchemaUri(const string& schemaUri)
-{
-    _pParameterMgr->setSchemaUri(schemaUri);
+    std::string error;
+    setFailureOnFailedSettingsLoad(bFail, error);
 }
 
 void CParameterMgrFullConnector::setValidateSchemasOnStart(bool bValidate)
 {
-    _pParameterMgr->setValidateSchemasOnStart(bValidate);
-}
-
-bool CParameterMgrFullConnector::getValidateSchemasOnStart() const
-{
-    return _pParameterMgr->getValidateSchemasOnStart();
+    std::string error;
+    setValidateSchemasOnStart(bValidate, error);
 }
 
 bool CParameterMgrFullConnector::setTuningMode(bool bOn, string& strError)

--- a/parameter/StringParameter.cpp
+++ b/parameter/StringParameter.cpp
@@ -69,8 +69,10 @@ void CStringParameter::setDefaultValues(CParameterAccessContext& parameterAccess
 bool CStringParameter::doSetValue(const string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const
 {
     if (strValue.length() >= getSize()) {
-
-        parameterAccessContext.setError("Maximum length exceeded");
+        using std::to_string;
+        parameterAccessContext.setError(
+                "Can not set a string of length " + to_string(strValue.length()) +
+                ": maximum length is " + std::to_string(getSize() - 1));
 
         return false;
     }

--- a/parameter/include/ParameterMgrFullConnector.h
+++ b/parameter/include/ParameterMgrFullConnector.h
@@ -35,6 +35,7 @@
 #include "SelectionCriterionInterface.h"
 #include "ParameterHandle.h"
 #include "ParameterMgrLoggerForward.h"
+#include "ParameterMgrPlatformConnector.h"
 
 #include <string>
 #include <list>
@@ -43,119 +44,33 @@
 
 class CParameterMgr;
 
-class PARAMETER_EXPORT CParameterMgrFullConnector
+class PARAMETER_EXPORT CParameterMgrFullConnector : public CParameterMgrPlatformConnector
 {
-    friend class CParameterMgrLogger<CParameterMgrFullConnector>;
-
 public:
 
     /** String list type which can hold list of error/info and can be presented to client */
     typedef std::list<std::string> Results;
 
     CParameterMgrFullConnector(const std::string& strConfigurationFilePath);
-    ~CParameterMgrFullConnector();
 
-    /** Interface to implement to provide a custom logger to the PF.
-     *
-      * Either:
-      *     - override info and warning methods
-      *     - override the log method
-      *
-      * Choice between the 2 is left to the client convenience.
-      * @Note Errors are always returned synchronously. Never logged.
-      */
-    class ILogger
-    {
-    public:
-        virtual void info(const std::string& strLog) = 0;
-        virtual void warning(const std::string& strLog) = 0;
-    protected:
-        virtual ~ILogger() {}
-    };
-    // Logging
-    /** Should be called before start */
-    void setLogger(ILogger* pLogger);
-
-
-    bool start(std::string& strError);
-
-    // Dynamic parameter handling
-    CParameterHandle* createParameterHandle(const std::string& strPath, std::string& strError);
-
-    ISelectionCriterionTypeInterface* createSelectionCriterionType(bool bIsInclusive);
-    ISelectionCriterionInterface* createSelectionCriterion(const std::string& strName,
-            const ISelectionCriterionTypeInterface* pSelectionCriterionType);
-    ISelectionCriterionInterface* getSelectionCriterion(const std::string& strName);
-
-    /** Is the remote interface forcefully disabled ?
+    /** @deprecated Same as its overload without error handling.
+     * @note this deprecated method in not available in the python wrapper.
      */
-    bool getForceNoRemoteInterface() const;
-
-    /**
-     * Forcefully disable the remote interface or cancel this policy.
-     *
-     * Has no effect if called after calling start().
-     *
-     * @param[in] bForceNoRemoteInterface disable the remote interface if true.
-     */
-    void setForceNoRemoteInterface(bool bForceNoRemoteInterface);
-
-    void applyConfigurations();
-
-    /** Should start fail in case of missing subsystems.
-      *
-      * @param[in] bFail: If set to true,  parameterMgr start will fail on missing subsystems.
-      *                   If set to false, missing subsystems will fallback on virtual subsystem.
-      */
     void setFailureOnMissingSubsystem(bool bFail);
+    using CParameterMgrPlatformConnector::setFailureOnMissingSubsystem;
 
-    /** Would start fail in case of missing subsystems.
-      *
-      * @return true if the subsystem will fail on missing subsystem, false otherwise.
-      */
-    bool getFailureOnMissingSubsystem() const;
-
-    /** Should start fail in failed settings load.
-      *
-      * @param[in] bFail: If set to true, parameterMgr start will fail on failed settings load.
-      *                   If set to false, failed settings load will be ignored.
-      */
+    /** @deprecated Same as its overload without error handling.
+     * @note this deprecated method in not available in the python wrapper.
+     */
     void setFailureOnFailedSettingsLoad(bool bFail);
-    /** Would start fail in case of failed settings load.
-      *
-      * @return failure on failed settings load policy state.
-      */
-    bool getFailureOnFailedSettingsLoad() const;
+    using CParameterMgrPlatformConnector::setFailureOnFailedSettingsLoad;
 
-    /** Get the XML Schemas URI
-     *
-     * @returns the XML Schemas URI
-     */
-    const std::string& getSchemaUri() const;
-
-    /** Override the XML Schemas URI
-     *
-     * @param[in] schemaUri the XML Schemas URI
-     */
-    void setSchemaUri(const std::string& schemaUri);
-
-    /** Should .xml files be validated on start ?
-     *
-     * @param[in] bValidate:
-     *     If set to true, parameterMgr will report an error
-     *         when being unable to validate .xml files
-     *     If set to false, no .xml/xsd validation will happen
-     *     (default behaviour)
-     *
-     * @return false if unable to set, true otherwise.
+    /** @deprecated Same as its overload without error handling.
+     * @note this deprecated method in not available in the python wrapper.
      */
     void setValidateSchemasOnStart(bool bValidate);
+    using CParameterMgrPlatformConnector::setValidateSchemasOnStart;
 
-    /** Would .xml files be validated on start?
-     *
-     * @return areSchemasValidated
-     */
-    bool getValidateSchemasOnStart() const;
     //////////// Tuning /////////////
     // Tuning mode
     bool setTuningMode(bool bOn, std::string& strError);
@@ -305,14 +220,4 @@ private:
     // disallow copying because this class manages raw pointers' lifecycle
     CParameterMgrFullConnector(const CParameterMgrFullConnector&);
     CParameterMgrFullConnector& operator=(const CParameterMgrFullConnector&);
-
-    void info(const std::string& log);
-    void warning(const std::string& log);
-
-    // Log wrapper
-    CParameterMgrLogger<CParameterMgrFullConnector>* _pParameterMgrLogger;
-
-    CParameterMgr* _pParameterMgr;
-
-    ILogger* _pLogger;
 };

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -43,7 +43,13 @@ class PARAMETER_EXPORT CParameterMgrPlatformConnector
 {
     friend class CParameterMgrLogger<CParameterMgrPlatformConnector>;
 public:
-    // Logger interface
+    /** Interface to implement to provide a custom logger to the PF.
+     *
+     * Override info and warning methods to specify how each log level
+     * should be printed.
+     *
+     * @Note Errors are always returned synchronously. Never logged.
+     */
     class ILogger
     {
     public:
@@ -55,7 +61,7 @@ public:
 
     // Construction
     CParameterMgrPlatformConnector(const std::string& strConfigurationFilePath);
-    ~CParameterMgrPlatformConnector(); // Not virtual since not supposed to be derived!
+    virtual ~CParameterMgrPlatformConnector();
 
     // Selection Criteria interface. Beware returned objects are lent, clients shall not delete them!
     // Should be called before start
@@ -180,6 +186,7 @@ private:
     void info(const std::string& log);
     void warning(const std::string& log);
 
+protected:
     // Private logging
     CParameterMgrLogger<CParameterMgrPlatformConnector>* _pParameterMgrLogger;
     // Implementation

--- a/test/functional-tests/CMakeLists.txt
+++ b/test/functional-tests/CMakeLists.txt
@@ -27,15 +27,24 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 if(BUILD_TESTING)
-    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+    find_package(LibXml2 REQUIRED)
+
+    # TODO: create a libxml2 library to properly export those definition & include
+    #       so that client only have to link with libxml2
+    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include"
+                        ${LIBXML2_INCLUDE_DIR})
 
     # Add unit test
     add_executable(parameterFunctionalTest
                    Basic.cpp
-                   FloatingPoint.cpp)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+                   FloatingPoint.cpp
+                   Handle.cpp)
 
-    target_link_libraries(parameterFunctionalTest parameter catch tmpfile)
+    target_link_libraries(parameterFunctionalTest
+                          parameter catch tmpfile ${LIBXML2_LIBRARIES})
+
+    target_compile_definitions(parameterFunctionalTest PRIVATE "${LIBXML2_DEFINITIONS}")
+
     add_test(NAME parameterFunctionalTest
              COMMAND parameterFunctionalTest)
 

--- a/test/functional-tests/FloatingPoint.cpp
+++ b/test/functional-tests/FloatingPoint.cpp
@@ -30,6 +30,7 @@
 
 #include "Config.hpp"
 #include "ParameterFramework.hpp"
+#include "ElementHandle.hpp"
 #include "Test.hpp"
 
 #include <catch.hpp>
@@ -145,10 +146,7 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
             }
 
             AND_THEN("Set/Get floating point parameter handle") {
-                /** @TODO: use move semantics to get an owned object so that
-                 * it will destroyed automatically */
-                ParameterHandle *handle;
-                CHECK_NOTHROW(handle = createParameterHandle(path));
+                ElementHandle handle{*this, path};
                 /** @FIXME: 'set' operations on a ParameterHandle are silently
                  * ignored in tuning mode. Does it make sense ? */
                 REQUIRE_NOTHROW(setTuningMode(false));
@@ -162,9 +160,9 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
                             { "(inside range)", 0.0f },
                         }) {
                     GIVEN("A valid value " + vec.title) {
-                        CHECK_NOTHROW(handle->setAsDouble(vec.payload));
+                        CHECK_NOTHROW(handle.setAsDouble(vec.payload));
                         double getValueBack;
-                        CHECK_NOTHROW(handle->getAsDouble(getValueBack));
+                        CHECK_NOTHROW(handle.getAsDouble(getValueBack));
                         CHECK(getValueBack == vec.payload);
                     }
                 }
@@ -173,10 +171,9 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
                             { "(too low)", -50.5f },
                         }) {
                     GIVEN("An invalid value " + vec.title) {
-                        CHECK_THROWS_AS(handle->setAsDouble(vec.payload), Exception);
+                        CHECK_THROWS_AS(handle.setAsDouble(vec.payload), Exception);
                     }
                 }
-                delete handle;
             }
         }
     }

--- a/test/functional-tests/Handle.cpp
+++ b/test/functional-tests/Handle.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.hpp"
+#include "Test.hpp"
+#include "Exception.hpp"
+#include "TmpFile.hpp"
+
+#include "ParameterFramework.hpp"
+#include "ElementHandle.hpp"
+
+#include <catch.hpp>
+
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+#include <string>
+
+using std::string;
+using Bytes = std::vector<uint8_t>;
+
+namespace parameterFramework
+{
+
+struct AllParamsPF : public ParameterFramework
+{
+    AllParamsPF() : ParameterFramework{getConfig()}
+    {
+        REQUIRE_NOTHROW(start());
+    }
+
+    string getBasicParams()
+    {
+        string structure = R"(
+            <BooleanParameter Name="bool" Description="bool"/>
+            <BooleanParameter ArrayLength="2" Name="bool_array" Description="bool-array"/>
+
+            <IntegerParameter Signed="false" Min="33" Max="123" Size="16" Name="integer"/>
+            <IntegerParameter Signed="true" Min="-10" Max="10" Size="32" ArrayLength="4" Name="integer_array"/>
+
+            <FixedPointParameter Size="32" Integral="3" Fractional="4" Name="fix_point"/>
+            <FixedPointParameter Size="32" Integral="3" Fractional="4" ArrayLength="3" Name="fix_point_array"/>
+
+            <EnumParameter Size="8" Name="enum">
+                <ValuePair Literal="min"  Numerical="-128"/>
+                <ValuePair Literal="five" Numerical="5"/>
+                <ValuePair Literal="max"  Numerical="127"/>
+            </EnumParameter>
+            <EnumParameter Size="16" ArrayLength="4" Name="enum_array">
+                <ValuePair Literal="eight"  Numerical="8"/>
+                <ValuePair Literal="min"  Numerical="-32767"/>
+            </EnumParameter>)";
+
+        // String and bit parameter arrays are not supported
+        structure += R"(
+            <StringParameter MaxLength="63" Name="string"/>
+
+            <BitParameterBlock Size="64" Name="bit_block">
+                <BitParameter Pos="1"  Size="1"  Max="1"  Name="one"/>
+                <BitParameter Pos="2"  Size="2"  Max="2"  Name="two"/>
+                <BitParameter Pos="6"  Size="6"  Max="10" Name="six"/>
+                <BitParameter Pos="16" Size="16" Max="99" Name="sixteen"/>
+                <BitParameter Pos="32" Size="32" Max="4294967295" Name="thirty_two"/>
+            </BitParameterBlock>
+            )";
+        return structure;
+    }
+
+    Config getConfig()
+    {
+        Config config;
+        config.components = nodeDesc("ComponentType", "component_type", getBasicParams());
+        config.instances = getBasicParams() +
+                           nodeDesc("ParameterBlock", "parameter_block",getBasicParams()) +
+                           nodeDesc("ParameterBlock", "parameter_block_array",
+                                    getBasicParams(), "ArrayLength='2'") +
+                           nodeDesc("Component", "component_scalar", "", "Type='component_type'") +
+                           // Test that ArrayLength have no effect on components
+                           nodeDesc("Component", "component_array", "",
+                                    "Type='component_type' ArrayLength='2'");
+        return config;
+   }
+
+    void checkStructure(const string &path, const string &expected)
+    {
+        CHECK_NOTHROW(checkXMLEq(ElementHandle{*this, path}.getStructureAsXML(),
+                      expected));
+    }
+
+    /** Use libxml2 to pretty format xml.
+     * Equivalent of xmllint --format
+     */
+    static string canonicalizeXML(const string &xml)
+    {
+        // Parse xml
+        // Might be better to specialize std::default_delete<xmlDoc>.
+        std::unique_ptr<xmlDoc, void(*)(xmlDoc *)> doc{
+                xmlReadMemory(xml.c_str(), (int)xml.length(), "structure.xml", nullptr, XML_PARSE_NOBLANKS),
+                xmlFreeDoc};
+        if (doc == nullptr) {
+            throw Exception{"Failed to parse document: " + xml};
+        }
+
+        // Dump it formated
+        int size;
+
+        // Need to use exception unsafe raw pointer as of libxml2 c api
+        xmlChar *unsafeFormated;
+
+        // TODO: Should use canonicalization (aka c14n).
+        //       cf: http://xmlsoft.org/html/libxml-c14n.html
+        //           https://en.wikipedia.org/wiki/Canonical_XML
+        //       Additionally to what is listed on that page,
+        //       attributes are also ordered deterministically.
+        //       That would solve the workaround in the node function with pre/post attributes.
+        //       Unfortunately c14n is not available in appveyor (Windows CI) libxml2 prebuild
+        xmlDocDumpFormatMemoryEnc(doc.get(), &unsafeFormated, &size, "UTF-8",1);
+        std::unique_ptr<xmlChar, void(*)(void *)> formated{unsafeFormated, xmlFree};
+
+        if (formated == nullptr) {
+            throw Exception{"Could not dump xml: " + xml};
+        }
+
+        return string{(char *)formated.get()};
+    }
+
+    static void checkEq(const string &result, const string& expected)
+    {
+        CHECK(result == expected);
+
+        // Pretty print the word differences with colors
+        // It does not matter if it fails as the test would still fail
+        // due to the above CHECK.
+        if (result != expected) {
+            utility::TmpFile resultFile(result);
+            utility::TmpFile expectedFile(expected);
+            auto gitCommand = "git --no-pager diff --word-diff-regex='[^ <>]+' --color --no-index ";
+            system((gitCommand + resultFile.getPath() + ' ' + expectedFile.getPath()).c_str());
+        }
+    }
+
+    static void checkXMLEq(const string &result, const string &expected)
+    {
+        checkEq(canonicalizeXML(result), canonicalizeXML(expected));
+    }
+
+    static string node(string tag, string name, string content,
+                       string attributes = "", string postAttributes = "")
+    {
+        return "<" + tag + " " + attributes + " Name='" + name + "' " + postAttributes + ">" +
+                content +
+               "</" + tag +">";
+    }
+    /** Node with a description.
+     * @param[in] maybeDescription If nullptr, description will be generated from the name
+     *                             Otherwise, the description.
+     */
+    static string nodeDesc(string tag, string name, string content, string attributes = "",
+                           const char *maybeDescription=nullptr)
+    {
+        string description = "description_" + name;
+        if (maybeDescription != nullptr) {
+            description = maybeDescription;
+        }
+        return node(tag, name, content, attributes, "Description='" + description + "'");
+    }
+
+    static string rootNode(string name, string attributes, string content)
+    {
+        return '<' + name + " xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
+                            " xsi:noNamespaceSchemaLocation='" + name + ".xsd'" +
+                             ' ' + attributes + '>' +
+                content + "</" + name + '>';
+    }
+};
+
+SCENARIO_METHOD(AllParamsPF, "Export boolean", "[handler][structure][xml]")
+{
+    string expected = rootNode("BooleanParameter", "Name='bool' Description='bool'", "");
+    checkStructure("/test/test/bool", expected);
+}
+
+SCENARIO_METHOD(AllParamsPF, "Export component", "[handler][structure][xml]")
+{
+    string expected = rootNode("ParameterBlock", "Name='component_scalar' "
+                                                 "Description='description_component_scalar'",
+                               getBasicParams());
+    checkStructure("/test/test/component_scalar", expected);
+}
+
+SCENARIO_METHOD(AllParamsPF, "Export component array", "[handler][structure][xml]")
+{
+    string expected = rootNode("ParameterBlock", "Name='component_array' "
+                                                 "Description='description_component_array'",
+                               // component array are the same as non array for now
+                               getBasicParams());
+    checkStructure("/test/test/component_array", expected);
+}
+
+SCENARIO_METHOD(AllParamsPF, "Export all parameters", "[handler][structure][xml]")
+{
+    string paramExpected = getBasicParams() +
+                           nodeDesc("ParameterBlock", "parameter_block", getBasicParams()) +
+                           nodeDesc("ParameterBlock", "parameter_block_array",
+                                   nodeDesc("ParameterBlock", "0", getBasicParams(), "",
+                                        // description is inherited from array
+                                        "description_parameter_block_array") +
+                                   nodeDesc("ParameterBlock", "1", getBasicParams(), "",
+                                        "description_parameter_block_array")) +
+                           // Components should be exported as parameterBlock
+                           nodeDesc("ParameterBlock", "component_scalar", getBasicParams()) +
+                           nodeDesc("ParameterBlock", "component_array", getBasicParams());
+
+    WHEN("Exporting subsystem") {
+        string expected = rootNode("Subsystem", "Name='test'", paramExpected);
+        checkStructure("/test/test", expected);
+    }
+
+
+    WHEN("Exporting systemClass") {
+        string expected = rootNode("SystemClass", "Name='test'",
+                                       "<Subsystem Name='test'>" + paramExpected + "</Subsystem>");
+
+        // Awkwardly, the root and its first child are the same element
+        checkStructure("/test", expected);
+        checkStructure("/", expected);
+    }
+}
+
+} // namespace parameterFramework

--- a/test/functional-tests/include/ElementHandle.hpp
+++ b/test/functional-tests/include/ElementHandle.hpp
@@ -29,30 +29,34 @@
  */
 #pragma once
 
-#include <ParameterHandle.h>
-
+#include "ParameterFramework.hpp"
 #include "FailureWrapper.hpp"
+
+#include <ElementHandle.h>
 
 namespace parameterFramework
 {
-/** Wrapper around ParameterHandle to throw exceptions on errors and have more
+/** Wrapper around ::ElementHandle to throw exceptions on errors and have more
  * user friendly methods.
+ * Contrary to ::ElementHandle, is constructed through it's constructor
+ * and not a factory method.
+ * @see parameterFramework::ParameterFramework for the main PF interface.
  */
-class ParameterHandle : private FailureWrapper<CParameterHandle>
+class ElementHandle : private FailureWrapper<::ElementHandle>
 {
-    ParameterHandle(const ParameterHandle &other) = delete;
-    ParameterHandle& operator=(const ParameterHandle& other) = delete;
+    ElementHandle(const ElementHandle &other) = delete;
+    ElementHandle& operator=(const ElementHandle& other) = delete;
 private:
-    using PH = CParameterHandle;
+    using EH = ::ElementHandle;
 
 public:
-    ParameterHandle(CParameterHandle *handle) :
-        FailureWrapper(*handle) { delete handle; }
+    ElementHandle(ParameterFramework &pf, const std::string& path) :
+        FailureWrapper(pf.createElementHandle(path)) {}
 
-    /** Wrap PH::setAsDouble to throw an exception on failure. */
-    void setAsDouble(double value) { mayFailCall(&PH::setAsDouble, value); }
-    /** Wrap PH::getAsDouble to throw an exception on failure. */
-    void getAsDouble(double &value) const { mayFailCall(&PH::getAsDouble, value); }
+    /** Wrap EH::setAsDouble to throw an exception on failure. */
+    void setAsDouble(double value) { mayFailCall(&EH::setAsDouble, value); }
+    /** Wrap EH::getAsDouble to throw an exception on failure. */
+    void getAsDouble(double &value) const { mayFailCall(&EH::getAsDouble, value); }
 };
 
 } // parameterFramework

--- a/test/functional-tests/include/ElementHandle.hpp
+++ b/test/functional-tests/include/ElementHandle.hpp
@@ -53,10 +53,36 @@ public:
     ElementHandle(ParameterFramework &pf, const std::string& path) :
         FailureWrapper(pf.createElementHandle(path)) {}
 
+    /** Wrap EH::getSize.
+     *
+     * @note: can not use `using EH::getSize` as getSize has private overloads in EH.
+     */
+    size_t getSize() const { return EH::getSize(); }
+
     /** Wrap EH::setAsDouble to throw an exception on failure. */
     void setAsDouble(double value) { mayFailCall(&EH::setAsDouble, value); }
     /** Wrap EH::getAsDouble to throw an exception on failure. */
     void getAsDouble(double &value) const { mayFailCall(&EH::getAsDouble, value); }
+
+    std::string getStructureAsXML() const {
+        return mayFailGet(&EH::getStructureAsXML);
+    }
+
+    std::string getAsXML() const {
+        return mayFailGet(&EH::getAsXML);
+    }
+    void setAsXML(const std::string &settings) {
+        mayFailSet(&EH::setAsXML, settings);
+    }
+
+    std::vector<uint8_t> getAsBytes() const {
+        std::vector<uint8_t> settings(getSize());
+        mayFailCall(&EH::getAsBytes, settings);
+        return settings;
+    }
+    void setAsBytes(const std::vector<uint8_t> &settings) {
+        mayFailSet(&EH::setAsBytes, settings);
+    }
 };
 
 } // parameterFramework

--- a/test/functional-tests/include/FailureWrapper.hpp
+++ b/test/functional-tests/include/FailureWrapper.hpp
@@ -37,18 +37,25 @@ namespace parameterFramework
 
 namespace detail
 {
+
 static inline bool successTest(bool res) { return res; }
+
 template <class T>
 static inline bool successTest(T *res) { return res != nullptr; }
+
 } // namespace detail
 
-template <class T>
-class FailureWrapper
+template <class Base>
+class FailureWrapper : protected Base
 {
 public:
-    FailureWrapper(T *wrapped) : mWrapped(*wrapped) {}
+    /** Forward construction to base.
+     *
+     * using Base::Base would be equivalent, but is not supported by VS 2013.
+     */
+    template <class... Args>
+    FailureWrapper(Args &&... args) : Base(std::forward<Args>(args)...) {}
 
-protected:
     /** Wrap a const method that may fail to throw an Exception instead of
      * retuning a boolean.
      *
@@ -56,7 +63,7 @@ protected:
      * @param[in] args parameters to call method call with. */
     template <class K, class... MArgs, class... Args>
     void mayFailCall(bool (K::*method)(MArgs...) const, Args&&... args) const {
-        wrapCall<K, bool>(method, std::forward<Args>(args)...);
+        wrapCall<bool>(*this, method, std::forward<Args>(args)...);
     }
 
     /** Wrap a method that may fail to throw an Exception instead of retuning a
@@ -66,7 +73,7 @@ protected:
      * @param[in] args parameters to call method call with. */
     template <class K, class... MArgs, class... Args>
     void mayFailCall(bool (K::*method)(MArgs...), Args&&... args) {
-        wrapCall<K, bool>(method, std::forward<Args>(args)...);
+        wrapCall<bool>(*this, method, std::forward<Args>(args)...);
     }
 
     /** Wrap a method that may indicate failure by returning a null pointer to
@@ -76,7 +83,7 @@ protected:
      * @param[in] args parameters to call method call with. */
     template <class K, class ReturnType, class... MArgs, class... Args>
     ReturnType *mayFailCall(ReturnType *(K::*method)(MArgs...), Args&&... args) {
-        return wrapCall<K, ReturnType *>(method, std::forward<Args>(args)...);
+        return wrapCall<ReturnType *>(*this, method, std::forward<Args>(args)...);
     }
 
     /** Wrap a const method that may indicate failure by returning a null pointer to
@@ -86,21 +93,19 @@ protected:
      * @param[in] args parameters to call method call with. */
     template <class K, class ReturnType, class... MArgs, class... Args>
     ReturnType *mayFailCall(ReturnType *(K::*method)(MArgs...) const, Args&&... args) const {
-        return wrapCall<K, ReturnType *>(method, std::forward<Args>(args)...);
-    }
-private:
-    template <class K, class Ret, class M, class... Args>
-    Ret wrapCall(M method, Args &&... args) const
-    {
-        static_assert(std::is_base_of<K, T>::value, "Attempt to call a method on an incompatible object.");
-        std::string error;
-        auto ret = (mWrapped.*method)(std::forward<Args>(args)..., error);
-        if (not detail::successTest(ret)) {
-            throw Exception(std::move(error));
-        }
-        return ret;
+        return wrapCall<ReturnType *>(*this, method, std::forward<Args>(args)...);
     }
 
-    T& mWrapped;
+private:
+    template <class Ret, class I, class M, class... Args>
+    static Ret wrapCall(I &instance, M method, Args&&... args)
+    {
+        std::string error;
+        auto res = (std::forward<I>(instance).*method)(std::forward<Args>(args)..., error);
+        if (not detail::successTest(res)) {
+            throw Exception(std::move(error));
+        }
+        return res;
+    }
 };
 } // parameterFramework

--- a/test/functional-tests/include/FailureWrapper.hpp
+++ b/test/functional-tests/include/FailureWrapper.hpp
@@ -96,12 +96,28 @@ public:
         return wrapCall<ReturnType *>(*this, method, std::forward<Args>(args)...);
     }
 
+    /** Wrap a getter to return by value and throw an exception on failure. */
+    template <class K, class Value>
+    Value mayFailGet(bool (K::*accessor)(Value &, std::string &) const) const
+    {
+        Value value;
+        wrapCall<bool>(*this, accessor, value);
+        return value;
+    }
+
+    /** Wrap a setter to throw an exception on failure instead of returning a boolean. */
+    template <class K, class Value>
+    void mayFailSet(bool (K::*accessor)(const Value &, std::string &), const Value &value)
+    {
+        wrapCall<bool>(*this, accessor, value);
+    }
+
 private:
     template <class Ret, class I, class M, class... Args>
     static Ret wrapCall(I &instance, M method, Args&&... args)
     {
         std::string error;
-        auto res = (std::forward<I>(instance).*method)(std::forward<Args>(args)..., error);
+        auto res = (instance.*method)(std::forward<Args>(args)..., error);
         if (not detail::successTest(res)) {
             throw Exception(std::move(error));
         }

--- a/test/functional-tests/include/FailureWrapper.hpp
+++ b/test/functional-tests/include/FailureWrapper.hpp
@@ -79,6 +79,15 @@ protected:
         return wrapCall<K, ReturnType *>(method, std::forward<Args>(args)...);
     }
 
+    /** Wrap a const method that may indicate failure by returning a null pointer to
+     * throw an Exception instead of retuning a null pointer.
+     *
+     * @param[in] method that return a nullprt to indicate failure.
+     * @param[in] args parameters to call method call with. */
+    template <class K, class ReturnType, class... MArgs, class... Args>
+    ReturnType *mayFailCall(ReturnType *(K::*method)(MArgs...) const, Args&&... args) const {
+        return wrapCall<K, ReturnType *>(method, std::forward<Args>(args)...);
+    }
 private:
     template <class K, class Ret, class M, class... Args>
     Ret wrapCall(M method, Args &&... args) const

--- a/test/functional-tests/include/ParameterFramework.hpp
+++ b/test/functional-tests/include/ParameterFramework.hpp
@@ -46,7 +46,12 @@ class ParameterFramework : private parameterFramework::ConfigFiles,
                            private CParameterMgrFullConnector,
                            private FailureWrapper<CParameterMgrFullConnector>
 {
-private:
+protected:
+    /** Alias to the Platform Connector PF.
+     * It should not be usefull as PF is a super set but is useful
+     * to disambiguate overloaded method for MS visual compiler.
+     */
+    using PPF = CParameterMgrPlatformConnector;
     using PF = CParameterMgrFullConnector;
 
 public:
@@ -66,9 +71,7 @@ public:
      * @{ */
     using PF::applyConfigurations;
     using PF::getFailureOnMissingSubsystem;
-    using PF::setFailureOnMissingSubsystem;
     using PF::getFailureOnFailedSettingsLoad;
-    using PF::setFailureOnFailedSettingsLoad;
     using PF::getForceNoRemoteInterface;
     using PF::setForceNoRemoteInterface;
     using PF::getSchemaUri;
@@ -82,6 +85,21 @@ public:
     using PF::isAutoSyncOn;
     using PF::setLogger;
     /** @} */
+
+    /** Wrap PF::setValidateSchemasOnStart to throw an exception on failure. */
+    void setValidateSchemasOnStart(bool validate) {
+        mayFailCall(&PPF::setValidateSchemasOnStart, validate);
+    }
+
+    /** Wrap PF::setFailureOnFailedSettingsLoad to throw an exception on failure. */
+    void setFailureOnFailedSettingsLoad(bool fail) {
+        mayFailCall(&PPF::setFailureOnFailedSettingsLoad, fail);
+    }
+
+    /** Wrap PF::setFailureOnMissingSubsystem to throw an exception on failure. */
+    void setFailureOnMissingSubsystem(bool fail) {
+        mayFailCall(&PPF::setFailureOnMissingSubsystem, fail);
+    }
 
     /** Renaming for better readability (and coherency with PF::isValueSpaceRaw)
      *  of PF::setValueSpace. */

--- a/test/functional-tests/include/ParameterFramework.hpp
+++ b/test/functional-tests/include/ParameterFramework.hpp
@@ -43,7 +43,6 @@ namespace parameterFramework
  *  have more user friendly methods.
  */
 class ParameterFramework : private parameterFramework::ConfigFiles,
-                           private CParameterMgrFullConnector,
                            private FailureWrapper<CParameterMgrFullConnector>
 {
 protected:
@@ -57,8 +56,7 @@ protected:
 public:
     ParameterFramework(const Config &config = Config()) :
         ConfigFiles(config),
-        PF(getPath()),
-        FailureWrapper(this) {}
+        FailureWrapper(getPath()) {}
 
     void start() {
         setForceNoRemoteInterface(true);

--- a/test/functional-tests/include/ParameterFramework.hpp
+++ b/test/functional-tests/include/ParameterFramework.hpp
@@ -85,7 +85,6 @@ public:
     using PF::getSchemaUri;
     using PF::setSchemaUri;
     using PF::getValidateSchemasOnStart;
-    using PF::setValidateSchemasOnStart;
     using PF::isValueSpaceRaw;
     using PF::isOutputRawFormatHex;
     using PF::setOutputRawFormat;
@@ -134,6 +133,11 @@ public:
         mayFailCall(&PF::accessParameterValue, path, value, false);
     }
 private:
+
+    /** Create an unwrapped element handle.
+     *
+     * Is not public as this method is intended to be used by ElementHandle facade.
+     */
     EH createElementHandle(const std::string& path)
     {
         // PF::createElementHandle takes it's handler in the free store

--- a/test/functional-tests/include/ParameterFramework.hpp
+++ b/test/functional-tests/include/ParameterFramework.hpp
@@ -64,10 +64,12 @@ protected:
 public:
     ParameterFramework(const Config &config = Config()) :
         ConfigFiles(config),
-        FailureWrapper(getPath()) {}
+        FailureWrapper(getPath())
+    {
+        setForceNoRemoteInterface(true);
+    }
 
     void start() {
-        setForceNoRemoteInterface(true);
         mayFailCall(&PF::start);
     }
 

--- a/test/functional-tests/include/ParameterHandle.hpp
+++ b/test/functional-tests/include/ParameterHandle.hpp
@@ -47,17 +47,12 @@ private:
 
 public:
     ParameterHandle(CParameterHandle *handle) :
-        FailureWrapper(handle),
-        mHandle(handle) {}
-
-    ~ParameterHandle() { delete mHandle; }
+        FailureWrapper(*handle) { delete handle; }
 
     /** Wrap PH::setAsDouble to throw an exception on failure. */
     void setAsDouble(double value) { mayFailCall(&PH::setAsDouble, value); }
     /** Wrap PH::getAsDouble to throw an exception on failure. */
     void getAsDouble(double &value) const { mayFailCall(&PH::getAsDouble, value); }
-
-private:
-    CParameterHandle *mHandle;
 };
+
 } // parameterFramework

--- a/xmlserializer/XmlSerializingContext.cpp
+++ b/xmlserializer/XmlSerializingContext.cpp
@@ -39,7 +39,8 @@ CXmlSerializingContext::CXmlSerializingContext(std::string& strError)
 
 CXmlSerializingContext::~CXmlSerializingContext()
 {
-    xmlSetGenericErrorFunc(NULL, NULL);
+    // TODO: restore the previous handler
+    xmlSetStructuredErrorFunc(NULL, NULL);
     prependToError(_strXmlError);
 }
 


### PR DESCRIPTION
- Fix bugs regarding structure export
 - Fix bugs regarding settings export and import
 - Test both feature
 - Few other minor improvements
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/306%23issuecomment-155110964%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23issuecomment-156056681%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23issuecomment-156058536%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23issuecomment-156100574%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23issuecomment-156444310%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23issuecomment-156446589%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44637732%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44637886%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638136%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638325%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638454%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638630%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638777%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638987%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639086%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639272%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639337%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639400%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639537%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639546%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639556%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44642454%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44642458%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44642466%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44642821%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44643077%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44643230%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44643632%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44643726%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44763522%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44763658%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44768259%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44783185%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44783186%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44783187%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44783188%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44797459%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44797487%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44798226%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44798234%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23issuecomment-155110964%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20seems%20to%20be%20a%20problem%20with%20appveyor%27s%20status%20report%20but%20it%20did%20succeed%3A%20https%3A//ci.appveyor.com/project/parameter-framework/parameter-framework/build/3.0.0-606%22%2C%20%22created_at%22%3A%20%222015-11-09T16%3A15%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dawagner%20%40tcahuzax%20please%20review%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A07%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dawagner%20%40tcahuzax%20please%20review%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A17%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T13%3A19%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%40dawagner%20%40tcahuzax%20I%20fixed%20or%20answered%20all%20your%20remarks.%22%2C%20%22created_at%22%3A%20%222015-11-13T14%3A19%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T14%3A26%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/include/ParameterFramework.hpp%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44783185%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A48%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/include/ParameterFramework.hpp%3AL32-64%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/include/ParameterFramework.hpp%2096%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638777%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20only%20friend%20the%20constructor%20%3F%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A59%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Can%20not%20be%20done%20as%20ElementHandle%20is%20forward%20declared.%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A43%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/include/ParameterFramework.hpp%3AL120-136%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/include/ParameterFramework.hpp%2087%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639086%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%60%60cpp%5Cr%5Cn/%2A%2A%20Create%20an%20unwrapped%20element%20handle.%5Cr%5Cn%20%2A%20Is%20not%20public%20as%20this%20method%20is%20intended%20to%20be%20used%20by%20ElementHandle%20%28facade%20pattern%29.%5Cr%5Cn%20%2A/%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A02%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22dawagner%3A%20You%20can%20use%20the%20using%20you%20introduced%20above%3A%20%60EH%60.%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A04%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A50%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/include/ParameterFramework.hpp%3AL120-136%22%7D%2C%20%22Pull%2089254336fbd42be8d0e93540b71a29cce7d4c157%20parameter/include/ParameterMgrPlatformConnector.h%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44797487%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22printed%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A55%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A00%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/include/ParameterMgrPlatformConnector.h%3AL43-57%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20xmlserializer/XmlSerializingContext.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638630%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60//%20FIXME%3A%20restored%20the%20previous%20handler.%60%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A57%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A42%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20xmlserializer/XmlSerializingContext.cpp%3AL39-46%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/include/FailureWrapper.hpp%2090%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639272%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22dawagner%3A%20forwarding%20%60instance%60%20isn%27t%20useful%20as%20it%20currently%20stands.%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A04%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20it%20is%20even%20not%20working%2C%20I%20should%20have%20written%20%60Instance%20%26%26%60%2C%20not%20%60Instance%20%26%60...%22%2C%20%22created_at%22%3A%20%222015-11-13T09%3A27%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/include/FailureWrapper.hpp%3AL83-127%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/include/ParameterFramework.hpp%2091%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639400%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22dawagner%3A%20You%20can%20use%20the%20using%20you%20introduced%20above%3A%20%60EH%60.%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A05%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T09%3A28%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/include/ParameterFramework.hpp%3AL120-136%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20bindings/python/pfw.i%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639556%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22keep%20old%20method%20for%20retrocompatibility.%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A06%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A48%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/python/pfw.i%3AL91-107%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/CMakeLists.txt%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638136%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%23%20TODO%3A%20create%20a%20libxml2%20library%20to%20properly%20export%20those%20definition%20%26%20include%60%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A51%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A37%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/CMakeLists.txt%3AL27-49%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20parameter/ParameterMgr.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44637732%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22modify%20inplace%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A47%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A37%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgr.h%3AL626-641%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20bindings/python/pfw.i%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639537%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22keep%20old%20method%20for%20retrocompatibility.%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A06%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A49%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/python/pfw.i%3AL91-107%22%7D%2C%20%22Pull%2089254336fbd42be8d0e93540b71a29cce7d4c157%20parameter/include/ParameterMgrPlatformConnector.h%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44797459%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22to%20be%20removed%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A55%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A00%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/include/ParameterMgrPlatformConnector.h%3AL43-57%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20bindings/python/pfw.i%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44639546%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22keep%20old%20method%20for%20retrocompatibility.%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A06%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A49%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/python/pfw.i%3AL91-107%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/include/ParameterFramework.hpp%2090%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638987%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22unique_ptr%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A01%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A49%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/include/ParameterFramework.hpp%3AL120-136%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/include/FailureWrapper.hpp%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638325%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22dawagner%3A%20%5C%22isn%27t%20the%20const-specifier%20missing%20on%20this%20mehod%20%3F%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A54%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A39%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/include/FailureWrapper.hpp%3AL83-127%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20test/functional-tests/include/ParameterFramework.hpp%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44638454%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22separate%20patch%20%3F%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A55%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T10%3A23%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/functional-tests/include/ParameterFramework.hpp%3AL32-64%22%7D%2C%20%22Pull%207f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e%20parameter/include/ParameterMgrPlatformConnector.h%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/306%23discussion_r44637886%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Dawagner%3A%20%5C%22There%27s%20no%20such%20method%20in%20ILogger.%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A49%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T10%3A37%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/include/ParameterMgrPlatformConnector.h%3AL43-58%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/tcahuzax%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/tcahuzax'><img src='https://avatars.githubusercontent.com/u/11178583?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#issuecomment-155110964'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> There seems to be a problem with appveyor's status report but it did succeed: https://ci.appveyor.com/project/parameter-framework/parameter-framework/build/3.0.0-606
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> @dawagner @tcahuzax please review
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> @dawagner @tcahuzax please review
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :-1:
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: @dawagner @tcahuzax I fixed or answered all your remarks.
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e parameter/ParameterMgr.h 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44637732'>File: parameter/ParameterMgr.h:L626-641</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> modify inplace
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e parameter/include/ParameterMgrPlatformConnector.h 9'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44637886'>File: parameter/include/ParameterMgrPlatformConnector.h:L43-58</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Dawagner: "There's no such method in ILogger."
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e test/functional-tests/CMakeLists.txt 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44638136'>File: test/functional-tests/CMakeLists.txt:L27-49</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> `# TODO: create a libxml2 library to properly export those definition & include`
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e test/functional-tests/include/FailureWrapper.hpp 62'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44638325'>File: test/functional-tests/include/FailureWrapper.hpp:L83-127</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> dawagner: "isn't the const-specifier missing on this mehod ?"
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e test/functional-tests/include/ParameterFramework.hpp 32'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44638454'>File: test/functional-tests/include/ParameterFramework.hpp:L32-64</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> separate patch ?
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e xmlserializer/XmlSerializingContext.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44638630'>File: xmlserializer/XmlSerializingContext.cpp:L39-46</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> `// FIXME: restored the previous handler.`
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e test/functional-tests/include/ParameterFramework.hpp 96'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44638777'>File: test/functional-tests/include/ParameterFramework.hpp:L120-136</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> maybe only friend the constructor ?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: Can not be done as ElementHandle is forward declared.
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e test/functional-tests/include/ParameterFramework.hpp 90'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44638987'>File: test/functional-tests/include/ParameterFramework.hpp:L120-136</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> unique_ptr
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e test/functional-tests/include/ParameterFramework.hpp 87'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44639086'>File: test/functional-tests/include/ParameterFramework.hpp:L120-136</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> 
```cpp
/** Create an unwrapped element handle.
* Is not public as this method is intended to be used by ElementHandle (facade pattern).
*/
```
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> dawagner: You can use the using you introduced above: `EH`.
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e test/functional-tests/include/FailureWrapper.hpp 90'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44639272'>File: test/functional-tests/include/FailureWrapper.hpp:L83-127</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> dawagner: forwarding `instance` isn't useful as it currently stands.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: it is even not working, I should have written `Instance &&`, not `Instance &`...
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e test/functional-tests/include/ParameterFramework.hpp 91'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44639400'>File: test/functional-tests/include/ParameterFramework.hpp:L120-136</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> dawagner: You can use the using you introduced above: `EH`.
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e bindings/python/pfw.i 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44639537'>File: bindings/python/pfw.i:L91-107</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> keep old method for retrocompatibility.
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e bindings/python/pfw.i 9'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44639546'>File: bindings/python/pfw.i:L91-107</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> keep old method for retrocompatibility.
- [x] <a href='#crh-comment-Pull 7f9d7996b2cc4c49b1c04d9bb3e4997b254abd8e bindings/python/pfw.i 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44639556'>File: bindings/python/pfw.i:L91-107</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> keep old method for retrocompatibility.
- [x] <a href='#crh-comment-Pull 89254336fbd42be8d0e93540b71a29cce7d4c157 parameter/include/ParameterMgrPlatformConnector.h 10'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44797459'>File: parameter/include/ParameterMgrPlatformConnector.h:L43-57</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> to be removed
- [x] <a href='#crh-comment-Pull 89254336fbd42be8d0e93540b71a29cce7d4c157 parameter/include/ParameterMgrPlatformConnector.h 8'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/306#discussion_r44797487'>File: parameter/include/ParameterMgrPlatformConnector.h:L43-57</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> printed


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/306?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/306?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/306?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/306'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>