### PR TITLE
[review] Python bindings: Remove useless nestedworkaround

### DIFF
--- a/bindings/python/pfw.i
+++ b/bindings/python/pfw.i
@@ -182,7 +182,11 @@ public:
 // CParameterMgrFullConnector
 // Logger interface
 %feature("director") ILogger;
-%nestedworkaround CParameterMgrFullConnector::ILogger;
+// The nested workaround is used to tell swig to ignore the
+// inner class definition that would be redundant with the fake outer class.
+// It would have been useful if ParameterMgrFullConnector.h was included
+// (as opposed to copying the class definition in this .i).
+// As their is no conflicting ILogger definition, this workaround is useless.
 class ILogger
 {
     public:


### PR DESCRIPTION
The swig "nested workaround" is used to tell swig to ignore the inner class definition that would be redundant with the fake outer class.
It would have been useful if ParameterMgrFullConnector.h was included (as opposed to copying the class definition in this .i).
As their was no conflicting ILogger definition, this workaround is useless.

This mean that python bindings can be generated with swig 3 as requested by feature request #166.
Beware though that **swig 3 is not official supported** as not tested in the CI.

Note: I tested this change by running sample.py and observing that logs were still coming out.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/314%23issuecomment-156721601%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/314%23issuecomment-156958238%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/314%23issuecomment-157373365%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/314%23issuecomment-156721601%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%40dawagner%20%40tcahuzax%20please%20review%22%2C%20%22created_at%22%3A%20%222015-11-14T17%3A24%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-16T08%3A52%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-17T13%3A42%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/tcahuzax%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/tcahuzax'><img src='https://avatars.githubusercontent.com/u/11178583?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/314#issuecomment-156721601'>General Comment</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: @dawagner @tcahuzax please review


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/314?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/314?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/314?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/314'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>