### PR TITLE
[Review] Using clang-format to format code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -87,8 +87,7 @@ PointerAlignment: Right
 PenaltyReturnTypeOnItsOwnLine: 10000
 
 # Treat 'catch' BDD macros as control instructions
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH, SCENARIO, SCENARIO_METHOD, SCENARIO,
- SCENARIO_METHOD, GIVEN, WHEN, AND_WHEN, THEN, AND_THEN, TEST_CASE, TEST_CASE_METHOD,
- METHOD_AS_TEST_CASE, SECTION ]
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH, GIVEN, WHEN, AND_WHEN, THEN, AND_THEN,
+    SECTION ]
 
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,94 @@
+# Copyright (c) 2015, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+# The extra indent or outdent of access modifiers
+AccessModifierOffset: -4
+
+# Align parameters on the open bracket
+AlignAfterOpenBracket: Align
+
+# Disallows contracting simple braced statements to a single line
+AllowShortBlocksOnASingleLine: 'false'
+
+# Short case labels wont't be contracted to a single line
+AllowShortCaseLabelsOnASingleLine: 'false'
+
+# Merge all inline functions fitting on a single line
+AllowShortFunctionsOnASingleLine: 'Inline'
+
+# If (a) return; cannot be put on a single line
+AllowShortIfStatementsOnASingleLine: 'false'
+
+# While (true) continue; cannot be put on a single line
+AllowShortLoopsOnASingleLine: 'false'
+
+# Break after the template<...> of a template declaration.
+AlwaysBreakTemplateDeclarations: 'true'
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: 'Custom'
+
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterClass: 'true'
+    AfterControlStatement: 'false'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'false'
+    BeforeElse : 'false'
+    IndentBraces : 'false'
+}
+
+# The column limit
+ColumnLimit: '100'
+
+# The number of columns to use for indentation.
+IndentWidth: '4'
+
+# Targeted language
+Language: Cpp
+
+# No indentation for namespaces.
+NamespaceIndentation: None
+
+# Pointer is aligned to right side
+PointerAlignment: Right
+
+# High penalty to avoid line break just after return type
+PenaltyReturnTypeOnItsOwnLine: 10000
+
+# Treat 'catch' BDD macros as control instructions
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH, SCENARIO, SCENARIO_METHOD, SCENARIO,
+ SCENARIO_METHOD, GIVEN, WHEN, AND_WHEN, THEN, AND_THEN, TEST_CASE, TEST_CASE_METHOD,
+ METHOD_AS_TEST_CASE, SECTION ]
+
+...

--- a/bindings/c/ParameterFramework.cpp
+++ b/bindings/c/ParameterFramework.cpp
@@ -47,9 +47,9 @@ using std::string;
 /** Rename long pfw types to short ones in pfw namespace. */
 namespace pfw
 {
-    typedef ISelectionCriterionInterface Criterion;
-    typedef std::map<string, Criterion *> Criteria;
-    typedef CParameterMgrPlatformConnector Pfw;
+typedef ISelectionCriterionInterface Criterion;
+typedef std::map<string, Criterion *> Criteria;
+typedef CParameterMgrPlatformConnector Pfw;
 }
 
 /** Class to abstract the boolean+string status api. */
@@ -59,16 +59,27 @@ public:
     /** Fail without an instance of status. */
     static bool failure() { return false; }
     /** Fail with the given error msg. */
-    bool failure(const string &msg) { mMsg = msg; return false; }
+    bool failure(const string &msg)
+    {
+        mMsg = msg;
+        return false;
+    }
     /** Success (no error message). */
-    bool success() { mMsg.clear(); return true; }
+    bool success()
+    {
+        mMsg.clear();
+        return true;
+    }
 
     /** Forward a status operation.
       * @param success[in] the operaton status to forward
       *                    or forward a previous failure if omitted
       */
-    bool forward(bool success = false) {
-        if (success) { mMsg.clear(); }
+    bool forward(bool success = false)
+    {
+        if (success) {
+            mMsg.clear();
+        }
         return success;
     }
     /** Error message accessors.
@@ -87,7 +98,8 @@ private:
 ///////////////////////////////
 
 /** Default log callback. Log to cout or cerr depending on level. */
-static void defaultLogCb(void *, PfwLogLevel level, const char *logLine) {
+static void defaultLogCb(void *, PfwLogLevel level, const char *logLine)
+{
     switch (level) {
     case pfwLogInfo:
         std::cout << logLine << std::endl;
@@ -98,7 +110,7 @@ static void defaultLogCb(void *, PfwLogLevel level, const char *logLine) {
     };
 }
 
-static PfwLogger defaultLogger = { NULL, &defaultLogCb };
+static PfwLogger defaultLogger = {NULL, &defaultLogCb};
 
 class LogWrapper : public CParameterMgrPlatformConnector::ILogger
 {
@@ -109,7 +121,7 @@ public:
 private:
     void info(const string &msg) override { log(pfwLogInfo, msg); }
 
-    void warning(const string &msg) override  { log(pfwLogWarning, msg); }
+    void warning(const string &msg) override { log(pfwLogWarning, msg); }
 
     void log(PfwLogLevel level, const string &strLog)
     {
@@ -137,6 +149,7 @@ struct PfwHandler_ : private utility::NonCopyable
       * Is mutable because even a const function can fail.
       */
     mutable Status lastStatus;
+
 private:
     LogWrapper mLogger;
 };
@@ -161,7 +174,6 @@ void PfwHandler::setLogger(const PfwLogger *logger)
     pfw->setLogger(&mLogger);
 }
 
-
 bool PfwHandler::createCriteria(const PfwCriterion criteriaArray[], size_t criterionNb)
 {
     Status &status = lastStatus;
@@ -176,8 +188,7 @@ bool PfwHandler::createCriteria(const PfwCriterion criteriaArray[], size_t crite
         }
         // Check that the criterion does not exist
         if (criteria.find(criterion.name) != criteria.end()) {
-            return status.failure("Criterion \"" + string(criterion.name) +
-                                  "\" already exist");
+            return status.failure("Criterion \"" + string(criterion.name) + "\" already exist");
         }
 
         // Create criterion type
@@ -189,7 +200,7 @@ bool PfwHandler::createCriteria(const PfwCriterion criteriaArray[], size_t crite
             int value;
             if (criterion.inclusive) {
                 // Check that (int)1 << valueIndex would not overflow (UB)
-                if(std::numeric_limits<int>::max() >> valueIndex == 0) {
+                if (std::numeric_limits<int>::max() >> valueIndex == 0) {
                     return status.failure("Too many values for criterion " +
                                           string(criterion.name));
                 }
@@ -197,7 +208,7 @@ bool PfwHandler::createCriteria(const PfwCriterion criteriaArray[], size_t crite
             } else {
                 value = static_cast<int>(valueIndex);
             }
-            const char * valueName = criterion.values[valueIndex];
+            const char *valueName = criterion.values[valueIndex];
             string error;
             if (not type->addValuePair(value, valueName, error)) {
                 return status.failure("Could not add value " + string(valueName) +
@@ -210,10 +221,8 @@ bool PfwHandler::createCriteria(const PfwCriterion criteriaArray[], size_t crite
     return status.success();
 }
 
-
-bool pfwStart(PfwHandler *handle, const char *configPath,
-              const PfwCriterion criteria[], size_t criterionNb,
-              const PfwLogger *logger)
+bool pfwStart(PfwHandler *handle, const char *configPath, const PfwCriterion criteria[],
+              size_t criterionNb, const PfwLogger *logger)
 {
     // Check that the api is correctly used
     Status &status = handle->lastStatus;
@@ -238,8 +247,7 @@ const char *pfwGetLastError(const PfwHandler *handle)
     return handle->lastStatus.msg().c_str();
 }
 
-static pfw::Criterion *getCriterion(const pfw::Criteria &criteria,
-                                    const string &name)
+static pfw::Criterion *getCriterion(const pfw::Criteria &criteria, const string &name)
 {
     pfw::Criteria::const_iterator it = criteria.find(name);
     return it == criteria.end() ? NULL : it->second;
@@ -300,7 +308,8 @@ PfwParameterHandler *pfwBindParameter(PfwHandler *handle, const char path[])
     Status &status = handle->lastStatus;
     if (handle->pfw == NULL) {
         status.failure("The parameter framework is not started, "
-                       "while trying to bind parameter \"" + string(path) + "\")");
+                       "while trying to bind parameter \"" +
+                       string(path) + "\")");
         return NULL;
     }
 
@@ -321,7 +330,6 @@ void pfwUnbindParameter(PfwParameterHandler *handle)
     delete handle;
 }
 
-
 bool pfwGetIntParameter(const PfwParameterHandler *handle, int32_t *value)
 {
     Status &status = handle->pfw.lastStatus;
@@ -339,7 +347,9 @@ bool pfwGetStringParameter(const PfwParameterHandler *handle, char *value[])
     *value = NULL;
     string retValue;
     bool success = handle->parameter.getAsString(retValue, status.msg());
-    if (not success) { return status.forward(); }
+    if (not success) {
+        return status.forward();
+    }
 
     *value = strdup(retValue.c_str());
     return status.success();
@@ -351,5 +361,7 @@ bool pfwSetStringParameter(PfwParameterHandler *handle, const char value[])
     return status.forward(handle->parameter.setAsString(value, status.msg()));
 }
 
-void pfwFree(void *ptr) { std::free(ptr); }
-
+void pfwFree(void *ptr)
+{
+    std::free(ptr);
+}

--- a/bindings/c/ParameterFramework.h
+++ b/bindings/c/ParameterFramework.h
@@ -38,7 +38,6 @@
 
 #pragma once
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,17 +52,17 @@ extern "C" {
   * Such arguments are marked NONNULL.
   */
 #if defined(__clang__) || defined(__GNUC__)
-#    define NONNULL  __attribute__((nonnull))
-#    define NONNULL_(...)  __attribute__((nonnull (__VA_ARGS__)))
-#    define USERESULT __attribute__((warn_unused_result))
+#define NONNULL __attribute__((nonnull))
+#define NONNULL_(...) __attribute__((nonnull(__VA_ARGS__)))
+#define USERESULT __attribute__((warn_unused_result))
 #elif defined(_MSC_VER)
-    // In visual studio's cl there is no
-    // equivalent of nonnull
-#    define NONNULL
-#    define NONNULL_(...)
-#    define USERESULT _Check_return_
+// In visual studio's cl there is no
+// equivalent of nonnull
+#define NONNULL
+#define NONNULL_(...)
+#define USERESULT _Check_return_
 #else
-#   error "Unknown compilator"
+#error "Unknown compilator"
 #endif
 
 /** Private handle to a parameter framework.
@@ -99,7 +98,8 @@ typedef enum {
 typedef void PfwLogCb(void *userCtx, PfwLogLevel level, const char *logLine);
 
 /** Logger containing a callback method and its context. */
-typedef struct {
+typedef struct
+{
     /** User defined arbitrary value that will be provided to all logCb call. */
     void *userCtx;
     /** Callback that will be called.
@@ -113,24 +113,24 @@ typedef struct {
 ///////////////////////////////
 
 /** Structure of a parameter framework criterion. */
-typedef struct {
+typedef struct
+{
     /** Name of the criterion in the pfw configuration rules. */
-    const char *name; //< Must not be null.
-    bool inclusive; //< True if the criterion is inclusive, false if exclusive.
-    /** Null terminated list of criterion value names.
-      * @example { "Red", "Green", "Blue", NULL }
-      *
-      * For an exclusive criterion, the list must not contain more elements then
-      *                             INT_MAX.
-      * For an inclusive criterion, the list must not contain more elements then
-      *                             sizeof(int) * BIT_CHAR - 1.
-      *                             Ie: (int)1 << n must *not* overflow (UB),
-      *                                 were n is the number of element in the
-      *                                 list. @see pfwSetCriterion
-      */
+    const char *name;    //< Must not be null.
+    bool inclusive;      //< True if the criterion is inclusive, false if exclusive.
+                         /** Null terminated list of criterion value names.
+                           * @example { "Red", "Green", "Blue", NULL }
+                           *
+                           * For an exclusive criterion, the list must not contain more elements then
+                           *                             INT_MAX.
+                           * For an inclusive criterion, the list must not contain more elements then
+                           *                             sizeof(int) * BIT_CHAR - 1.
+                           *                             Ie: (int)1 << n must *not* overflow (UB),
+                           *                                 were n is the number of element in the
+                           *                                 list. @see pfwSetCriterion
+                           */
     const char **values; //< Must not be null.
 } PfwCriterion;
-
 
 /** Create a parameter framework instance.
   * Can not fail except for memory allocation.
@@ -153,9 +153,8 @@ void pfwDestroy(PfwHandler *handle) NONNULL;
   * @return true on success, false on failure.
   */
 CPARAMETER_EXPORT
-bool pfwStart(PfwHandler *handle, const char *configPath,
-              const PfwCriterion criteria[], size_t criterionNb,
-              const PfwLogger *loggger) NONNULL_(1, 2, 3) USERESULT;
+bool pfwStart(PfwHandler *handle, const char *configPath, const PfwCriterion criteria[],
+              size_t criterionNb, const PfwLogger *loggger) NONNULL_(1, 2, 3) USERESULT;
 
 /** @return a string describing the last call result.
   * If the last pfw function call succeeded, return an empty string.
@@ -190,7 +189,8 @@ CPARAMETER_EXPORT
 bool pfwSetCriterion(PfwHandler *handle, const char name[], int value) NONNULL USERESULT;
 /** Get a criterion value given its name.
   * Same usage as pfwSetCriterion except that value is an out param.
-  * Get criterion will return the last value setted with pfwSetCriterion independantly of pfwCommitCritenio.
+  * Get criterion will return the last value setted with pfwSetCriterion independantly of
+ * pfwCommitCritenio.
   */
 CPARAMETER_EXPORT
 bool pfwGetCriterion(const PfwHandler *handle, const char name[], int *value) NONNULL USERESULT;
@@ -244,7 +244,7 @@ void pfwUnbindParameter(PfwParameterHandler *handle) NONNULL;
   * return true of success, false on failure.
   */
 CPARAMETER_EXPORT
-bool pfwGetIntParameter(const PfwParameterHandler *handle, int32_t *value ) NONNULL USERESULT;
+bool pfwGetIntParameter(const PfwParameterHandler *handle, int32_t *value) NONNULL USERESULT;
 
 /** Set the value of a previously bind int parameter.
   * @param handle[in] Handler to a valid parameter.

--- a/bindings/c/ParameterFramework.h
+++ b/bindings/c/ParameterFramework.h
@@ -116,19 +116,20 @@ typedef struct
 typedef struct
 {
     /** Name of the criterion in the pfw configuration rules. */
-    const char *name;    //< Must not be null.
-    bool inclusive;      //< True if the criterion is inclusive, false if exclusive.
-                         /** Null terminated list of criterion value names.
-                           * @example { "Red", "Green", "Blue", NULL }
-                           *
-                           * For an exclusive criterion, the list must not contain more elements then
-                           *                             INT_MAX.
-                           * For an inclusive criterion, the list must not contain more elements then
-                           *                             sizeof(int) * BIT_CHAR - 1.
-                           *                             Ie: (int)1 << n must *not* overflow (UB),
-                           *                                 were n is the number of element in the
-                           *                                 list. @see pfwSetCriterion
-                           */
+    const char *name; //< Must not be null.
+    bool inclusive;   //< True if the criterion is inclusive, false if exclusive.
+
+    /** Null terminated list of criterion value names.
+      * @example { "Red", "Green", "Blue", NULL }
+      *
+      * For an exclusive criterion, the list must not contain more elements then
+      *                             INT_MAX.
+      * For an inclusive criterion, the list must not contain more elements then
+      *                             sizeof(int) * BIT_CHAR - 1.
+      *                             Ie: (int)1 << n must *not* overflow (UB),
+      *                                 were n is the number of element in the
+      *                                 list. @see pfwSetCriterion
+      */
     const char **values; //< Must not be null.
 } PfwCriterion;
 
@@ -190,7 +191,7 @@ bool pfwSetCriterion(PfwHandler *handle, const char name[], int value) NONNULL U
 /** Get a criterion value given its name.
   * Same usage as pfwSetCriterion except that value is an out param.
   * Get criterion will return the last value setted with pfwSetCriterion independantly of
- * pfwCommitCritenio.
+  * pfwCommitCritenio.
   */
 CPARAMETER_EXPORT
 bool pfwGetCriterion(const PfwHandler *handle, const char name[], int *value) NONNULL USERESULT;

--- a/bindings/c/Test.cpp
+++ b/bindings/c/Test.cpp
@@ -32,7 +32,7 @@
 
 #include "TmpFile.hpp"
 
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
+#define CATCH_CONFIG_MAIN // This tells Catch to provide a main()
 #include <catch.hpp>
 
 #include <string>
@@ -43,7 +43,6 @@
 #include <cstring>
 #include <cerrno>
 #include <climits>
-
 
 struct Test
 {
@@ -56,7 +55,7 @@ struct Test
 
     void REQUIRE_FAILURE(bool success)
     {
-        THEN("It should be an error") {
+        THEN ("It should be an error") {
             INFO("Previous pfw log: \n" + logLines);
             CAPTURE(pfwGetLastError(pfw));
             CHECK(not success);
@@ -66,7 +65,7 @@ struct Test
 
     void REQUIRE_SUCCESS(bool success)
     {
-        THEN("It should be a success") {
+        THEN ("It should be a success") {
             INFO("Previous pfw log: \n" + logLines);
             CAPTURE(pfwGetLastError(pfw));
             CHECK(success);
@@ -81,10 +80,11 @@ struct Test
     {
     private:
         using Base = parameterFramework::utility::TmpFile;
+
     public:
         /** `using Base::TmpFile` does not work on VS 2013*/
         TmpFile(std::string content) : Base(content) {}
-        
+
         using Base::getPath;
         /** Implicitly convert to the path of the temporary file. */
         operator const char *() const { return getPath().c_str(); }
@@ -94,7 +94,7 @@ struct Test
     static void logCb(void *voidLogLines, PfwLogLevel level, const char *logLine)
     {
         std::string &logLines = *reinterpret_cast<std::string *>(voidLogLines);
-        switch(level) {
+        switch (level) {
         case pfwLogWarning:
             logLines += "Warning: ";
             break;
@@ -110,18 +110,16 @@ struct Test
 
     /** Pfw handler used in the tests. */
     PfwHandler *pfw;
-
 };
 
-TEST_CASE_METHOD(Test, "Parameter-framework c api use") {
+TEST_CASE_METHOD (Test, "Parameter-framework c api use") {
     // Create criteria
     const char *letterList[] = {"a", "b", "c", NULL};
     const char *numberList[] = {"1", "2", "3", NULL};
     const PfwCriterion criteria[] = {
-        {"inclusiveCrit", true, letterList},
-        {"exclusiveCrit", false, numberList},
+        {"inclusiveCrit", true, letterList}, {"exclusiveCrit", false, numberList},
     };
-    size_t criterionNb = sizeof(criteria)/sizeof(criteria[0]);
+    size_t criterionNb = sizeof(criteria) / sizeof(criteria[0]);
     PfwLogger logger = {&logLines, logCb};
 
     // Create valid pfw config file
@@ -137,61 +135,61 @@ TEST_CASE_METHOD(Test, "Parameter-framework c api use") {
         </Subsystem>");
     TmpFile libraries("<?xml version='1.0' encoding='UTF-8'?>\
         <SystemClass Name='test'>\
-            <SubsystemInclude Path='" + system.getPath() + "'/>\
+            <SubsystemInclude Path='" +
+                      system.getPath() + "'/>\
         </SystemClass>");
     TmpFile config("<?xml version='1.0' encoding='UTF-8'?>\
         <ParameterFrameworkConfiguration\
             SystemClassName='test' TuningAllowed='false'>\
             <SubsystemPlugins/>\
-            <StructureDescriptionFileLocation Path='" + libraries.getPath() + "'/>\
+            <StructureDescriptionFileLocation Path='" +
+                   libraries.getPath() + "'/>\
         </ParameterFrameworkConfiguration>");
 
-    GIVEN("A created parameter framework") {
+    GIVEN ("A created parameter framework") {
         pfw = pfwCreate();
         REQUIRE(pfw != NULL);
 
-        THEN("Error message should be empty") {
+        THEN ("Error message should be empty") {
             CHECK(empty(pfwGetLastError(pfw)));
         }
 
-        WHEN("The pfw is started without an existent file") {
+        WHEN ("The pfw is started without an existent file") {
             REQUIRE_FAILURE(pfwStart(pfw, "/doNotExist", criteria, criterionNb, &logger));
         }
 
-        WHEN("The pfw is started with duplicated criterion value") {
+        WHEN ("The pfw is started with duplicated criterion value") {
             const PfwCriterion duplicatedCriteria[] = {
-                {"duplicated name", true, letterList},
-                {"duplicated name", false, numberList},
+                {"duplicated name", true, letterList}, {"duplicated name", false, numberList},
             };
             REQUIRE_FAILURE(pfwStart(pfw, config, duplicatedCriteria, 2, &logger));
         }
-        WHEN("The pfw is started with duplicated criterion value state") {
-            const char * values[] = {"a", "a", NULL};
+        WHEN ("The pfw is started with duplicated criterion value state") {
+            const char *values[] = {"a", "a", NULL};
             const PfwCriterion duplicatedCriteria[] = {{"name", true, values}};
 
-            WHEN("Using test logger") {
+            WHEN ("Using test logger") {
                 REQUIRE_FAILURE(pfwStart(pfw, config, duplicatedCriteria, 1, &logger));
             }
-            WHEN("Using default logger") {
+            WHEN ("Using default logger") {
                 // Test coverage of default logger warning
                 REQUIRE_FAILURE(pfwStart(pfw, config, duplicatedCriteria, 1, NULL));
             }
         }
-        WHEN("The pfw is started with NULL name criterion") {
+        WHEN ("The pfw is started with NULL name criterion") {
             const PfwCriterion duplicatedCriteria[] = {{NULL, true, letterList}};
             REQUIRE_FAILURE(pfwStart(pfw, config, duplicatedCriteria, 1, &logger));
         }
-        WHEN("The pfw is started with NULL criterion state list") {
+        WHEN ("The pfw is started with NULL criterion state list") {
             const PfwCriterion duplicatedCriteria[] = {{"name", true, NULL}};
             REQUIRE_FAILURE(pfwStart(pfw, config, duplicatedCriteria, 1, &logger));
         }
-        GIVEN("A criteria with lots of values")
-        {
+        GIVEN ("A criteria with lots of values") {
             // Build a criterion with as many value as there is bits in int.
             std::vector<char> names(sizeof(int) * CHAR_BIT + 1, 'a');
             names.back() = '\0';
             std::vector<const char *> values(names.size());
-            for(size_t i = 0; i < values.size(); ++i) {
+            for (size_t i = 0; i < values.size(); ++i) {
                 values[i] = &names[i];
             }
             values.back() = NULL;
@@ -223,57 +221,56 @@ TEST_CASE_METHOD(Test, "Parameter-framework c api use") {
              */
             const PfwCriterion duplicatedCriteria[] = {{"name", true, &values[0]}};
 
-            WHEN("The pfw is started with a too long criterion state list") {
+            WHEN ("The pfw is started with a too long criterion state list") {
                 REQUIRE_FAILURE(pfwStart(pfw, config, duplicatedCriteria, 1, &logger));
             }
-            WHEN("The pfw is started with max length criterion state list") {
+            WHEN ("The pfw is started with max length criterion state list") {
                 values[values.size() - 2] = NULL; // Hide last value
                 REQUIRE_SUCCESS(pfwStart(pfw, config, duplicatedCriteria, 1, &logger));
             }
         }
 
-        WHEN("The pfw is started with zero criteria") {
+        WHEN ("The pfw is started with zero criteria") {
             REQUIRE_SUCCESS(pfwStart(pfw, config, criteria, 0, &logger));
         }
 
-        WHEN("The pfw is started twice a pfw") {
+        WHEN ("The pfw is started twice a pfw") {
             REQUIRE_SUCCESS(pfwStart(pfw, config, criteria, criterionNb, &logger));
             REQUIRE_FAILURE(pfwStart(pfw, config, criteria, criterionNb, &logger));
         }
 
-        WHEN("The pfw is started without a logger callback") {
-            PfwLogger noLog = { NULL, NULL };
+        WHEN ("The pfw is started without a logger callback") {
+            PfwLogger noLog = {NULL, NULL};
             REQUIRE_SUCCESS(pfwStart(pfw, config, criteria, criterionNb, &noLog));
         }
-        WHEN("The pfw is started with default logger") {
+        WHEN ("The pfw is started with default logger") {
             REQUIRE_SUCCESS(pfwStart(pfw, config, criteria, criterionNb, NULL));
         }
 
-        WHEN("Get criterion of a stopped pfw") {
+        WHEN ("Get criterion of a stopped pfw") {
             int value;
             REQUIRE_FAILURE(pfwGetCriterion(pfw, criteria[0].name, &value));
         }
-        WHEN("Set criterion of a stopped pfw") {
+        WHEN ("Set criterion of a stopped pfw") {
             REQUIRE_FAILURE(pfwSetCriterion(pfw, criteria[0].name, 1));
         }
-        WHEN("Commit criteria of a stopped pfw") {
+        WHEN ("Commit criteria of a stopped pfw") {
             REQUIRE_FAILURE(pfwApplyConfigurations(pfw));
         }
 
-        WHEN("Bind parameter with a stopped pfw") {
+        WHEN ("Bind parameter with a stopped pfw") {
             REQUIRE(pfwBindParameter(pfw, intParameterPath) == NULL);
         }
 
-        WHEN("The pfw is started correctly")
-        {
+        WHEN ("The pfw is started correctly") {
             REQUIRE_SUCCESS(pfwStart(pfw, config, criteria, criterionNb, &logger));
             int value;
 
-            WHEN("Get not existing criterion") {
+            WHEN ("Get not existing criterion") {
                 REQUIRE_FAILURE(pfwGetCriterion(pfw, "Do not exist", &value));
             }
-            THEN("All criterion should value 0") {
-                for(size_t i = 0; i < criterionNb; ++i) {
+            THEN ("All criterion should value 0") {
+                for (size_t i = 0; i < criterionNb; ++i) {
                     const char *criterionName = criteria[i].name;
                     CAPTURE(criterionName);
                     REQUIRE_SUCCESS(pfwGetCriterion(pfw, criterionName, &value));
@@ -281,27 +278,27 @@ TEST_CASE_METHOD(Test, "Parameter-framework c api use") {
                 }
             }
 
-            WHEN("Set not existing criterion") {
+            WHEN ("Set not existing criterion") {
                 REQUIRE_FAILURE(pfwSetCriterion(pfw, "Do not exist", 3));
             }
-            WHEN("Set criterion value") {
-                for(size_t i = 0; i < criterionNb; ++i) {
+            WHEN ("Set criterion value") {
+                for (size_t i = 0; i < criterionNb; ++i) {
                     const char *criterionName = criteria[i].name;
                     CAPTURE(criterionName);
                     REQUIRE_SUCCESS(pfwSetCriterion(pfw, criterionName, 3));
                 }
-                THEN("Get criterion value should return what was set") {
-                    for(size_t i = 0; i < criterionNb; ++i) {
+                THEN ("Get criterion value should return what was set") {
+                    for (size_t i = 0; i < criterionNb; ++i) {
                         const char *criterionName = criteria[i].name;
                         CAPTURE(criterionName);
                         REQUIRE_SUCCESS(pfwGetCriterion(pfw, criterionName, &value));
                         REQUIRE(value == 3);
                     }
                 }
-                WHEN("Set a new value to a criterion without committing first") {
+                WHEN ("Set a new value to a criterion without committing first") {
                     const char *criterionName = criteria[0].name;
                     REQUIRE_SUCCESS(pfwSetCriterion(pfw, criterionName, 0));
-                    THEN("A warning message should have been displayed") {
+                    THEN ("A warning message should have been displayed") {
                         INFO("Previous pfw log: \n" + logLines);
                         size_t logPos = logLines.find("Warning: Selection criterion "
                                                       "'inclusiveCrit' has been modified 1 time(s)"
@@ -310,24 +307,24 @@ TEST_CASE_METHOD(Test, "Parameter-framework c api use") {
                     }
                 }
             }
-            WHEN("Commit criteria of a started pfw") {
+            WHEN ("Commit criteria of a started pfw") {
                 REQUIRE_SUCCESS(pfwApplyConfigurations(pfw));
             }
-            WHEN("Bind a non existing parameter") {
+            WHEN ("Bind a non existing parameter") {
                 REQUIRE_FAILURE(pfwBindParameter(pfw, "do/not/exist") != NULL);
             }
 
-            GIVEN("An integer parameter handle") {
+            GIVEN ("An integer parameter handle") {
                 PfwParameterHandler *param = pfwBindParameter(pfw, intParameterPath);
                 REQUIRE_SUCCESS(param != NULL);
 
-                WHEN("Set parameter out of range") {
+                WHEN ("Set parameter out of range") {
                     REQUIRE_FAILURE(pfwSetIntParameter(param, 101));
                 }
 
-                WHEN("Set parameter") {
+                WHEN ("Set parameter") {
                     REQUIRE_SUCCESS(pfwSetIntParameter(param, 11));
-                    THEN("Get parameter should return what was set") {
+                    THEN ("Get parameter should return what was set") {
                         REQUIRE_SUCCESS(pfwGetIntParameter(param, &value));
                         REQUIRE(value == 11);
                     }
@@ -336,18 +333,18 @@ TEST_CASE_METHOD(Test, "Parameter-framework c api use") {
                 pfwUnbindParameter(param);
             }
 
-            GIVEN("An string parameter handle") {
+            GIVEN ("An string parameter handle") {
                 PfwParameterHandler *param = pfwBindParameter(pfw, stringParameterPath);
                 REQUIRE_SUCCESS(param != NULL);
 
-                WHEN("Set parameter out of range") {
+                WHEN ("Set parameter out of range") {
                     REQUIRE_FAILURE(pfwSetStringParameter(param, "ko_1234567"));
                 }
 
-                WHEN("Set parameter") {
+                WHEN ("Set parameter") {
                     char *value;
                     REQUIRE_SUCCESS(pfwSetStringParameter(param, "ok"));
-                    THEN("Get parameter should return what was set") {
+                    THEN ("Get parameter should return what was set") {
                         REQUIRE_SUCCESS(pfwGetStringParameter(param, &value));
                         REQUIRE(value == std::string("ok"));
                         pfwFree(value);

--- a/bindings/c/Test.cpp
+++ b/bindings/c/Test.cpp
@@ -112,7 +112,8 @@ struct Test
     PfwHandler *pfw;
 };
 
-TEST_CASE_METHOD (Test, "Parameter-framework c api use") {
+TEST_CASE_METHOD(Test, "Parameter-framework c api use")
+{
     // Create criteria
     const char *letterList[] = {"a", "b", "c", NULL};
     const char *numberList[] = {"1", "2", "3", NULL};

--- a/parameter/AreaConfiguration.cpp
+++ b/parameter/AreaConfiguration.cpp
@@ -32,14 +32,16 @@
 #include "ConfigurationAccessContext.h"
 #include <assert.h>
 
-CAreaConfiguration::CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet)
+CAreaConfiguration::CAreaConfiguration(const CConfigurableElement *pConfigurableElement,
+                                       const CSyncerSet *pSyncerSet)
     : _pConfigurableElement(pConfigurableElement), _pSyncerSet(pSyncerSet)
 {
     // Size blackboard
     _blackboard.setSize(_pConfigurableElement->getFootPrint());
 }
 
-CAreaConfiguration::CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet, size_t size)
+CAreaConfiguration::CAreaConfiguration(const CConfigurableElement *pConfigurableElement,
+                                       const CSyncerSet *pSyncerSet, size_t size)
     : _pConfigurableElement(pConfigurableElement), _pSyncerSet(pSyncerSet)
 {
     // Size blackboard
@@ -47,15 +49,14 @@ CAreaConfiguration::CAreaConfiguration(const CConfigurableElement* pConfigurable
 }
 
 // Save data from current
-void CAreaConfiguration::save(const CParameterBlackboard* pMainBlackboard)
+void CAreaConfiguration::save(const CParameterBlackboard *pMainBlackboard)
 {
     copyFrom(pMainBlackboard, _pConfigurableElement->getOffset());
 }
 
 // Apply data to current
-bool CAreaConfiguration::restore(CParameterBlackboard* pMainBlackboard,
-                                 bool bSync,
-                                 core::Results* errors) const
+bool CAreaConfiguration::restore(CParameterBlackboard *pMainBlackboard, bool bSync,
+                                 core::Results *errors) const
 {
     assert(_bValid);
 
@@ -66,7 +67,7 @@ bool CAreaConfiguration::restore(CParameterBlackboard* pMainBlackboard,
 }
 
 // Ensure validity
-void CAreaConfiguration::validate(const CParameterBlackboard* pMainBlackboard)
+void CAreaConfiguration::validate(const CParameterBlackboard *pMainBlackboard)
 {
     if (!_bValid) {
 
@@ -84,7 +85,7 @@ bool CAreaConfiguration::isValid() const
 }
 
 // Ensure validity against given valid area configuration
-void CAreaConfiguration::validateAgainst(const CAreaConfiguration* pValidAreaConfiguration)
+void CAreaConfiguration::validateAgainst(const CAreaConfiguration *pValidAreaConfiguration)
 {
     // Should be called on purpose
     assert(!_bValid);
@@ -103,7 +104,9 @@ void CAreaConfiguration::validateAgainst(const CAreaConfiguration* pValidAreaCon
 }
 
 // XML configuration settings parsing
-bool CAreaConfiguration::serializeXmlSettings(CXmlElement& xmlConfigurableElementSettingsElementContent, CConfigurationAccessContext& configurationAccessContext)
+bool CAreaConfiguration::serializeXmlSettings(
+    CXmlElement &xmlConfigurableElementSettingsElementContent,
+    CConfigurationAccessContext &configurationAccessContext)
 {
     // Assign blackboard to configuration context
     configurationAccessContext.setParameterBlackboard(&_blackboard);
@@ -112,7 +115,8 @@ bool CAreaConfiguration::serializeXmlSettings(CXmlElement& xmlConfigurableElemen
     configurationAccessContext.setBaseOffset(_pConfigurableElement->getOffset());
 
     // Parse configuration settings (element contents)
-    if (_pConfigurableElement->serializeXmlSettings(xmlConfigurableElementSettingsElementContent, configurationAccessContext)) {
+    if (_pConfigurableElement->serializeXmlSettings(xmlConfigurableElementSettingsElementContent,
+                                                    configurationAccessContext)) {
 
         if (!configurationAccessContext.serializeOut()) {
 
@@ -125,36 +129,40 @@ bool CAreaConfiguration::serializeXmlSettings(CXmlElement& xmlConfigurableElemen
 }
 
 // Compound handling
-const CConfigurableElement* CAreaConfiguration::getConfigurableElement() const
+const CConfigurableElement *CAreaConfiguration::getConfigurableElement() const
 {
     return _pConfigurableElement;
 }
 
-void CAreaConfiguration::copyToOuter(CAreaConfiguration* pToAreaConfiguration) const
+void CAreaConfiguration::copyToOuter(CAreaConfiguration *pToAreaConfiguration) const
 {
     assert(_pConfigurableElement->isDescendantOf(pToAreaConfiguration->getConfigurableElement()));
 
-    copyTo(&pToAreaConfiguration->_blackboard, _pConfigurableElement->getOffset() - pToAreaConfiguration->getConfigurableElement()->getOffset());
+    copyTo(&pToAreaConfiguration->_blackboard,
+           _pConfigurableElement->getOffset() -
+               pToAreaConfiguration->getConfigurableElement()->getOffset());
 }
 
-void CAreaConfiguration::copyFromOuter(const CAreaConfiguration* pFromAreaConfiguration)
+void CAreaConfiguration::copyFromOuter(const CAreaConfiguration *pFromAreaConfiguration)
 {
     assert(_pConfigurableElement->isDescendantOf(pFromAreaConfiguration->getConfigurableElement()));
 
-    copyFrom(&pFromAreaConfiguration->_blackboard, _pConfigurableElement->getOffset() - pFromAreaConfiguration->getConfigurableElement()->getOffset());
+    copyFrom(&pFromAreaConfiguration->_blackboard,
+             _pConfigurableElement->getOffset() -
+                 pFromAreaConfiguration->getConfigurableElement()->getOffset());
 
     // Inner becomes valid
     setValid(true);
 }
 
-CParameterBlackboard& CAreaConfiguration::getBlackboard()
+CParameterBlackboard &CAreaConfiguration::getBlackboard()
 {
     return _blackboard;
 }
 
-const CParameterBlackboard& CAreaConfiguration::getBlackboard() const
+const CParameterBlackboard &CAreaConfiguration::getBlackboard() const
 {
-     return _blackboard;
+    return _blackboard;
 }
 
 // Store validity
@@ -164,13 +172,12 @@ void CAreaConfiguration::setValid(bool bValid)
 }
 
 // Blackboard copies
-void CAreaConfiguration::copyTo(CParameterBlackboard* pToBlackboard, size_t offset) const
+void CAreaConfiguration::copyTo(CParameterBlackboard *pToBlackboard, size_t offset) const
 {
     pToBlackboard->restoreFrom(&_blackboard, offset);
 }
 
-void CAreaConfiguration::copyFrom(const CParameterBlackboard* pFromBlackboard, size_t offset)
+void CAreaConfiguration::copyFrom(const CParameterBlackboard *pFromBlackboard, size_t offset)
 {
-   pFromBlackboard->saveTo(&_blackboard, offset);
+    pFromBlackboard->saveTo(&_blackboard, offset);
 }
-

--- a/parameter/AreaConfiguration.h
+++ b/parameter/AreaConfiguration.h
@@ -40,12 +40,13 @@ class CConfigurationAccessContext;
 class CAreaConfiguration
 {
 public:
-    CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet);
+    CAreaConfiguration(const CConfigurableElement *pConfigurableElement,
+                       const CSyncerSet *pSyncerSet);
 
     virtual ~CAreaConfiguration() = default;
 
     // Save data from current
-    void save(const CParameterBlackboard* pMainBlackboard);
+    void save(const CParameterBlackboard *pMainBlackboard);
 
     /** Restore the configuration area
      *
@@ -54,56 +55,57 @@ public:
      * @param[out] errors, errors encountered during restoration
      * @return true if success false otherwise
      */
-    bool restore(CParameterBlackboard* pMainBlackboard, bool bSync, core::Results* errors) const;
+    bool restore(CParameterBlackboard *pMainBlackboard, bool bSync, core::Results *errors) const;
 
     // Ensure validity
-    void validate(const CParameterBlackboard* pMainBlackboard);
+    void validate(const CParameterBlackboard *pMainBlackboard);
 
     // Return validity
     bool isValid() const;
 
     // Ensure validity against given valid area configuration
-    void validateAgainst(const CAreaConfiguration* pValidAreaConfiguration);
+    void validateAgainst(const CAreaConfiguration *pValidAreaConfiguration);
 
     // Compound handling
-    const CConfigurableElement* getConfigurableElement() const;
+    const CConfigurableElement *getConfigurableElement() const;
 
     // Configuration merging
-    virtual void copyToOuter(CAreaConfiguration* pToAreaConfiguration) const;
+    virtual void copyToOuter(CAreaConfiguration *pToAreaConfiguration) const;
 
     // Configuration splitting
-    virtual void copyFromOuter(const CAreaConfiguration* pFromAreaConfiguration);
+    virtual void copyFromOuter(const CAreaConfiguration *pFromAreaConfiguration);
 
     // XML configuration settings parsing/composing
-    bool serializeXmlSettings(CXmlElement& xmlConfigurableElementSettingsElementContent, CConfigurationAccessContext& configurationAccessContext);
+    bool serializeXmlSettings(CXmlElement &xmlConfigurableElementSettingsElementContent,
+                              CConfigurationAccessContext &configurationAccessContext);
 
     // Fetch the Configuration Blackboard
-    CParameterBlackboard& getBlackboard();
-    const CParameterBlackboard& getBlackboard() const;
+    CParameterBlackboard &getBlackboard();
+    const CParameterBlackboard &getBlackboard() const;
 
 protected:
-    CAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet, size_t size);
+    CAreaConfiguration(const CConfigurableElement *pConfigurableElement,
+                       const CSyncerSet *pSyncerSet, size_t size);
 
 private:
     // Blackboard copies
-    virtual void copyTo(CParameterBlackboard* pToBlackboard, size_t offset) const;
-    virtual void copyFrom(const CParameterBlackboard* pFromBlackboard, size_t offset);
+    virtual void copyTo(CParameterBlackboard *pToBlackboard, size_t offset) const;
+    virtual void copyFrom(const CParameterBlackboard *pFromBlackboard, size_t offset);
 
     // Store validity
     void setValid(bool bValid);
 
 protected:
     // Associated configurable element
-    const CConfigurableElement* _pConfigurableElement;
+    const CConfigurableElement *_pConfigurableElement;
 
     // Configurable element settings
     CParameterBlackboard _blackboard;
 
 private:
     // Syncer set (required for immediate synchronization)
-    const CSyncerSet* _pSyncerSet;
+    const CSyncerSet *_pSyncerSet;
 
     // Area configuration validity (invalid area configurations can't be restored)
     bool _bValid{false};
 };
-

--- a/parameter/ArrayParameter.cpp
+++ b/parameter/ArrayParameter.cpp
@@ -41,7 +41,8 @@
 
 using std::string;
 
-CArrayParameter::CArrayParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
+CArrayParameter::CArrayParameter(const string &strName, const CTypeElement *pTypeElement)
+    : base(strName, pTypeElement)
 {
 }
 
@@ -57,7 +58,7 @@ size_t CArrayParameter::getArrayLength() const
 }
 
 // Element properties
-void CArrayParameter::showProperties(string& strResult) const
+void CArrayParameter::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -68,7 +69,8 @@ void CArrayParameter::showProperties(string& strResult) const
 }
 
 // User set/get
-bool CArrayParameter::accessValue(CPathNavigator& pathNavigator, string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::accessValue(CPathNavigator &pathNavigator, string &strValue, bool bSet,
+                                  CParameterAccessContext &parameterAccessContext) const
 {
     size_t index;
 
@@ -86,8 +88,8 @@ bool CArrayParameter::accessValue(CPathNavigator& pathNavigator, string& strValu
         }
 
         // Actually set values
-        if (!setValues(index, getOffset() - parameterAccessContext.getBaseOffset(),
-                       strValue, parameterAccessContext)) {
+        if (!setValues(index, getOffset() - parameterAccessContext.getBaseOffset(), strValue,
+                       parameterAccessContext)) {
             return false;
         }
 
@@ -102,11 +104,13 @@ bool CArrayParameter::accessValue(CPathNavigator& pathNavigator, string& strValu
         if (index == (size_t)-1) {
 
             // Whole array requested
-            strValue = getValues(getOffset() - parameterAccessContext.getBaseOffset(), parameterAccessContext);
+            strValue = getValues(getOffset() - parameterAccessContext.getBaseOffset(),
+                                 parameterAccessContext);
 
         } else {
             // Scalar requested
-            CParameter::doGetValue(strValue, getOffset() + index * getSize(), parameterAccessContext);
+            CParameter::doGetValue(strValue, getOffset() + index * getSize(),
+                                   parameterAccessContext);
         }
     }
 
@@ -115,45 +119,50 @@ bool CArrayParameter::accessValue(CPathNavigator& pathNavigator, string& strValu
 
 /// Actual parameter access
 // String access
-bool CArrayParameter::doSetValue(const string& value, size_t offset,
-                                 CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::doSetValue(const string &value, size_t offset,
+                                 CParameterAccessContext &parameterAccessContext) const
 {
     return setValues(0, offset, value, parameterAccessContext);
 }
 
-void CArrayParameter::doGetValue(string& value, size_t offset,
-                                 CParameterAccessContext& parameterAccessContext) const
+void CArrayParameter::doGetValue(string &value, size_t offset,
+                                 CParameterAccessContext &parameterAccessContext) const
 {
     // Whole array requested
     value = getValues(offset, parameterAccessContext);
 }
 
 // Boolean
-bool CArrayParameter::access(std::vector<bool>& abValues, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::access(std::vector<bool> &abValues, bool bSet,
+                             CParameterAccessContext &parameterAccessContext) const
 {
     return accessValues(abValues, bSet, parameterAccessContext);
 }
 
 // Integer
-bool CArrayParameter::access(std::vector<uint32_t>& auiValues, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::access(std::vector<uint32_t> &auiValues, bool bSet,
+                             CParameterAccessContext &parameterAccessContext) const
 {
     return accessValues(auiValues, bSet, parameterAccessContext);
 }
 
 // Signed Integer Access
-bool CArrayParameter::access(std::vector<int32_t>& aiValues, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::access(std::vector<int32_t> &aiValues, bool bSet,
+                             CParameterAccessContext &parameterAccessContext) const
 {
     return accessValues(aiValues, bSet, parameterAccessContext);
 }
 
 // Double Access
-bool CArrayParameter::access(std::vector<double>& adValues, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::access(std::vector<double> &adValues, bool bSet,
+                             CParameterAccessContext &parameterAccessContext) const
 {
     return accessValues(adValues, bSet, parameterAccessContext);
 }
 
 // String Access
-bool CArrayParameter::access(std::vector<string>& astrValues, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::access(std::vector<string> &astrValues, bool bSet,
+                             CParameterAccessContext &parameterAccessContext) const
 {
     return accessValues(astrValues, bSet, parameterAccessContext);
 }
@@ -166,13 +175,14 @@ string CArrayParameter::logValue(CParameterAccessContext &context) const
 }
 
 // Used for simulation and virtual subsystems
-void CArrayParameter::setDefaultValues(CParameterAccessContext& parameterAccessContext) const
+void CArrayParameter::setDefaultValues(CParameterAccessContext &parameterAccessContext) const
 {
     // Get default value from type
-    uint32_t uiDefaultValue = static_cast<const CParameterType*>(getTypeElement())->getDefaultValue();
+    uint32_t uiDefaultValue =
+        static_cast<const CParameterType *>(getTypeElement())->getDefaultValue();
 
     // Write blackboard
-    CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Process
     size_t valueIndex;
@@ -190,28 +200,30 @@ void CArrayParameter::setDefaultValues(CParameterAccessContext& parameterAccessC
 }
 
 // Index from path
-bool CArrayParameter::getIndex(CPathNavigator& pathNavigator, size_t& index, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::getIndex(CPathNavigator &pathNavigator, size_t &index,
+                               CParameterAccessContext &parameterAccessContext) const
 {
     index = (size_t)-1;
 
-    string* pStrChildName = pathNavigator.next();
+    string *pStrChildName = pathNavigator.next();
 
     if (pStrChildName) {
 
         // Check index is numeric
-	std::istringstream iss(*pStrChildName);
+        std::istringstream iss(*pStrChildName);
 
         iss >> index;
 
         if (!iss) {
 
-            parameterAccessContext.setError("Expected numerical expression as last item in " + pathNavigator.getCurrentPath());
+            parameterAccessContext.setError("Expected numerical expression as last item in " +
+                                            pathNavigator.getCurrentPath());
 
             return false;
         }
 
         if (index >= getArrayLength()) {
-	    std::ostringstream oss;
+            std::ostringstream oss;
 
             oss << "Provided index out of range (max is " << getArrayLength() - 1 << ")";
 
@@ -236,7 +248,8 @@ bool CArrayParameter::getIndex(CPathNavigator& pathNavigator, size_t& index, CPa
 }
 
 // Common set value processing
-bool CArrayParameter::setValues(size_t uiStartIndex, size_t offset, const string& strValue, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::setValues(size_t uiStartIndex, size_t offset, const string &strValue,
+                                CParameterAccessContext &parameterAccessContext) const
 {
     // Deal with value(s)
     Tokenizer tok(strValue, Tokenizer::defaultDelimiters + ",");
@@ -275,7 +288,8 @@ bool CArrayParameter::setValues(size_t uiStartIndex, size_t offset, const string
 }
 
 // Common get value processing
-string CArrayParameter::getValues(size_t offset, CParameterAccessContext& parameterAccessContext) const
+string CArrayParameter::getValues(size_t offset,
+                                  CParameterAccessContext &parameterAccessContext) const
 {
     size_t size = getSize();
     size_t arrayLength = getArrayLength();
@@ -307,7 +321,8 @@ string CArrayParameter::getValues(size_t offset, CParameterAccessContext& parame
 
 // Generic Access
 template <typename type>
-bool CArrayParameter::accessValues(std::vector<type>& values, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::accessValues(std::vector<type> &values, bool bSet,
+                                   CParameterAccessContext &parameterAccessContext) const
 {
     if (bSet) {
 
@@ -334,7 +349,8 @@ bool CArrayParameter::accessValues(std::vector<type>& values, bool bSet, CParame
 }
 
 template <typename type>
-bool CArrayParameter::setValues(const std::vector<type>& values, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::setValues(const std::vector<type> &values,
+                                CParameterAccessContext &parameterAccessContext) const
 {
     size_t nbValues = getArrayLength();
     size_t size = getSize();
@@ -353,11 +369,12 @@ bool CArrayParameter::setValues(const std::vector<type>& values, CParameterAcces
         offset += size;
     }
 
-   return true;
+    return true;
 }
 
 template <typename type>
-bool CArrayParameter::getValues(std::vector<type>& values, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::getValues(std::vector<type> &values,
+                                CParameterAccessContext &parameterAccessContext) const
 {
     size_t nbValues = getArrayLength();
     size_t size = getSize();
@@ -381,16 +398,18 @@ bool CArrayParameter::getValues(std::vector<type>& values, CParameterAccessConte
 }
 
 template <typename type>
-bool CArrayParameter::doSet(type value, size_t offset, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::doSet(type value, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     uint32_t uiData;
 
-    if (!static_cast<const CParameterType*>(getTypeElement())->toBlackboard(value, uiData, parameterAccessContext)) {
+    if (!static_cast<const CParameterType *>(getTypeElement())
+             ->toBlackboard(value, uiData, parameterAccessContext)) {
 
         return false;
     }
     // Write blackboard
-    CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Beware this code works on little endian architectures only!
     pBlackboard->writeInteger(&uiData, getSize(), offset);
@@ -399,16 +418,17 @@ bool CArrayParameter::doSet(type value, size_t offset, CParameterAccessContext& 
 }
 
 template <typename type>
-bool CArrayParameter::doGet(type& value, size_t offset, CParameterAccessContext& parameterAccessContext) const
+bool CArrayParameter::doGet(type &value, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     uint32_t uiData = 0;
 
     // Read blackboard
-    const CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    const CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Beware this code works on little endian architectures only!
     pBlackboard->readInteger(&uiData, getSize(), offset);
 
-    return static_cast<const CParameterType*>(getTypeElement())->fromBlackboard(value, uiData, parameterAccessContext);
+    return static_cast<const CParameterType *>(getTypeElement())
+        ->fromBlackboard(value, uiData, parameterAccessContext);
 }
-

--- a/parameter/ArrayParameter.h
+++ b/parameter/ArrayParameter.h
@@ -34,64 +34,71 @@
 class CArrayParameter : public CParameter
 {
 public:
-    CArrayParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    CArrayParameter(const std::string &strName, const CTypeElement *pTypeElement);
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;
 
     /// Value access
     using CBaseParameter::access;
-    bool access(std::vector<bool>& abValues, bool bSet,
-                       CParameterAccessContext& parameterAccessContext) const override final;
-    bool access(std::vector<uint32_t>& auiValues, bool bSet,
-                       CParameterAccessContext& parameterAccessContext) const override final;
-    bool access(std::vector<int32_t>& aiValues, bool bSet,
-                       CParameterAccessContext& parameterAccessContext) const override final;
-    bool access(std::vector<double>& adValues, bool bSet,
-                       CParameterAccessContext& parameterAccessContext) const override final;
-    bool access(std::vector<std::string>& astrValues, bool bSet,
-                       CParameterAccessContext& parameterAccessContext) const override final;
+    bool access(std::vector<bool> &abValues, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override final;
+    bool access(std::vector<uint32_t> &auiValues, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override final;
+    bool access(std::vector<int32_t> &aiValues, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override final;
+    bool access(std::vector<double> &adValues, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override final;
+    bool access(std::vector<std::string> &astrValues, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override final;
 
 protected:
     // User set/get
-    virtual bool accessValue(CPathNavigator& pathNavigator, std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool accessValue(CPathNavigator &pathNavigator, std::string &strValue, bool bSet,
+                             CParameterAccessContext &parameterAccessContext) const;
     // Used for simulation and virtual subsystems
-    virtual void setDefaultValues(CParameterAccessContext& parameterAccessContext) const;
+    virtual void setDefaultValues(CParameterAccessContext &parameterAccessContext) const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
+
 private:
     // Array length
     size_t getArrayLength() const;
     // Common set value processing
-    bool setValues(size_t uiStartIndex, size_t offset, const std::string& strValue, CParameterAccessContext& parameterAccessContext) const;
+    bool setValues(size_t uiStartIndex, size_t offset, const std::string &strValue,
+                   CParameterAccessContext &parameterAccessContext) const;
     // Log / get values common
-    std::string getValues(size_t baseOffset, CParameterAccessContext& parameterAccessContext) const;
+    std::string getValues(size_t baseOffset, CParameterAccessContext &parameterAccessContext) const;
     std::string logValue(CParameterAccessContext &context) const override;
     // Index retrieval from user set/get request
-    bool getIndex(CPathNavigator& pathNavigator, size_t& index, CParameterAccessContext& parameterAccessContext) const;
+    bool getIndex(CPathNavigator &pathNavigator, size_t &index,
+                  CParameterAccessContext &parameterAccessContext) const;
 
     /** Access whole array.
      *
      * @param[in] offset Offset of the array in the context blackboard.
      * @{
      */
-    bool doSetValue(const std::string& strValue, size_t offset,
-                    CParameterAccessContext& parameterAccessContext) const override;
-    void doGetValue(std::string& strValue, size_t offset,
-                    CParameterAccessContext& parameterAccessContext) const override;
+    bool doSetValue(const std::string &strValue, size_t offset,
+                    CParameterAccessContext &parameterAccessContext) const override;
+    void doGetValue(std::string &strValue, size_t offset,
+                    CParameterAccessContext &parameterAccessContext) const override;
     /** @} */
 
     /// Value access
     // Generic Access
     template <typename type>
-    bool accessValues(std::vector<type>& values, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    bool accessValues(std::vector<type> &values, bool bSet,
+                      CParameterAccessContext &parameterAccessContext) const;
     template <typename type>
-    bool setValues(const std::vector<type>& values, CParameterAccessContext& parameterAccessContext) const;
+    bool setValues(const std::vector<type> &values,
+                   CParameterAccessContext &parameterAccessContext) const;
     template <typename type>
-    bool getValues(std::vector<type>& values, CParameterAccessContext& parameterAccessContext) const;
+    bool getValues(std::vector<type> &values,
+                   CParameterAccessContext &parameterAccessContext) const;
     template <typename type>
-    bool doSet(type value, size_t offset, CParameterAccessContext& parameterAccessContext) const;
+    bool doSet(type value, size_t offset, CParameterAccessContext &parameterAccessContext) const;
     template <typename type>
-    bool doGet(type& value, size_t offset, CParameterAccessContext& parameterAccessContext) const;
+    bool doGet(type &value, size_t offset, CParameterAccessContext &parameterAccessContext) const;
 };

--- a/parameter/BackSynchronizer.h
+++ b/parameter/BackSynchronizer.h
@@ -40,8 +40,9 @@ class CParameterBlackboard;
 class CBackSynchronizer : private utility::NonCopyable
 {
 public:
-    CBackSynchronizer(const CConfigurableElement* pConfigurableElement)
-        : _configurableElementAggregator(_needingBackSyncList, &CConfigurableElement::hasNoValidDomainAssociated)
+    CBackSynchronizer(const CConfigurableElement *pConfigurableElement)
+        : _configurableElementAggregator(_needingBackSyncList,
+                                         &CConfigurableElement::hasNoValidDomainAssociated)
     {
         // Aggegate elements
         _configurableElementAggregator.aggegate(pConfigurableElement);
@@ -53,10 +54,9 @@ public:
 
 protected:
     // Aggregate list
-    std::list<const CConfigurableElement*> _needingBackSyncList;
+    std::list<const CConfigurableElement *> _needingBackSyncList;
 
 private:
     // Aggegator
     CConfigurableElementAggregator _configurableElementAggregator;
 };
-

--- a/parameter/BaseParameter.cpp
+++ b/parameter/BaseParameter.cpp
@@ -38,18 +38,23 @@
 
 using std::string;
 
-CBaseParameter::CBaseParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
+CBaseParameter::CBaseParameter(const string &strName, const CTypeElement *pTypeElement)
+    : base(strName, pTypeElement)
 {
 }
 
 // XML configuration settings parsing/composing
-bool CBaseParameter::serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const
+bool CBaseParameter::serializeXmlSettings(
+    CXmlElement &xmlConfigurationSettingsElementContent,
+    CConfigurationAccessContext &configurationAccessContext) const
 {
     // Handle access
     if (!configurationAccessContext.serializeOut()) {
 
         // Write to blackboard
-        if (!doSetValue(xmlConfigurationSettingsElementContent.getTextContent(), getOffset() - configurationAccessContext.getBaseOffset(), configurationAccessContext)) {
+        if (!doSetValue(xmlConfigurationSettingsElementContent.getTextContent(),
+                        getOffset() - configurationAccessContext.getBaseOffset(),
+                        configurationAccessContext)) {
 
             appendParameterPathToError(configurationAccessContext);
             return false;
@@ -59,14 +64,16 @@ bool CBaseParameter::serializeXmlSettings(CXmlElement& xmlConfigurationSettingsE
         // Get string value
         string strValue;
 
-        doGetValue(strValue, getOffset() - configurationAccessContext.getBaseOffset(), configurationAccessContext);
+        doGetValue(strValue, getOffset() - configurationAccessContext.getBaseOffset(),
+                   configurationAccessContext);
 
         // Populate value into xml text node
         xmlConfigurationSettingsElementContent.setTextContent(strValue);
     }
 
     // Done
-    return base::serializeXmlSettings(xmlConfigurationSettingsElementContent, configurationAccessContext);
+    return base::serializeXmlSettings(xmlConfigurationSettingsElementContent,
+                                      configurationAccessContext);
 }
 
 // Dump
@@ -84,57 +91,67 @@ bool CBaseParameter::isParameter() const
     return true;
 }
 
-bool CBaseParameter::access(bool& /*bValue*/, bool /*bSet*/, CParameterAccessContext& parameterAccessContext) const
+bool CBaseParameter::access(bool & /*bValue*/, bool /*bSet*/,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
-bool CBaseParameter::access(std::vector<bool>& /*abValues*/, bool /*bSet*/, CParameterAccessContext& parameterAccessContext) const
-{
-    parameterAccessContext.setError("Unsupported conversion");
-    return false;
-}
-
-bool CBaseParameter::access(uint32_t& /*bValue*/, bool /*bSet*/, CParameterAccessContext& parameterAccessContext) const
-{
-    parameterAccessContext.setError("Unsupported conversion");
-    return false;
-}
-bool CBaseParameter::access(std::vector<uint32_t>& /*abValues*/, bool /*bSet*/, CParameterAccessContext& parameterAccessContext) const
+bool CBaseParameter::access(std::vector<bool> & /*abValues*/, bool /*bSet*/,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
 
-bool CBaseParameter::access(int32_t& /*bValue*/, bool /*bSet*/, CParameterAccessContext& parameterAccessContext) const
+bool CBaseParameter::access(uint32_t & /*bValue*/, bool /*bSet*/,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
-bool CBaseParameter::access(std::vector<int32_t>& /*abValues*/, bool /*bSet*/, CParameterAccessContext& parameterAccessContext) const
+bool CBaseParameter::access(std::vector<uint32_t> & /*abValues*/, bool /*bSet*/,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
 
-bool CBaseParameter::access(double& /*bValue*/, bool /*bSet*/, CParameterAccessContext& parameterAccessContext) const
+bool CBaseParameter::access(int32_t & /*bValue*/, bool /*bSet*/,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
-bool CBaseParameter::access(std::vector<double>& /*abValues*/, bool /*bSet*/, CParameterAccessContext& parameterAccessContext) const
+bool CBaseParameter::access(std::vector<int32_t> & /*abValues*/, bool /*bSet*/,
+                            CParameterAccessContext &parameterAccessContext) const
+{
+    parameterAccessContext.setError("Unsupported conversion");
+    return false;
+}
+
+bool CBaseParameter::access(double & /*bValue*/, bool /*bSet*/,
+                            CParameterAccessContext &parameterAccessContext) const
+{
+    parameterAccessContext.setError("Unsupported conversion");
+    return false;
+}
+bool CBaseParameter::access(std::vector<double> & /*abValues*/, bool /*bSet*/,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
 
 // String Access
-bool CBaseParameter::access(string &strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CBaseParameter::access(string &strValue, bool bSet,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     if (bSet) {
 
         // Set Value
-        if (!doSetValue(strValue, getOffset() - parameterAccessContext.getBaseOffset(), parameterAccessContext)) {
+        if (!doSetValue(strValue, getOffset() - parameterAccessContext.getBaseOffset(),
+                        parameterAccessContext)) {
 
             appendParameterPathToError(parameterAccessContext);
             return false;
@@ -148,13 +165,15 @@ bool CBaseParameter::access(string &strValue, bool bSet, CParameterAccessContext
 
     } else {
         // Get Value
-        doGetValue(strValue, getOffset() - parameterAccessContext.getBaseOffset(), parameterAccessContext);
+        doGetValue(strValue, getOffset() - parameterAccessContext.getBaseOffset(),
+                   parameterAccessContext);
     }
 
     return true;
 }
 
-bool CBaseParameter::access(std::vector<string>& /*astrValues*/, bool /*bSet*/, CParameterAccessContext& /*ctx*/) const
+bool CBaseParameter::access(std::vector<string> & /*astrValues*/, bool /*bSet*/,
+                            CParameterAccessContext & /*ctx*/) const
 {
     // Generic string array access to scalar parameter must have been filtered out before
     assert(0);
@@ -163,7 +182,8 @@ bool CBaseParameter::access(std::vector<string>& /*astrValues*/, bool /*bSet*/, 
 }
 
 // Parameter Access
-bool CBaseParameter::accessValue(CPathNavigator& pathNavigator, string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CBaseParameter::accessValue(CPathNavigator &pathNavigator, string &strValue, bool bSet,
+                                 CParameterAccessContext &parameterAccessContext) const
 {
     // Check path validity
     if (!checkPathExhausted(pathNavigator, parameterAccessContext)) {
@@ -174,16 +194,16 @@ bool CBaseParameter::accessValue(CPathNavigator& pathNavigator, string& strValue
     return access(strValue, bSet, parameterAccessContext);
 }
 
-void CBaseParameter::structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+void CBaseParameter::structureToXml(CXmlElement &xmlElement,
+                                    CXmlSerializingContext &serializingContext) const
 {
 
     // Delegate to type element
     getTypeElement()->toXml(xmlElement, serializingContext);
 }
 
-
-void CBaseParameter::appendParameterPathToError(CParameterAccessContext& parameterAccessContext)
-const
+void CBaseParameter::appendParameterPathToError(
+    CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.appendToError(" " + getPath());
 }

--- a/parameter/BaseParameter.h
+++ b/parameter/BaseParameter.h
@@ -40,54 +40,70 @@ class CConfigurationAccessContext;
 class CBaseParameter : public CInstanceConfigurableElement
 {
 public:
-    CBaseParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    CBaseParameter(const std::string &strName, const CTypeElement *pTypeElement);
 
     // XML configuration settings parsing/composing
-    virtual bool serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const;
+    virtual bool serializeXmlSettings(
+        CXmlElement &xmlConfigurationSettingsElementContent,
+        CConfigurationAccessContext &configurationAccessContext) const;
 
     // Check element is a parameter
     virtual bool isParameter() const;
 
     // Boolean access
-    virtual bool access(bool& bValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool access(std::vector<bool>& abValues, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool access(bool &bValue, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
+    virtual bool access(std::vector<bool> &abValues, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
 
     // Integer Access
-    virtual bool access(uint32_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool access(std::vector<uint32_t>& auiValues, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool access(uint32_t &uiValue, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
+    virtual bool access(std::vector<uint32_t> &auiValues, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
 
     // Signed Integer Access
-    virtual bool access(int32_t& iValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool access(std::vector<int32_t>& aiValues, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool access(int32_t &iValue, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
+    virtual bool access(std::vector<int32_t> &aiValues, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
 
     // Double Access
-    virtual bool access(double& dValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool access(std::vector<double>& adValues, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool access(double &dValue, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
+    virtual bool access(std::vector<double> &adValues, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
 
     // String Access
     // This one is not virtual because it is very generic. You can think if it
     // as the client saying: "I don't care about the type, here's the value as
     // a string - convert it yourself". Then, string-to-anything and
     // anything-to-string methods are used to convert it into a suitable type.
-    bool access(std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool access(std::vector<std::string>& astrValues, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    bool access(std::string &strValue, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const;
+    virtual bool access(std::vector<std::string> &astrValues, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const;
 
-    void structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const override final;
+    void structureToXml(CXmlElement &xmlElement,
+                        CXmlSerializingContext &serializingContext) const override final;
 
 protected:
     // Parameter Access
-    virtual bool accessValue(CPathNavigator& pathNavigator, std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool accessValue(CPathNavigator &pathNavigator, std::string &strValue, bool bSet,
+                             CParameterAccessContext &parameterAccessContext) const;
 
     // Actual value access (to be implemented by derived)
-    virtual bool doSetValue(const std::string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const = 0;
-    virtual void doGetValue(std::string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const = 0;
+    virtual bool doSetValue(const std::string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const = 0;
+    virtual void doGetValue(std::string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const = 0;
 
     /**
      * Append the parameter path to the error.
      *
      * @param[in:out] parameterAccessContext Parameter Access Context object.
      */
-    void appendParameterPathToError(CParameterAccessContext& parameterAccessContext) const;
+    void appendParameterPathToError(CParameterAccessContext &parameterAccessContext) const;
 
 private:
     std::string logValue(CParameterAccessContext &context) const override;

--- a/parameter/BitParameter.cpp
+++ b/parameter/BitParameter.cpp
@@ -39,7 +39,8 @@
 
 using std::string;
 
-CBitParameter::CBitParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
+CBitParameter::CBitParameter(const string &strName, const CTypeElement *pTypeElement)
+    : base(strName, pTypeElement)
 {
 }
 
@@ -52,7 +53,7 @@ CInstanceConfigurableElement::Type CBitParameter::getType() const
 // Size
 size_t CBitParameter::getBelongingBlockSize() const
 {
-    return static_cast<const CBitParameterBlock*>(getParent())->getSize();
+    return static_cast<const CBitParameterBlock *>(getParent())->getSize();
 }
 
 // Instantiation, allocation
@@ -63,21 +64,24 @@ size_t CBitParameter::getFootPrint() const
 }
 
 // Actual parameter access (tuning)
-bool CBitParameter::doSetValue(const string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const
+bool CBitParameter::doSetValue(const string &strValue, size_t offset,
+                               CParameterAccessContext &parameterAccessContext) const
 {
     return doSet(strValue, offset, parameterAccessContext);
 }
 
-void CBitParameter::doGetValue(string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const
+void CBitParameter::doGetValue(string &strValue, size_t offset,
+                               CParameterAccessContext &parameterAccessContext) const
 {
     doGet(strValue, offset, parameterAccessContext);
 }
 
 /// Value access
-bool CBitParameter::access(bool& bValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CBitParameter::access(bool &bValue, bool bSet,
+                           CParameterAccessContext &parameterAccessContext) const
 {
     // Check boolean access validity here
-    if (static_cast<const CBitParameterType*>(getTypeElement())->getBitSize() != 1) {
+    if (static_cast<const CBitParameterType *>(getTypeElement())->getBitSize() != 1) {
 
         parameterAccessContext.setError("Type mismatch");
         appendParameterPathToError(parameterAccessContext);
@@ -106,7 +110,8 @@ bool CBitParameter::access(bool& bValue, bool bSet, CParameterAccessContext& par
     return true;
 }
 
-bool CBitParameter::access(uint32_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CBitParameter::access(uint32_t &uiValue, bool bSet,
+                           CParameterAccessContext &parameterAccessContext) const
 {
     size_t offset = getOffset();
 
@@ -133,18 +138,20 @@ bool CBitParameter::access(uint32_t& uiValue, bool bSet, CParameterAccessContext
 }
 
 template <typename type>
-bool CBitParameter::doSet(type value, size_t offset, CParameterAccessContext& parameterAccessContext) const
+bool CBitParameter::doSet(type value, size_t offset,
+                          CParameterAccessContext &parameterAccessContext) const
 {
     uint64_t uiData = 0;
 
     // Read/modify/write
-    CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Beware this code works on little endian architectures only!
     pBlackboard->readInteger(&uiData, getBelongingBlockSize(), offset);
 
     // Convert
-    if (!static_cast<const CBitParameterType*>(getTypeElement())->toBlackboard(value, uiData, parameterAccessContext)) {
+    if (!static_cast<const CBitParameterType *>(getTypeElement())
+             ->toBlackboard(value, uiData, parameterAccessContext)) {
 
         return false;
     }
@@ -155,22 +162,24 @@ bool CBitParameter::doSet(type value, size_t offset, CParameterAccessContext& pa
 }
 
 template <typename type>
-void CBitParameter::doGet(type& value, size_t offset, CParameterAccessContext& parameterAccessContext) const
+void CBitParameter::doGet(type &value, size_t offset,
+                          CParameterAccessContext &parameterAccessContext) const
 {
     uint64_t uiData = 0;
 
     // Read blackboard
-    const CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    const CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Beware this code works on little endian architectures only!
     pBlackboard->readInteger(&uiData, getBelongingBlockSize(), offset);
 
     // Convert
-    static_cast<const CBitParameterType*>(getTypeElement())->fromBlackboard(value, uiData, parameterAccessContext);
+    static_cast<const CBitParameterType *>(getTypeElement())
+        ->fromBlackboard(value, uiData, parameterAccessContext);
 }
 
 // AreaConfiguration creation
-CAreaConfiguration* CBitParameter::createAreaConfiguration(const CSyncerSet* pSyncerSet) const
+CAreaConfiguration *CBitParameter::createAreaConfiguration(const CSyncerSet *pSyncerSet) const
 {
     return new CBitwiseAreaConfiguration(this, pSyncerSet);
 }
@@ -179,5 +188,5 @@ CAreaConfiguration* CBitParameter::createAreaConfiguration(const CSyncerSet* pSy
 uint64_t CBitParameter::merge(uint64_t uiOriginData, uint64_t uiNewData) const
 {
     // Convert
-    return static_cast<const CBitParameterType*>(getTypeElement())->merge(uiOriginData, uiNewData);
+    return static_cast<const CBitParameterType *>(getTypeElement())->merge(uiOriginData, uiNewData);
 }

--- a/parameter/BitParameter.h
+++ b/parameter/BitParameter.h
@@ -36,7 +36,7 @@
 class CBitParameter : public CBaseParameter
 {
 public:
-    CBitParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    CBitParameter(const std::string &strName, const CTypeElement *pTypeElement);
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;
@@ -46,29 +46,32 @@ public:
 
     /// Value access
     // Boolean access
-    bool access(bool& bValue, bool bSet, CParameterAccessContext& parameterAccessContext) const override final;
+    bool access(bool &bValue, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override final;
 
     // Integer Access
-    bool access(uint32_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const override final;
+    bool access(uint32_t &uiValue, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override final;
 
     // AreaConfiguration creation
-    virtual CAreaConfiguration* createAreaConfiguration(const CSyncerSet* pSyncerSet) const;
+    virtual CAreaConfiguration *createAreaConfiguration(const CSyncerSet *pSyncerSet) const;
 
     // Size
     size_t getBelongingBlockSize() const;
 
     // Access from area configuration
     uint64_t merge(uint64_t uiOriginData, uint64_t uiNewData) const;
-private:
 
+private:
     // String Access
-    virtual bool doSetValue(const std::string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const;
-    virtual void doGetValue(std::string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool doSetValue(const std::string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const;
+    virtual void doGetValue(std::string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const;
 
     // Generic Access
     template <typename type>
-    bool doSet(type value, size_t offset, CParameterAccessContext& parameterAccessContext) const;
+    bool doSet(type value, size_t offset, CParameterAccessContext &parameterAccessContext) const;
     template <typename type>
-    void doGet(type& value, size_t offset, CParameterAccessContext& parameterAccessContext) const;
-
+    void doGet(type &value, size_t offset, CParameterAccessContext &parameterAccessContext) const;
 };

--- a/parameter/BitParameterBlock.cpp
+++ b/parameter/BitParameterBlock.cpp
@@ -36,7 +36,8 @@
 
 using std::string;
 
-CBitParameterBlock::CBitParameterBlock(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
+CBitParameterBlock::CBitParameterBlock(const string &strName, const CTypeElement *pTypeElement)
+    : base(strName, pTypeElement)
 {
 }
 
@@ -54,11 +55,11 @@ size_t CBitParameterBlock::getFootPrint() const
 // Size
 size_t CBitParameterBlock::getSize() const
 {
-    return static_cast<const CBitParameterBlockType*>(getTypeElement())->getSize();
+    return static_cast<const CBitParameterBlockType *>(getTypeElement())->getSize();
 }
 
 // Used for simulation and virtual subsystems
-void CBitParameterBlock::setDefaultValues(CParameterAccessContext& parameterAccessContext) const
+void CBitParameterBlock::setDefaultValues(CParameterAccessContext &parameterAccessContext) const
 {
     // Default value is 0 as their is no min bound for bit parameters,
     // thus 0 is always a valid value.
@@ -67,9 +68,9 @@ void CBitParameterBlock::setDefaultValues(CParameterAccessContext& parameterAcce
     uint64_t uiDefaultValue = 0;
 
     // Write blackboard
-    CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Beware this code works on little endian architectures only!
-    pBlackboard->writeInteger(&uiDefaultValue, getSize(), getOffset() - parameterAccessContext.getBaseOffset());
+    pBlackboard->writeInteger(&uiDefaultValue, getSize(),
+                              getOffset() - parameterAccessContext.getBaseOffset());
 }
-

--- a/parameter/BitParameterBlock.h
+++ b/parameter/BitParameterBlock.h
@@ -34,7 +34,7 @@
 class CBitParameterBlock : public CInstanceConfigurableElement
 {
 public:
-    CBitParameterBlock(const std::string& strName, const CTypeElement* pTypeElement);
+    CBitParameterBlock(const std::string &strName, const CTypeElement *pTypeElement);
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;
@@ -46,13 +46,11 @@ public:
     size_t getSize() const;
 
     // Used for simulation and virtual subsystems
-    virtual void setDefaultValues(CParameterAccessContext& parameterAccessContext) const;
+    virtual void setDefaultValues(CParameterAccessContext &parameterAccessContext) const;
 
-    void structureToXml(CXmlElement &xmlElement,
-                        CXmlSerializingContext &serializingContext) const
+    void structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
     {
         xmlElement.setAttribute("Size", getSize() * 8);
         CInstanceConfigurableElement::structureToXml(xmlElement, serializingContext);
     }
 };
-

--- a/parameter/BitParameterBlockType.cpp
+++ b/parameter/BitParameterBlockType.cpp
@@ -35,7 +35,7 @@
 
 using std::string;
 
-CBitParameterBlockType::CBitParameterBlockType(const string& strName) : base(strName)
+CBitParameterBlockType::CBitParameterBlockType(const string &strName) : base(strName)
 {
 }
 
@@ -56,7 +56,8 @@ size_t CBitParameterBlockType::getSize() const
 }
 
 // From IXmlSink
-bool CBitParameterBlockType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CBitParameterBlockType::fromXml(const CXmlElement &xmlElement,
+                                     CXmlSerializingContext &serializingContext)
 {
     // Size
     xmlElement.getAttribute("Size", _size);
@@ -67,13 +68,14 @@ bool CBitParameterBlockType::fromXml(const CXmlElement& xmlElement, CXmlSerializ
 }
 
 // Instantiation
-CInstanceConfigurableElement* CBitParameterBlockType::doInstantiate() const
+CInstanceConfigurableElement *CBitParameterBlockType::doInstantiate() const
 {
     return new CBitParameterBlock(getName(), this);
 }
 
 // From IXmlSource
-void CBitParameterBlockType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CBitParameterBlockType::toXml(CXmlElement &xmlElement,
+                                   CXmlSerializingContext &serializingContext) const
 {
     // Size
     xmlElement.setAttribute("Size", _size * 8);

--- a/parameter/BitParameterBlockType.h
+++ b/parameter/BitParameterBlockType.h
@@ -36,25 +36,25 @@
 class CBitParameterBlockType : public CTypeElement
 {
 public:
-    CBitParameterBlockType(const std::string& strName);
+    CBitParameterBlockType(const std::string &strName);
 
     // Size
     size_t getSize() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // CElement
     virtual std::string getKind() const;
+
 private:
     virtual bool childrenAreDynamic() const;
     // Instantiation
-    virtual CInstanceConfigurableElement* doInstantiate() const;
+    virtual CInstanceConfigurableElement *doInstantiate() const;
 
     // Size in bytes
     size_t _size{0};
 };
-

--- a/parameter/BitParameterType.cpp
+++ b/parameter/BitParameterType.cpp
@@ -39,7 +39,7 @@
 
 using std::string;
 
-CBitParameterType::CBitParameterType(const string& strName) : base(strName)
+CBitParameterType::CBitParameterType(const string &strName) : base(strName)
 {
 }
 
@@ -50,7 +50,7 @@ string CBitParameterType::getKind() const
 }
 
 // Element properties
-void CBitParameterType::showProperties(string& strResult) const
+void CBitParameterType::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -71,7 +71,8 @@ void CBitParameterType::showProperties(string& strResult) const
 }
 
 // From IXmlSink
-bool CBitParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CBitParameterType::fromXml(const CXmlElement &xmlElement,
+                                CXmlSerializingContext &serializingContext)
 {
     // Pos
     xmlElement.getAttribute("Pos", _bitPos);
@@ -80,16 +81,18 @@ bool CBitParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingCo
     xmlElement.getAttribute("Size", _uiBitSize);
 
     // Validate bit pos and size still fit into parent type
-    const CBitParameterBlockType* pBitParameterBlockType = static_cast<const CBitParameterBlockType*>(getParent());
+    const CBitParameterBlockType *pBitParameterBlockType =
+        static_cast<const CBitParameterBlockType *>(getParent());
 
     size_t uiParentBlockBitSize = pBitParameterBlockType->getSize() * 8;
 
     if (_bitPos + _uiBitSize > uiParentBlockBitSize) {
 
         // Range exceeded
-	std::ostringstream strStream;
+        std::ostringstream strStream;
 
-        strStream << "Pos and Size attributes inconsistent with maximum container element size (" << uiParentBlockBitSize << " bits) for " + getKind();
+        strStream << "Pos and Size attributes inconsistent with maximum container element size ("
+                  << uiParentBlockBitSize << " bits) for " + getKind();
 
         serializingContext.setError(strStream.str());
 
@@ -103,7 +106,8 @@ bool CBitParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingCo
         // Max value exceeded
         std::ostringstream strStream;
 
-        strStream << "Max attribute inconsistent with maximum encodable size (" << getMaxEncodableValue() << ") for " + getKind();
+        strStream << "Max attribute inconsistent with maximum encodable size ("
+                  << getMaxEncodableValue() << ") for " + getKind();
 
         serializingContext.setError(strStream.str());
 
@@ -115,7 +119,8 @@ bool CBitParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingCo
 }
 
 // Conversion
-bool CBitParameterType::toBlackboard(const string& strValue, uint64_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CBitParameterType::toBlackboard(const string &strValue, uint64_t &uiValue,
+                                     CParameterAccessContext &parameterAccessContext) const
 {
     // Get value
     uint64_t uiConvertedValue = strtoull(strValue.c_str(), NULL, 0);
@@ -123,13 +128,14 @@ bool CBitParameterType::toBlackboard(const string& strValue, uint64_t& uiValue, 
     if (uiConvertedValue > _uiMax) {
 
         // Range exceeded
-	std::ostringstream strStream;
+        std::ostringstream strStream;
 
         strStream << "Value " << strValue << " standing out of admitted range [";
 
         if (utility::isHexadecimal(strValue)) {
 
-            strStream << "0x0, " << "0x" << std::hex << std::uppercase;
+            strStream << "0x0, "
+                      << "0x" << std::hex << std::uppercase;
         } else {
 
             strStream << "0, ";
@@ -147,7 +153,8 @@ bool CBitParameterType::toBlackboard(const string& strValue, uint64_t& uiValue, 
     return true;
 }
 
-void CBitParameterType::fromBlackboard(string& strValue, const uint64_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+void CBitParameterType::fromBlackboard(string &strValue, const uint64_t &uiValue,
+                                       CParameterAccessContext &parameterAccessContext) const
 {
     uint64_t uiConvertedValue = (uiValue & getMask()) >> _bitPos;
 
@@ -167,7 +174,8 @@ void CBitParameterType::fromBlackboard(string& strValue, const uint64_t& uiValue
 
 // Value access
 // Integer
-bool CBitParameterType::toBlackboard(uint64_t uiUserValue, uint64_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CBitParameterType::toBlackboard(uint64_t uiUserValue, uint64_t &uiValue,
+                                     CParameterAccessContext &parameterAccessContext) const
 {
     if (uiUserValue > _uiMax) {
 
@@ -182,7 +190,8 @@ bool CBitParameterType::toBlackboard(uint64_t uiUserValue, uint64_t& uiValue, CP
     return true;
 }
 
-void CBitParameterType::fromBlackboard(uint32_t& userValue, uint64_t value, CParameterAccessContext& /*ctx*/) const
+void CBitParameterType::fromBlackboard(uint32_t &userValue, uint64_t value,
+                                       CParameterAccessContext & /*ctx*/) const
 {
     userValue = static_cast<uint32_t>((value & getMask()) >> _bitPos);
 }
@@ -199,7 +208,7 @@ size_t CBitParameterType::getBitSize() const
     return _uiBitSize;
 }
 
-CInstanceConfigurableElement* CBitParameterType::doInstantiate() const
+CInstanceConfigurableElement *CBitParameterType::doInstantiate() const
 {
     return new CBitParameter(getName(), this);
 }
@@ -231,7 +240,8 @@ bool CBitParameterType::isEncodable(uint64_t uiData) const
 }
 
 // From IXmlSource
-void CBitParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CBitParameterType::toXml(CXmlElement &xmlElement,
+                              CXmlSerializingContext &serializingContext) const
 {
     // Position
     xmlElement.setAttribute("Pos", _bitPos);
@@ -243,5 +253,4 @@ void CBitParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& s
     xmlElement.setAttribute("Max", _uiMax);
 
     base::toXml(xmlElement, serializingContext);
-
 }

--- a/parameter/BitParameterType.h
+++ b/parameter/BitParameterType.h
@@ -41,20 +41,24 @@ class CParameterAccessContext;
 class CBitParameterType : public CTypeElement
 {
 public:
-    CBitParameterType(const std::string& strName);
+    CBitParameterType(const std::string &strName);
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
     /// Conversion
     // String
-    bool toBlackboard(const std::string& strValue, uint64_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    void fromBlackboard(std::string& strValue, const uint64_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    bool toBlackboard(const std::string &strValue, uint64_t &uiValue,
+                      CParameterAccessContext &parameterAccessContext) const;
+    void fromBlackboard(std::string &strValue, const uint64_t &uiValue,
+                        CParameterAccessContext &parameterAccessContext) const;
     // Integer
-    bool toBlackboard(uint64_t uiUserValue, uint64_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    void fromBlackboard(uint32_t& uiUserValue, uint64_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    bool toBlackboard(uint64_t uiUserValue, uint64_t &uiValue,
+                      CParameterAccessContext &parameterAccessContext) const;
+    void fromBlackboard(uint32_t &uiUserValue, uint64_t uiValue,
+                        CParameterAccessContext &parameterAccessContext) const;
     // Access from area configuration
     uint64_t merge(uint64_t uiOriginData, uint64_t uiNewData) const;
 
@@ -62,7 +66,7 @@ public:
     size_t getBitSize() const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // CElement
     virtual std::string getKind() const;
@@ -76,7 +80,7 @@ public:
     size_t getBitPos() const { return _bitPos; }
 private:
     // Instantiation
-    virtual CInstanceConfigurableElement* doInstantiate() const;
+    virtual CInstanceConfigurableElement *doInstantiate() const;
     // Max encodable value
     uint64_t getMaxEncodableValue() const;
     // Biwise mask

--- a/parameter/BitwiseAreaConfiguration.cpp
+++ b/parameter/BitwiseAreaConfiguration.cpp
@@ -33,16 +33,18 @@
 
 #define base CAreaConfiguration
 
-CBitwiseAreaConfiguration::CBitwiseAreaConfiguration(const CConfigurableElement *pConfigurableElement, const CSyncerSet *pSyncerSet)
-    : base(pConfigurableElement, pSyncerSet, static_cast<const CBitParameter*>(pConfigurableElement)->getBelongingBlockSize())
+CBitwiseAreaConfiguration::CBitwiseAreaConfiguration(
+    const CConfigurableElement *pConfigurableElement, const CSyncerSet *pSyncerSet)
+    : base(pConfigurableElement, pSyncerSet,
+           static_cast<const CBitParameter *>(pConfigurableElement)->getBelongingBlockSize())
 {
 }
 
 // Blackboard copies
-void CBitwiseAreaConfiguration::copyTo(CParameterBlackboard* pToBlackboard, size_t offset) const
+void CBitwiseAreaConfiguration::copyTo(CParameterBlackboard *pToBlackboard, size_t offset) const
 {
     // Beware this code works on little endian architectures only!
-    const CBitParameter* pBitParameter = static_cast<const CBitParameter*>(_pConfigurableElement);
+    const CBitParameter *pBitParameter = static_cast<const CBitParameter *>(_pConfigurableElement);
 
     uint64_t uiSrcData = 0;
     uint64_t uiDstData = 0;
@@ -62,10 +64,10 @@ void CBitwiseAreaConfiguration::copyTo(CParameterBlackboard* pToBlackboard, size
     pToBlackboard->writeInteger(&uiDstData, pBitParameter->getBelongingBlockSize(), offset);
 }
 
-void CBitwiseAreaConfiguration::copyFrom(const CParameterBlackboard* pFromBlackboard, size_t offset)
+void CBitwiseAreaConfiguration::copyFrom(const CParameterBlackboard *pFromBlackboard, size_t offset)
 {
     // Beware this code works on little endian architectures only!
-    const CBitParameter* pBitParameter = static_cast<const CBitParameter*>(_pConfigurableElement);
+    const CBitParameter *pBitParameter = static_cast<const CBitParameter *>(_pConfigurableElement);
 
     uint64_t uiSrcData = 0;
     uint64_t uiDstData = 0;
@@ -84,4 +86,3 @@ void CBitwiseAreaConfiguration::copyFrom(const CParameterBlackboard* pFromBlackb
     // Write dst blackboard
     _blackboard.writeInteger(&uiDstData, pBitParameter->getBelongingBlockSize(), 0);
 }
-

--- a/parameter/BitwiseAreaConfiguration.h
+++ b/parameter/BitwiseAreaConfiguration.h
@@ -36,11 +36,11 @@ class CBitParameter;
 class CBitwiseAreaConfiguration : public CAreaConfiguration
 {
 public:
-    CBitwiseAreaConfiguration(const CConfigurableElement* pConfigurableElement, const CSyncerSet* pSyncerSet);
+    CBitwiseAreaConfiguration(const CConfigurableElement *pConfigurableElement,
+                              const CSyncerSet *pSyncerSet);
 
 private:
     // Blackboard copies
-    virtual void copyTo(CParameterBlackboard* pToBlackboard, size_t offset) const;
-    virtual void copyFrom(const CParameterBlackboard* pFromBlackboard, size_t offset);
+    virtual void copyTo(CParameterBlackboard *pToBlackboard, size_t offset) const;
+    virtual void copyFrom(const CParameterBlackboard *pFromBlackboard, size_t offset);
 };
-

--- a/parameter/BooleanParameterType.cpp
+++ b/parameter/BooleanParameterType.cpp
@@ -33,7 +33,7 @@
 
 #define base CParameterType
 
-CBooleanParameterType::CBooleanParameterType(const std::string& strName) : base(strName)
+CBooleanParameterType::CBooleanParameterType(const std::string &strName) : base(strName)
 {
     setSize(1);
 }
@@ -44,7 +44,8 @@ std::string CBooleanParameterType::getKind() const
 }
 
 // Tuning interface
-bool CBooleanParameterType::toBlackboard(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CBooleanParameterType::toBlackboard(const std::string &strValue, uint32_t &uiValue,
+                                         CParameterAccessContext &parameterAccessContext) const
 {
     if (strValue == "1" || strValue == "0x1") {
 
@@ -70,7 +71,8 @@ bool CBooleanParameterType::toBlackboard(const std::string& strValue, uint32_t& 
     return true;
 }
 
-bool CBooleanParameterType::fromBlackboard(std::string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CBooleanParameterType::fromBlackboard(std::string &strValue, const uint32_t &uiValue,
+                                           CParameterAccessContext &parameterAccessContext) const
 {
     strValue = uiValue ? "1" : "0";
 
@@ -83,14 +85,16 @@ bool CBooleanParameterType::fromBlackboard(std::string& strValue, const uint32_t
 }
 
 // Value access
-bool CBooleanParameterType::toBlackboard(bool bUserValue, uint32_t& uiValue, CParameterAccessContext& /*ctx*/) const
+bool CBooleanParameterType::toBlackboard(bool bUserValue, uint32_t &uiValue,
+                                         CParameterAccessContext & /*ctx*/) const
 {
     uiValue = bUserValue;
 
     return true;
 }
 
-bool CBooleanParameterType::fromBlackboard(bool& bUserValue, uint32_t uiValue, CParameterAccessContext& /*ctx*/) const
+bool CBooleanParameterType::fromBlackboard(bool &bUserValue, uint32_t uiValue,
+                                           CParameterAccessContext & /*ctx*/) const
 {
     bUserValue = uiValue != 0;
 
@@ -98,7 +102,8 @@ bool CBooleanParameterType::fromBlackboard(bool& bUserValue, uint32_t uiValue, C
 }
 
 // Integer
-bool CBooleanParameterType::toBlackboard(uint32_t uiUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CBooleanParameterType::toBlackboard(uint32_t uiUserValue, uint32_t &uiValue,
+                                         CParameterAccessContext &parameterAccessContext) const
 {
     if (uiUserValue > 1) {
 
@@ -110,7 +115,8 @@ bool CBooleanParameterType::toBlackboard(uint32_t uiUserValue, uint32_t& uiValue
     return true;
 }
 
-bool CBooleanParameterType::fromBlackboard(uint32_t& uiUserValue, uint32_t uiValue, CParameterAccessContext& /*ctx*/) const
+bool CBooleanParameterType::fromBlackboard(uint32_t &uiUserValue, uint32_t uiValue,
+                                           CParameterAccessContext & /*ctx*/) const
 {
     uiUserValue = uiValue != 0;
 

--- a/parameter/BooleanParameterType.h
+++ b/parameter/BooleanParameterType.h
@@ -36,7 +36,7 @@
 class CBooleanParameterType : public CParameterType
 {
 public:
-    CBooleanParameterType(const std::string& strName);
+    CBooleanParameterType(const std::string &strName);
     virtual ~CBooleanParameterType() = default;
 
     // Kind
@@ -44,12 +44,18 @@ public:
 
     /// Conversion
     // String
-    virtual bool toBlackboard(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(std::string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(const std::string &strValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(std::string &strValue, const uint32_t &uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Boolean
-    virtual bool toBlackboard(bool bUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(bool& bUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(bool bUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(bool &bUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Integer
-    virtual bool toBlackboard(uint32_t uiUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(uint32_t& uiUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(uint32_t uiUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(uint32_t &uiUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
 };

--- a/parameter/Component.h
+++ b/parameter/Component.h
@@ -36,14 +36,11 @@
 class CComponent : public CInstanceConfigurableElement
 {
 public:
-    CComponent(const std::string& strName, const CTypeElement* pTypeElement) : CInstanceConfigurableElement(strName, pTypeElement)
+    CComponent(const std::string &strName, const CTypeElement *pTypeElement)
+        : CInstanceConfigurableElement(strName, pTypeElement)
     {
     }
 
     // Type
-    virtual Type getType() const
-    {
-        return EComponent;
-    }
+    virtual Type getType() const { return EComponent; }
 };
-

--- a/parameter/ComponentInstance.cpp
+++ b/parameter/ComponentInstance.cpp
@@ -36,7 +36,7 @@
 
 #define base CTypeElement
 
-CComponentInstance::CComponentInstance(const std::string& strName) : base(strName)
+CComponentInstance::CComponentInstance(const std::string &strName) : base(strName)
 {
 }
 
@@ -57,10 +57,12 @@ bool CComponentInstance::childrenAreDynamic() const
     return true;
 }
 
-bool CComponentInstance::getMappingData(const std::string& strKey, const std::string*& pStrValue) const
+bool CComponentInstance::getMappingData(const std::string &strKey,
+                                        const std::string *&pStrValue) const
 {
     // Try myself first then associated component type
-    return base::getMappingData(strKey, pStrValue) || (_pComponentType && _pComponentType->getMappingData(strKey, pStrValue));
+    return base::getMappingData(strKey, pStrValue) ||
+           (_pComponentType && _pComponentType->getMappingData(strKey, pStrValue));
 }
 
 bool CComponentInstance::hasMappingData() const
@@ -81,12 +83,14 @@ std::string CComponentInstance::getFormattedMapping() const
     return strValue;
 }
 
-bool CComponentInstance::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CComponentInstance::fromXml(const CXmlElement &xmlElement,
+                                 CXmlSerializingContext &serializingContext)
 {
     // Context
-    CXmlParameterSerializingContext& parameterBuildContext = static_cast<CXmlParameterSerializingContext&>(serializingContext);
+    CXmlParameterSerializingContext &parameterBuildContext =
+        static_cast<CXmlParameterSerializingContext &>(serializingContext);
 
-    const CComponentLibrary* pComponentLibrary = parameterBuildContext.getComponentLibrary();
+    const CComponentLibrary *pComponentLibrary = parameterBuildContext.getComponentLibrary();
 
     std::string strComponentType;
     xmlElement.getAttribute("Type", strComponentType);
@@ -95,13 +99,16 @@ bool CComponentInstance::fromXml(const CXmlElement& xmlElement, CXmlSerializingC
 
     if (!_pComponentType) {
 
-        serializingContext.setError("Unable to create Component " + xmlElement.getPath() + ". ComponentType " + strComponentType + " not found!");
+        serializingContext.setError("Unable to create Component " + xmlElement.getPath() +
+                                    ". ComponentType " + strComponentType + " not found!");
 
         return false;
     }
     if (_pComponentType == getParent()) {
 
-        serializingContext.setError("Recursive definition of " + _pComponentType->getName() + " due to " + xmlElement.getPath() + " referring to one of its own type.");
+        serializingContext.setError("Recursive definition of " + _pComponentType->getName() +
+                                    " due to " + xmlElement.getPath() +
+                                    " referring to one of its own type.");
 
         return false;
     }
@@ -109,7 +116,7 @@ bool CComponentInstance::fromXml(const CXmlElement& xmlElement, CXmlSerializingC
     return base::fromXml(xmlElement, serializingContext);
 }
 
-CInstanceConfigurableElement* CComponentInstance::doInstantiate() const
+CInstanceConfigurableElement *CComponentInstance::doInstantiate() const
 {
     if (isScalar()) {
         return new CComponent(getName(), this);
@@ -118,7 +125,7 @@ CInstanceConfigurableElement* CComponentInstance::doInstantiate() const
     }
 }
 
-void CComponentInstance::populate(CElement* pElement) const
+void CComponentInstance::populate(CElement *pElement) const
 {
     size_t arrayLength = getArrayLength();
 
@@ -127,7 +134,7 @@ void CComponentInstance::populate(CElement* pElement) const
         // Create child elements
         for (size_t child = 0; child < arrayLength; child++) {
 
-            CComponent* pChildComponent = new CComponent(std::to_string(child), this);
+            CComponent *pChildComponent = new CComponent(std::to_string(child), this);
 
             pElement->addChild(pChildComponent);
 
@@ -138,6 +145,6 @@ void CComponentInstance::populate(CElement* pElement) const
     } else {
         base::populate(pElement);
 
-        _pComponentType->populate(static_cast<CComponent*>(pElement));
+        _pComponentType->populate(static_cast<CComponent *>(pElement));
     }
 }

--- a/parameter/ComponentInstance.h
+++ b/parameter/ComponentInstance.h
@@ -38,10 +38,10 @@ class CComponentType;
 class CComponentInstance : public CTypeElement
 {
 public:
-    CComponentInstance(const std::string& strName);
+    CComponentInstance(const std::string &strName);
 
     // Mapping info
-    virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const;
+    virtual bool getMappingData(const std::string &strKey, const std::string *&pStrValue) const;
     virtual bool hasMappingData() const;
     /**
      * Returns the mapping associated to the current TypeElement instance
@@ -51,17 +51,17 @@ public:
     virtual std::string getFormattedMapping() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // CElement
     virtual std::string getKind() const;
     std::string getXmlElementName() const override;
+
 private:
     virtual bool childrenAreDynamic() const;
-    virtual CInstanceConfigurableElement* doInstantiate() const;
-    virtual void populate(CElement* pElement) const;
+    virtual CInstanceConfigurableElement *doInstantiate() const;
+    virtual void populate(CElement *pElement) const;
 
     // Related component type
-    const CComponentType* _pComponentType{nullptr};
+    const CComponentType *_pComponentType{nullptr};
 };
-

--- a/parameter/ComponentLibrary.cpp
+++ b/parameter/ComponentLibrary.cpp
@@ -41,13 +41,13 @@ std::string CComponentLibrary::getKind() const
     return "ComponentLibrary";
 }
 
-const CComponentType* CComponentLibrary::getComponentType(const std::string& strName) const
+const CComponentType *CComponentLibrary::getComponentType(const std::string &strName) const
 {
-    return static_cast<const CComponentType*>(findChild(strName));
+    return static_cast<const CComponentType *>(findChild(strName));
 }
 
-bool CComponentLibrary::fromXml(const CXmlElement& xmlElement,
-                                CXmlSerializingContext& serializingContext)
+bool CComponentLibrary::fromXml(const CXmlElement &xmlElement,
+                                CXmlSerializingContext &serializingContext)
 {
     CXmlElement childElement;
 
@@ -66,7 +66,7 @@ bool CComponentLibrary::fromXml(const CXmlElement& xmlElement,
             }
         } else {
             // Regular child creation and populating
-            CElement* pChild = createChild(childElement, serializingContext);
+            CElement *pChild = createChild(childElement, serializingContext);
 
             if (!pChild || !pChild->fromXml(childElement, serializingContext)) {
 
@@ -77,4 +77,3 @@ bool CComponentLibrary::fromXml(const CXmlElement& xmlElement,
 
     return true;
 }
-

--- a/parameter/ComponentLibrary.h
+++ b/parameter/ComponentLibrary.h
@@ -40,12 +40,12 @@ class CComponentType;
 class CComponentLibrary : public CElement
 {
 public:
-    const CComponentType* getComponentType(const std::string& strName) const;
+    const CComponentType *getComponentType(const std::string &strName) const;
 
     virtual std::string getKind() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
 private:
     virtual bool childrenAreDynamic() const;

--- a/parameter/ComponentType.cpp
+++ b/parameter/ComponentType.cpp
@@ -35,7 +35,7 @@
 
 #define base CTypeElement
 
-CComponentType::CComponentType(const std::string& strName) : base(strName)
+CComponentType::CComponentType(const std::string &strName) : base(strName)
 {
 }
 
@@ -49,16 +49,18 @@ bool CComponentType::childrenAreDynamic() const
     return true;
 }
 
-bool CComponentType::getMappingData(const std::string& strKey, const std::string*& pStrValue) const
+bool CComponentType::getMappingData(const std::string &strKey, const std::string *&pStrValue) const
 {
     // Try myself first then extended component type
-    return base::getMappingData(strKey, pStrValue) || (_pExtendsComponentType && _pExtendsComponentType->getMappingData(strKey, pStrValue));
+    return base::getMappingData(strKey, pStrValue) ||
+           (_pExtendsComponentType && _pExtendsComponentType->getMappingData(strKey, pStrValue));
 }
 
 bool CComponentType::hasMappingData() const
 {
     // Try myself first then extended component type
-    return base::hasMappingData() || (_pExtendsComponentType && _pExtendsComponentType->hasMappingData());
+    return base::hasMappingData() ||
+           (_pExtendsComponentType && _pExtendsComponentType->hasMappingData());
 }
 
 std::string CComponentType::getFormattedMapping() const
@@ -73,12 +75,14 @@ std::string CComponentType::getFormattedMapping() const
     return strValue;
 }
 
-bool CComponentType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CComponentType::fromXml(const CXmlElement &xmlElement,
+                             CXmlSerializingContext &serializingContext)
 {
     // Context
-    CXmlParameterSerializingContext& parameterBuildContext = static_cast<CXmlParameterSerializingContext&>(serializingContext);
+    CXmlParameterSerializingContext &parameterBuildContext =
+        static_cast<CXmlParameterSerializingContext &>(serializingContext);
 
-    const CComponentLibrary* pComponentLibrary = parameterBuildContext.getComponentLibrary();
+    const CComponentLibrary *pComponentLibrary = parameterBuildContext.getComponentLibrary();
 
     // Populate children
     if (!base::fromXml(xmlElement, serializingContext)) {
@@ -96,14 +100,16 @@ bool CComponentType::fromXml(const CXmlElement& xmlElement, CXmlSerializingConte
 
         if (!_pExtendsComponentType) {
 
-            serializingContext.setError("ComponentType " + strExtendsType + " referred to by " + xmlElement.getPath() + " not found!");
+            serializingContext.setError("ComponentType " + strExtendsType + " referred to by " +
+                                        xmlElement.getPath() + " not found!");
 
             return false;
         }
 
         if (_pExtendsComponentType == this) {
 
-            serializingContext.setError("Recursive ComponentType definition of " + xmlElement.getPath());
+            serializingContext.setError("Recursive ComponentType definition of " +
+                                        xmlElement.getPath());
 
             return false;
         }
@@ -112,7 +118,7 @@ bool CComponentType::fromXml(const CXmlElement& xmlElement, CXmlSerializingConte
     return true;
 }
 
-void CComponentType::populate(CElement* pElement) const
+void CComponentType::populate(CElement *pElement) const
 {
     // Populate children
     base::populate(pElement);
@@ -125,7 +131,7 @@ void CComponentType::populate(CElement* pElement) const
     }
 }
 
-CInstanceConfigurableElement* CComponentType::doInstantiate() const
+CInstanceConfigurableElement *CComponentType::doInstantiate() const
 {
     // Not supposed to be called directly (instantiation made through CComponentInstance object)
     assert(0);

--- a/parameter/ComponentType.h
+++ b/parameter/ComponentType.h
@@ -38,13 +38,13 @@ class CInstanceConfigurableElement;
 class CComponentType : public CTypeElement
 {
 public:
-    CComponentType(const std::string& strName);
+    CComponentType(const std::string &strName);
 
     // Object creation
-    virtual void populate(CElement* pElement) const;
+    virtual void populate(CElement *pElement) const;
 
     // Mapping info
-    virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const;
+    virtual bool getMappingData(const std::string &strKey, const std::string *&pStrValue) const;
     virtual bool hasMappingData() const;
     /**
      * Returns the mapping associated to the current TypeElement instance
@@ -54,15 +54,16 @@ public:
     virtual std::string getFormattedMapping() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
     // CElement
     virtual std::string getKind() const;
+
 private:
     // CElement
     virtual bool childrenAreDynamic() const;
     // Component creation
-    virtual CInstanceConfigurableElement* doInstantiate() const;
+    virtual CInstanceConfigurableElement *doInstantiate() const;
 
     // Ref
-    const CComponentType* _pExtendsComponentType{nullptr};
+    const CComponentType *_pExtendsComponentType{nullptr};
 };

--- a/parameter/CompoundRule.cpp
+++ b/parameter/CompoundRule.cpp
@@ -35,10 +35,7 @@
 using std::string;
 
 // Types
-const char* CCompoundRule::_apcTypes[2] = {
-    "Any",
-    "All"
-};
+const char *CCompoundRule::_apcTypes[2] = {"Any", "All"};
 
 // Class kind
 string CCompoundRule::getKind() const
@@ -53,14 +50,14 @@ bool CCompoundRule::childrenAreDynamic() const
 }
 
 // Content dumping
-string CCompoundRule::logValue(utility::ErrorContext& /*ctx*/) const
+string CCompoundRule::logValue(utility::ErrorContext & /*ctx*/) const
 {
     // Type
     return _apcTypes[_bTypeAll];
 }
 
 // Parse
-bool CCompoundRule::parse(CRuleParser& ruleParser, string& strError)
+bool CCompoundRule::parse(CRuleParser &ruleParser, string &strError)
 {
     // Get rule type
     for (size_t typeIndex = 0; typeIndex < 2; typeIndex++) {
@@ -99,7 +96,7 @@ string CCompoundRule::dump() const
         }
 
         // Dump inner rule
-        const CRule* pRule = static_cast<const CRule*>(getChild(uiChild));
+        const CRule *pRule = static_cast<const CRule *>(getChild(uiChild));
 
         output += pRule->dump();
 
@@ -118,7 +115,7 @@ bool CCompoundRule::matches() const
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        const CRule* pRule = static_cast<const CRule*>(getChild(uiChild));
+        const CRule *pRule = static_cast<const CRule *>(getChild(uiChild));
 
         if (pRule->matches() ^ _bTypeAll) {
 
@@ -129,7 +126,8 @@ bool CCompoundRule::matches() const
 }
 
 // From IXmlSink
-bool CCompoundRule::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CCompoundRule::fromXml(const CXmlElement &xmlElement,
+                            CXmlSerializingContext &serializingContext)
 {
     // Get type
     string strType;
@@ -141,7 +139,7 @@ bool CCompoundRule::fromXml(const CXmlElement& xmlElement, CXmlSerializingContex
 }
 
 // From IXmlSource
-void CCompoundRule::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CCompoundRule::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
 {
     // Set type
     xmlElement.setAttribute("Type", _apcTypes[_bTypeAll]);

--- a/parameter/CompoundRule.h
+++ b/parameter/CompoundRule.h
@@ -37,7 +37,7 @@ class CCompoundRule : public CRule
 {
 public:
     // Parse
-    virtual bool parse(CRuleParser& ruleParser, std::string& strError);
+    virtual bool parse(CRuleParser &ruleParser, std::string &strError);
 
     // Dump
     std::string dump() const override;
@@ -46,16 +46,17 @@ public:
     virtual bool matches() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // Class kind
     virtual std::string getKind() const;
+
 private:
     // Content dumping
-    std::string logValue(utility::ErrorContext& errorContext) const override;
+    std::string logValue(utility::ErrorContext &errorContext) const override;
 
     // Returns true if children dynamic creation is to be dealt with
     virtual bool childrenAreDynamic() const;
@@ -64,5 +65,5 @@ private:
     bool _bTypeAll{false};
 
     // Types
-    static const char* _apcTypes[];
+    static const char *_apcTypes[];
 };

--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -42,7 +42,7 @@
 
 using std::string;
 
-CConfigurableDomain::CConfigurableDomain(const string& strName) : base(strName)
+CConfigurableDomain::CConfigurableDomain(const string &strName) : base(strName)
 {
 }
 
@@ -53,7 +53,7 @@ CConfigurableDomain::~CConfigurableDomain()
 
     for (it = _configurableElementList.begin(); it != _configurableElementList.end(); ++it) {
 
-        CConfigurableElement* pConfigurableElement = *it;
+        CConfigurableElement *pConfigurableElement = *it;
 
         // Remove from configurable element
         pConfigurableElement->removeAttachedConfigurableDomain(this);
@@ -62,7 +62,8 @@ CConfigurableDomain::~CConfigurableDomain()
     // Remove all associated syncer sets
     ConfigurableElementToSyncerSetMapIterator mapIt;
 
-    for (mapIt = _configurableElementToSyncerSetMap.begin(); mapIt != _configurableElementToSyncerSetMap.end(); ++mapIt) {
+    for (mapIt = _configurableElementToSyncerSetMap.begin();
+         mapIt != _configurableElementToSyncerSetMap.end(); ++mapIt) {
 
         delete mapIt->second;
     }
@@ -79,17 +80,16 @@ bool CConfigurableDomain::childrenAreDynamic() const
 }
 
 // Content dumping
-string CConfigurableDomain::logValue(utility::ErrorContext& /*ctx*/) const
+string CConfigurableDomain::logValue(utility::ErrorContext & /*ctx*/) const
 {
     return string("{") +
 
-        "Sequence aware: " +
-        (_bSequenceAware ? "yes" : "no") +
+           "Sequence aware: " + (_bSequenceAware ? "yes" : "no") +
 
-        ", Last applied configuration: " +
-        (_pLastAppliedConfiguration ? _pLastAppliedConfiguration->getName() : "<none>") +
+           ", Last applied configuration: " +
+           (_pLastAppliedConfiguration ? _pLastAppliedConfiguration->getName() : "<none>") +
 
-        "}";
+           "}";
 }
 
 // Sequence awareness
@@ -107,7 +107,8 @@ bool CConfigurableDomain::getSequenceAwareness() const
 }
 
 // From IXmlSource
-void CConfigurableDomain::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CConfigurableDomain::toXml(CXmlElement &xmlElement,
+                                CXmlSerializingContext &serializingContext) const
 {
     base::toXml(xmlElement, serializingContext);
 
@@ -115,8 +116,8 @@ void CConfigurableDomain::toXml(CXmlElement& xmlElement, CXmlSerializingContext&
     xmlElement.setAttribute("SequenceAware", _bSequenceAware);
 }
 
-void CConfigurableDomain::childrenToXml(CXmlElement& xmlElement,
-                                        CXmlSerializingContext& serializingContext) const
+void CConfigurableDomain::childrenToXml(CXmlElement &xmlElement,
+                                        CXmlSerializingContext &serializingContext) const
 {
     // Configurations
     composeDomainConfigurations(xmlElement, serializingContext);
@@ -129,7 +130,8 @@ void CConfigurableDomain::childrenToXml(CXmlElement& xmlElement,
 }
 
 // XML composing
-void CConfigurableDomain::composeDomainConfigurations(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CConfigurableDomain::composeDomainConfigurations(
+    CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
 {
     // Create Configurations element
     CXmlElement xmlConfigurationsElement;
@@ -140,7 +142,7 @@ void CConfigurableDomain::composeDomainConfigurations(CXmlElement& xmlElement, C
     base::childrenToXml(xmlConfigurationsElement, serializingContext);
 }
 
-void CConfigurableDomain::composeConfigurableElements(CXmlElement& xmlElement) const
+void CConfigurableDomain::composeConfigurableElements(CXmlElement &xmlElement) const
 {
     // Create ConfigurableElements element
     CXmlElement xmlConfigurableElementsElement;
@@ -152,19 +154,21 @@ void CConfigurableDomain::composeConfigurableElements(CXmlElement& xmlElement) c
 
     for (it = _configurableElementList.begin(); it != _configurableElementList.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;
+        const CConfigurableElement *pConfigurableElement = *it;
 
         // Create corresponding XML child element
         CXmlElement xmlChildConfigurableElement;
 
-        xmlConfigurableElementsElement.createChild(xmlChildConfigurableElement, "ConfigurableElement");
+        xmlConfigurableElementsElement.createChild(xmlChildConfigurableElement,
+                                                   "ConfigurableElement");
 
         // Set Path attribute
         xmlChildConfigurableElement.setAttribute("Path", pConfigurableElement->getPath());
     }
 }
 
-void CConfigurableDomain::composeSettings(CXmlElement& xmlElement, CXmlDomainExportContext& context) const
+void CConfigurableDomain::composeSettings(CXmlElement &xmlElement,
+                                          CXmlDomainExportContext &context) const
 {
     if (!context.withSettings()) {
 
@@ -180,14 +184,17 @@ void CConfigurableDomain::composeSettings(CXmlElement& xmlElement, CXmlDomainExp
     size_t uiNbConfigurations = getNbChildren();
     size_t uiChildConfiguration;
 
-    for (uiChildConfiguration = 0; uiChildConfiguration < uiNbConfigurations; uiChildConfiguration++) {
+    for (uiChildConfiguration = 0; uiChildConfiguration < uiNbConfigurations;
+         uiChildConfiguration++) {
 
-        const CDomainConfiguration* pDomainConfiguration = static_cast<const CDomainConfiguration*>(getChild(uiChildConfiguration));
+        const CDomainConfiguration *pDomainConfiguration =
+            static_cast<const CDomainConfiguration *>(getChild(uiChildConfiguration));
 
         // Create child xml element for that configuration
         CXmlElement xmlConfigurationSettingsElement;
 
-        xmlSettingsElement.createChild(xmlConfigurationSettingsElement, pDomainConfiguration->getXmlElementName());
+        xmlSettingsElement.createChild(xmlConfigurationSettingsElement,
+                                       pDomainConfiguration->getXmlElementName());
 
         // Set its name attribute
         xmlConfigurationSettingsElement.setNameAttribute(pDomainConfiguration->getName());
@@ -198,11 +205,12 @@ void CConfigurableDomain::composeSettings(CXmlElement& xmlElement, CXmlDomainExp
 }
 
 // From IXmlSink
-bool CConfigurableDomain::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CConfigurableDomain::fromXml(const CXmlElement &xmlElement,
+                                  CXmlSerializingContext &serializingContext)
 {
     // Context
-    CXmlDomainImportContext& xmlDomainImportContext =
-        static_cast<CXmlDomainImportContext&>(serializingContext);
+    CXmlDomainImportContext &xmlDomainImportContext =
+        static_cast<CXmlDomainImportContext &>(serializingContext);
 
     // Sequence awareness (optional)
     xmlElement.getAttribute("SequenceAware", _bSequenceAware);
@@ -220,7 +228,8 @@ bool CConfigurableDomain::fromXml(const CXmlElement& xmlElement, CXmlSerializing
     }
 
     // All provided configurations are parsed
-    // Attempt validation on areas of non provided configurations for all configurable elements if required
+    // Attempt validation on areas of non provided configurations for all configurable elements if
+    // required
     if (xmlDomainImportContext.autoValidationRequired()) {
 
         autoValidateAll();
@@ -230,8 +239,8 @@ bool CConfigurableDomain::fromXml(const CXmlElement& xmlElement, CXmlSerializing
 }
 
 // XML parsing
-bool CConfigurableDomain::parseDomainConfigurations(const CXmlElement& xmlElement,
-                                                    CXmlDomainImportContext& serializingContext)
+bool CConfigurableDomain::parseDomainConfigurations(const CXmlElement &xmlElement,
+                                                    CXmlDomainImportContext &serializingContext)
 {
     // We're supposedly clean
     assert(_configurableElementList.empty());
@@ -246,10 +255,10 @@ bool CConfigurableDomain::parseDomainConfigurations(const CXmlElement& xmlElemen
 }
 
 // Parse configurable elements
-bool CConfigurableDomain::parseConfigurableElements(const CXmlElement& xmlElement,
-                                                    CXmlDomainImportContext& serializingContext)
+bool CConfigurableDomain::parseConfigurableElements(const CXmlElement &xmlElement,
+                                                    CXmlDomainImportContext &serializingContext)
 {
-    CSystemClass& systemClass = serializingContext.getSystemClass();
+    CSystemClass &systemClass = serializingContext.getSystemClass();
 
     // Get ConfigurableElements element
     CXmlElement xmlConfigurableElementsElement;
@@ -272,17 +281,21 @@ bool CConfigurableDomain::parseConfigurableElements(const CXmlElement& xmlElemen
         // Is there an element and does it match system class name?
         if (!pathNavigator.navigateThrough(systemClass.getName(), strError)) {
 
-            serializingContext.setError("Could not find configurable element of path " + strConfigurableElementPath + " from ConfigurableDomain description " + getName() + " (" + strError + ")");
+            serializingContext.setError(
+                "Could not find configurable element of path " + strConfigurableElementPath +
+                " from ConfigurableDomain description " + getName() + " (" + strError + ")");
 
             return false;
         }
         // Browse system class for configurable element
-        CConfigurableElement* pConfigurableElement =
-            static_cast<CConfigurableElement*>(systemClass.findDescendant(pathNavigator));
+        CConfigurableElement *pConfigurableElement =
+            static_cast<CConfigurableElement *>(systemClass.findDescendant(pathNavigator));
 
         if (!pConfigurableElement) {
 
-            serializingContext.setError("Could not find configurable element of path " + strConfigurableElementPath + " from ConfigurableDomain description " + getName());
+            serializingContext.setError("Could not find configurable element of path " +
+                                        strConfigurableElementPath +
+                                        " from ConfigurableDomain description " + getName());
 
             return false;
         }
@@ -301,8 +314,8 @@ bool CConfigurableDomain::parseConfigurableElements(const CXmlElement& xmlElemen
 }
 
 // Parse settings
-bool CConfigurableDomain::parseSettings(const CXmlElement& xmlElement,
-                                        CXmlDomainImportContext& serializingContext)
+bool CConfigurableDomain::parseSettings(const CXmlElement &xmlElement,
+                                        CXmlDomainImportContext &serializingContext)
 {
     // Check we actually need to parse configuration settings
     if (!serializingContext.withSettings()) {
@@ -326,12 +339,14 @@ bool CConfigurableDomain::parseSettings(const CXmlElement& xmlElement,
 
     while (it.next(xmlConfigurationSettingsElement)) {
         // Get domain configuration
-        CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(findChild(xmlConfigurationSettingsElement.getNameAttribute()));
+        CDomainConfiguration *pDomainConfiguration = static_cast<CDomainConfiguration *>(
+            findChild(xmlConfigurationSettingsElement.getNameAttribute()));
 
         if (!pDomainConfiguration) {
 
             serializingContext.setError("Could not find domain configuration referred to by"
-                                        " configurable domain \"" + getName() + "\".");
+                                        " configurable domain \"" +
+                                        getName() + "\".");
 
             return false;
         }
@@ -346,16 +361,15 @@ bool CConfigurableDomain::parseSettings(const CXmlElement& xmlElement,
     return true;
 }
 // Configurable elements association
-bool CConfigurableDomain::addConfigurableElement(CConfigurableElement* pConfigurableElement,
-                                                 const CParameterBlackboard* pMainBlackboard,
-                                                 core::Results& infos)
+bool CConfigurableDomain::addConfigurableElement(CConfigurableElement *pConfigurableElement,
+                                                 const CParameterBlackboard *pMainBlackboard,
+                                                 core::Results &infos)
 {
     // Already associated?
     if (containsConfigurableElement(pConfigurableElement)) {
 
-        infos.push_back("Configurable element "
-                + pConfigurableElement->getPath()
-                + " already associated to configuration domain " + getName());
+        infos.push_back("Configurable element " + pConfigurableElement->getPath() +
+                        " already associated to configuration domain " + getName());
 
         return false;
     }
@@ -363,9 +377,8 @@ bool CConfigurableDomain::addConfigurableElement(CConfigurableElement* pConfigur
     // Already owned?
     if (pConfigurableElement->belongsTo(this)) {
 
-        infos.push_back("Configurable element "
-                + pConfigurableElement->getPath()
-                + " already owned by configuration domain " + getName());
+        infos.push_back("Configurable element " + pConfigurableElement->getPath() +
+                        " already owned by configuration domain " + getName());
 
         return false;
     }
@@ -376,12 +389,14 @@ bool CConfigurableDomain::addConfigurableElement(CConfigurableElement* pConfigur
     return true;
 }
 
-bool CConfigurableDomain::removeConfigurableElement(CConfigurableElement* pConfigurableElement, string& strError)
+bool CConfigurableDomain::removeConfigurableElement(CConfigurableElement *pConfigurableElement,
+                                                    string &strError)
 {
     // Not associated?
     if (!containsConfigurableElement(pConfigurableElement)) {
 
-        strError = "Configurable element " + pConfigurableElement->getPath() + " not associated to configuration domain " + getName();
+        strError = "Configurable element " + pConfigurableElement->getPath() +
+                   " not associated to configuration domain " + getName();
 
         return false;
     }
@@ -411,14 +426,14 @@ bool CConfigurableDomain::removeConfigurableElement(CConfigurableElement* pConfi
 *
 * return Pointer to the Blackboard of the Configuration.
 */
-CParameterBlackboard* CConfigurableDomain::findConfigurationBlackboard(const string& strConfiguration,
-                                                                       const CConfigurableElement* pCandidateDescendantConfigurableElement,
-                                                                       size_t& baseOffset,
-                                                                       bool& bIsLastApplied,
-                                                                       string& strError) const
+CParameterBlackboard *CConfigurableDomain::findConfigurationBlackboard(
+    const string &strConfiguration,
+    const CConfigurableElement *pCandidateDescendantConfigurableElement, size_t &baseOffset,
+    bool &bIsLastApplied, string &strError) const
 {
     // Find Configuration
-    const CDomainConfiguration* pDomainConfiguration = static_cast<const CDomainConfiguration*>(findChild(strConfiguration));
+    const CDomainConfiguration *pDomainConfiguration =
+        static_cast<const CDomainConfiguration *>(findChild(strConfiguration));
 
     if (!pDomainConfiguration) {
 
@@ -432,11 +447,12 @@ CParameterBlackboard* CConfigurableDomain::findConfigurationBlackboard(const str
 
     for (it = _configurableElementList.begin(); it != _configurableElementList.end(); ++it) {
 
-        const CConfigurableElement* pAssociatedConfigurableElement = *it;
+        const CConfigurableElement *pAssociatedConfigurableElement = *it;
 
         // Check if the the associated element is the configurable element or one of its ancestors
         if ((pCandidateDescendantConfigurableElement == pAssociatedConfigurableElement) ||
-            (pCandidateDescendantConfigurableElement->isDescendantOf(pAssociatedConfigurableElement))) {
+            (pCandidateDescendantConfigurableElement->isDescendantOf(
+                pAssociatedConfigurableElement))) {
 
             baseOffset = pAssociatedConfigurableElement->getOffset();
             bIsLastApplied = (pDomainConfiguration == _pLastAppliedConfiguration);
@@ -451,14 +467,13 @@ CParameterBlackboard* CConfigurableDomain::findConfigurationBlackboard(const str
 }
 
 // Domain splitting
-bool CConfigurableDomain::split(CConfigurableElement* pConfigurableElement,
-                                core::Results& infos)
+bool CConfigurableDomain::split(CConfigurableElement *pConfigurableElement, core::Results &infos)
 {
     // Not associated?
     if (!containsConfigurableElement(pConfigurableElement)) {
 
-        std::string strError = "Configurable element " + pConfigurableElement->getPath()
-            + " not associated to configuration domain " + getName();
+        std::string strError = "Configurable element " + pConfigurableElement->getPath() +
+                               " not associated to configuration domain " + getName();
         infos.push_back(strError);
 
         return false;
@@ -469,8 +484,8 @@ bool CConfigurableDomain::split(CConfigurableElement* pConfigurableElement,
 
     if (!uiNbConfigurableElementChildren) {
 
-        std::string strError = "Configurable element " + pConfigurableElement->getPath()
-            + " has no children to split configurable domain to";
+        std::string strError = "Configurable element " + pConfigurableElement->getPath() +
+                               " has no children to split configurable domain to";
         infos.push_back(strError);
 
         return false;
@@ -478,7 +493,8 @@ bool CConfigurableDomain::split(CConfigurableElement* pConfigurableElement,
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurableElementChildren; uiChild++) {
 
-        CConfigurableElement* pChildConfigurableElement = static_cast<CConfigurableElement*>(pConfigurableElement->getChild(uiChild));
+        CConfigurableElement *pChildConfigurableElement =
+            static_cast<CConfigurableElement *>(pConfigurableElement->getChild(uiChild));
 
         doAddConfigurableElement(pChildConfigurableElement, infos);
     }
@@ -488,27 +504,32 @@ bool CConfigurableDomain::split(CConfigurableElement* pConfigurableElement,
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(getChild(uiChild));
+        CDomainConfiguration *pDomainConfiguration =
+            static_cast<CDomainConfiguration *>(getChild(uiChild));
 
         pDomainConfiguration->split(pConfigurableElement);
     }
 
     // Remove given configurable element from this domain
-    // Note: we shouldn't need to recompute the sync set in that case, as the splitted element should include the syncers of its children elements
+    // Note: we shouldn't need to recompute the sync set in that case, as the splitted element
+    // should include the syncers of its children elements
     doRemoveConfigurableElement(pConfigurableElement, false);
 
     return true;
 }
 
-// Check if there is a pending configuration for this domain: i.e. an applicable configuration different from the last applied configuration
-const CDomainConfiguration* CConfigurableDomain::getPendingConfiguration() const
+// Check if there is a pending configuration for this domain: i.e. an applicable configuration
+// different from the last applied configuration
+const CDomainConfiguration *CConfigurableDomain::getPendingConfiguration() const
 {
-    const CDomainConfiguration* pApplicableDomainConfiguration = findApplicableDomainConfiguration();
+    const CDomainConfiguration *pApplicableDomainConfiguration =
+        findApplicableDomainConfiguration();
 
     if (pApplicableDomainConfiguration) {
 
         // Check not the last one before applying
-        if (!_pLastAppliedConfiguration || (_pLastAppliedConfiguration != pApplicableDomainConfiguration)) {
+        if (!_pLastAppliedConfiguration ||
+            (_pLastAppliedConfiguration != pApplicableDomainConfiguration)) {
 
             return pApplicableDomainConfiguration;
         }
@@ -518,14 +539,12 @@ const CDomainConfiguration* CConfigurableDomain::getPendingConfiguration() const
 }
 
 // Configuration application if required
-void CConfigurableDomain::apply(CParameterBlackboard* pParameterBlackboard,
-                                CSyncerSet* pSyncerSet,
-                                bool bForce,
-                                std::string& strInfo) const
+void CConfigurableDomain::apply(CParameterBlackboard *pParameterBlackboard, CSyncerSet *pSyncerSet,
+                                bool bForce, std::string &strInfo) const
 {
     // Apply configuration only if the blackboard will
     // be synchronized either now or by syncerSet.
-    if(!pSyncerSet ^ _bSequenceAware) {
+    if (!pSyncerSet ^ _bSequenceAware) {
         // The configuration can not be syncronised
         return;
     }
@@ -534,15 +553,17 @@ void CConfigurableDomain::apply(CParameterBlackboard* pParameterBlackboard,
         // Force a configuration restore by forgetting about last applied configuration
         _pLastAppliedConfiguration = NULL;
     }
-    const CDomainConfiguration* pApplicableDomainConfiguration = findApplicableDomainConfiguration();
+    const CDomainConfiguration *pApplicableDomainConfiguration =
+        findApplicableDomainConfiguration();
 
     if (pApplicableDomainConfiguration) {
 
         // Check not the last one before applying
-        if (!_pLastAppliedConfiguration || _pLastAppliedConfiguration != pApplicableDomainConfiguration) {
+        if (!_pLastAppliedConfiguration ||
+            _pLastAppliedConfiguration != pApplicableDomainConfiguration) {
 
-            strInfo = "Applying configuration '" + pApplicableDomainConfiguration->getName()
-                    + "' from domain '" + getName() + "'";
+            strInfo = "Applying configuration '" + pApplicableDomainConfiguration->getName() +
+                      "' from domain '" + getName() + "'";
 
             // Check if we need to synchronize during restore
             bool bSync = !pSyncerSet && _bSequenceAware;
@@ -564,11 +585,14 @@ void CConfigurableDomain::apply(CParameterBlackboard* pParameterBlackboard,
 }
 
 // Return applicable configuration validity for given configurable element
-bool CConfigurableDomain::isApplicableConfigurationValid(const CConfigurableElement* pConfigurableElement) const
+bool CConfigurableDomain::isApplicableConfigurationValid(
+    const CConfigurableElement *pConfigurableElement) const
 {
-    const CDomainConfiguration* pApplicableDomainConfiguration = findApplicableDomainConfiguration();
+    const CDomainConfiguration *pApplicableDomainConfiguration =
+        findApplicableDomainConfiguration();
 
-    return pApplicableDomainConfiguration && pApplicableDomainConfiguration->isValid(pConfigurableElement);
+    return pApplicableDomainConfiguration &&
+           pApplicableDomainConfiguration->isValid(pConfigurableElement);
 }
 
 // In case configurable element was removed
@@ -580,16 +604,19 @@ void CConfigurableDomain::computeSyncSet()
     // Add syncer sets for all associated configurable elements
     ConfigurableElementToSyncerSetMapIterator mapIt;
 
-    for (mapIt = _configurableElementToSyncerSetMap.begin(); mapIt != _configurableElementToSyncerSetMap.end(); ++mapIt) {
+    for (mapIt = _configurableElementToSyncerSetMap.begin();
+         mapIt != _configurableElementToSyncerSetMap.end(); ++mapIt) {
 
-        const CSyncerSet* pSyncerSet = mapIt->second;
+        const CSyncerSet *pSyncerSet = mapIt->second;
 
         _syncerSet += *pSyncerSet;
     }
 }
 
 // Configuration Management
-bool CConfigurableDomain::createConfiguration(const string& strName, const CParameterBlackboard* pMainBlackboard, string& strError)
+bool CConfigurableDomain::createConfiguration(const string &strName,
+                                              const CParameterBlackboard *pMainBlackboard,
+                                              string &strError)
 {
     // Already exists?
     if (findChild(strName)) {
@@ -600,17 +627,18 @@ bool CConfigurableDomain::createConfiguration(const string& strName, const CPara
     }
 
     // Creation
-    CDomainConfiguration* pDomainConfiguration = new CDomainConfiguration(strName);
+    CDomainConfiguration *pDomainConfiguration = new CDomainConfiguration(strName);
 
     // Configurable elements association
     ConfigurableElementListIterator it;
 
     for (it = _configurableElementList.begin(); it != _configurableElementList.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;;
+        const CConfigurableElement *pConfigurableElement = *it;
+        ;
 
         // Retrieve associated syncer set
-        CSyncerSet* pSyncerSet = getSyncerSet(pConfigurableElement);
+        CSyncerSet *pSyncerSet = getSyncerSet(pConfigurableElement);
 
         // Associate to configuration
         pDomainConfiguration->addConfigurableElement(pConfigurableElement, pSyncerSet);
@@ -623,16 +651,17 @@ bool CConfigurableDomain::createConfiguration(const string& strName, const CPara
     // Attempt auto validation, so that the user gets his/her own settings by defaults
     if (!autoValidateConfiguration(pDomainConfiguration)) {
 
-        // No valid configuration found to copy in from, validate againt main blackboard (will concerned remaining invalid parts)
+        // No valid configuration found to copy in from, validate againt main blackboard (will
+        // concerned remaining invalid parts)
         pDomainConfiguration->validate(pMainBlackboard);
     }
 
     return true;
 }
 
-bool CConfigurableDomain::deleteConfiguration(const string& strName, string& strError)
+bool CConfigurableDomain::deleteConfiguration(const string &strName, string &strError)
 {
-    CDomainConfiguration* pDomainConfiguration = findConfiguration(strName, strError);
+    CDomainConfiguration *pDomainConfiguration = findConfiguration(strName, strError);
 
     if (!pDomainConfiguration) {
 
@@ -655,7 +684,7 @@ bool CConfigurableDomain::deleteConfiguration(const string& strName, string& str
     return true;
 }
 
-void CConfigurableDomain::listAssociatedToElements(string& strResult) const
+void CConfigurableDomain::listAssociatedToElements(string &strResult) const
 {
     strResult = "\n";
 
@@ -664,15 +693,16 @@ void CConfigurableDomain::listAssociatedToElements(string& strResult) const
     // Browse all configurable elements
     for (it = _configurableElementList.begin(); it != _configurableElementList.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;
+        const CConfigurableElement *pConfigurableElement = *it;
 
         strResult += pConfigurableElement->getPath() + "\n";
     }
 }
 
-bool CConfigurableDomain::renameConfiguration(const string& strName, const string& strNewName, string& strError)
+bool CConfigurableDomain::renameConfiguration(const string &strName, const string &strNewName,
+                                              string &strError)
 {
-    CDomainConfiguration* pDomainConfiguration = findConfiguration(strName, strError);
+    CDomainConfiguration *pDomainConfiguration = findConfiguration(strName, strError);
 
     if (!pDomainConfiguration) {
 
@@ -683,14 +713,13 @@ bool CConfigurableDomain::renameConfiguration(const string& strName, const strin
     return pDomainConfiguration->rename(strNewName, strError);
 }
 
-bool CConfigurableDomain::restoreConfiguration(const string& configurationName,
-                                               CParameterBlackboard* mainBlackboard,
-                                               bool autoSync,
-                                               core::Results& errors) const
+bool CConfigurableDomain::restoreConfiguration(const string &configurationName,
+                                               CParameterBlackboard *mainBlackboard, bool autoSync,
+                                               core::Results &errors) const
 {
     string error;
 
-    const CDomainConfiguration* configuration = findConfiguration(configurationName, error);
+    const CDomainConfiguration *configuration = findConfiguration(configurationName, error);
 
     if (configuration == NULL) {
 
@@ -712,10 +741,12 @@ bool CConfigurableDomain::restoreConfiguration(const string& configurationName,
     return bSuccess;
 }
 
-bool CConfigurableDomain::saveConfiguration(const string& strName, const CParameterBlackboard* pMainBlackboard, string& strError)
+bool CConfigurableDomain::saveConfiguration(const string &strName,
+                                            const CParameterBlackboard *pMainBlackboard,
+                                            string &strError)
 {
     // Find Domain configuration
-    CDomainConfiguration* pDomainConfiguration = findConfiguration(strName, strError);
+    CDomainConfiguration *pDomainConfiguration = findConfiguration(strName, strError);
 
     if (!pDomainConfiguration) {
 
@@ -728,10 +759,12 @@ bool CConfigurableDomain::saveConfiguration(const string& strName, const CParame
     return true;
 }
 
-bool CConfigurableDomain::setElementSequence(const string& strConfiguration, const std::vector<string>& astrNewElementSequence, string& strError)
+bool CConfigurableDomain::setElementSequence(const string &strConfiguration,
+                                             const std::vector<string> &astrNewElementSequence,
+                                             string &strError)
 {
     // Find Domain configuration
-    CDomainConfiguration* pDomainConfiguration = findConfiguration(strConfiguration, strError);
+    CDomainConfiguration *pDomainConfiguration = findConfiguration(strConfiguration, strError);
 
     if (!pDomainConfiguration) {
 
@@ -742,10 +775,12 @@ bool CConfigurableDomain::setElementSequence(const string& strConfiguration, con
     return pDomainConfiguration->setElementSequence(astrNewElementSequence, strError);
 }
 
-bool CConfigurableDomain::getElementSequence(const string& strConfiguration, string& strResult) const
+bool CConfigurableDomain::getElementSequence(const string &strConfiguration,
+                                             string &strResult) const
 {
     // Find Domain configuration
-    const CDomainConfiguration* pDomainConfiguration = findConfiguration(strConfiguration, strResult);
+    const CDomainConfiguration *pDomainConfiguration =
+        findConfiguration(strConfiguration, strResult);
 
     if (!pDomainConfiguration) {
 
@@ -758,10 +793,12 @@ bool CConfigurableDomain::getElementSequence(const string& strConfiguration, str
     return true;
 }
 
-bool CConfigurableDomain::setApplicationRule(const string& strConfiguration, const string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition, string& strError)
+bool CConfigurableDomain::setApplicationRule(
+    const string &strConfiguration, const string &strApplicationRule,
+    const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition, string &strError)
 {
     // Find Domain configuration
-    CDomainConfiguration* pDomainConfiguration = findConfiguration(strConfiguration, strError);
+    CDomainConfiguration *pDomainConfiguration = findConfiguration(strConfiguration, strError);
 
     if (!pDomainConfiguration) {
 
@@ -769,13 +806,14 @@ bool CConfigurableDomain::setApplicationRule(const string& strConfiguration, con
     }
 
     // Delegate to configuration
-    return pDomainConfiguration->setApplicationRule(strApplicationRule, pSelectionCriteriaDefinition, strError);
+    return pDomainConfiguration->setApplicationRule(strApplicationRule,
+                                                    pSelectionCriteriaDefinition, strError);
 }
 
-bool CConfigurableDomain::clearApplicationRule(const string& strConfiguration, string& strError)
+bool CConfigurableDomain::clearApplicationRule(const string &strConfiguration, string &strError)
 {
     // Find Domain configuration
-    CDomainConfiguration* pDomainConfiguration = findConfiguration(strConfiguration, strError);
+    CDomainConfiguration *pDomainConfiguration = findConfiguration(strConfiguration, strError);
 
     if (!pDomainConfiguration) {
 
@@ -788,10 +826,12 @@ bool CConfigurableDomain::clearApplicationRule(const string& strConfiguration, s
     return true;
 }
 
-bool CConfigurableDomain::getApplicationRule(const string& strConfiguration, string& strResult) const
+bool CConfigurableDomain::getApplicationRule(const string &strConfiguration,
+                                             string &strResult) const
 {
     // Find Domain configuration
-    const CDomainConfiguration* pDomainConfiguration = findConfiguration(strConfiguration, strResult);
+    const CDomainConfiguration *pDomainConfiguration =
+        findConfiguration(strConfiguration, strResult);
 
     if (!pDomainConfiguration) {
 
@@ -817,7 +857,8 @@ string CConfigurableDomain::getLastAppliedConfigurationName() const
 // Pending configuration
 string CConfigurableDomain::getPendingConfigurationName() const
 {
-    const CDomainConfiguration* pApplicableDomainConfiguration = findApplicableDomainConfiguration();
+    const CDomainConfiguration *pApplicableDomainConfiguration =
+        findApplicableDomainConfiguration();
 
     if (!pApplicableDomainConfiguration) {
 
@@ -830,8 +871,7 @@ string CConfigurableDomain::getPendingConfigurationName() const
 
         // Found config will get applied
         return pApplicableDomainConfiguration->getName();
-    }
-    else {
+    } else {
 
         // Same configuration as current
         return "";
@@ -839,7 +879,7 @@ string CConfigurableDomain::getPendingConfigurationName() const
 }
 
 // Ensure validity on whole domain from main blackboard
-void CConfigurableDomain::validate(const CParameterBlackboard* pMainBlackboard)
+void CConfigurableDomain::validate(const CParameterBlackboard *pMainBlackboard)
 {
 
     // Propagate
@@ -847,27 +887,31 @@ void CConfigurableDomain::validate(const CParameterBlackboard* pMainBlackboard)
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(getChild(uiChild));
+        CDomainConfiguration *pDomainConfiguration =
+            static_cast<CDomainConfiguration *>(getChild(uiChild));
 
         pDomainConfiguration->validate(pMainBlackboard);
     }
 }
 
 // Ensure validity on areas related to configurable element
-void CConfigurableDomain::validateAreas(const CConfigurableElement* pConfigurableElement, const CParameterBlackboard* pMainBlackboard)
+void CConfigurableDomain::validateAreas(const CConfigurableElement *pConfigurableElement,
+                                        const CParameterBlackboard *pMainBlackboard)
 {
     // Propagate
     size_t uiNbConfigurations = getNbChildren();
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(getChild(uiChild));
+        CDomainConfiguration *pDomainConfiguration =
+            static_cast<CDomainConfiguration *>(getChild(uiChild));
 
         pDomainConfiguration->validate(pConfigurableElement, pMainBlackboard);
     }
 }
 
-// Attempt validation for all configurable element's areas, relying on already existing valid configuration inside domain
+// Attempt validation for all configurable element's areas, relying on already existing valid
+// configuration inside domain
 void CConfigurableDomain::autoValidateAll()
 {
     // Validate
@@ -876,18 +920,20 @@ void CConfigurableDomain::autoValidateAll()
     // Browse all configurable elements for configuration validation
     for (it = _configurableElementList.begin(); it != _configurableElementList.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;
+        const CConfigurableElement *pConfigurableElement = *it;
 
         // Auto validate element
         autoValidateAreas(pConfigurableElement);
     }
 }
 
-// Attempt validation for configurable element's areas, relying on already existing valid configuration inside domain
-void CConfigurableDomain::autoValidateAreas(const CConfigurableElement* pConfigurableElement)
+// Attempt validation for configurable element's areas, relying on already existing valid
+// configuration inside domain
+void CConfigurableDomain::autoValidateAreas(const CConfigurableElement *pConfigurableElement)
 {
     // Find first valid configuration for given configurable element
-    const CDomainConfiguration* pValidDomainConfiguration = findValidDomainConfiguration(pConfigurableElement);
+    const CDomainConfiguration *pValidDomainConfiguration =
+        findValidDomainConfiguration(pConfigurableElement);
 
     // No valid configuration found, give up
     if (!pValidDomainConfiguration) {
@@ -900,24 +946,28 @@ void CConfigurableDomain::autoValidateAreas(const CConfigurableElement* pConfigu
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(getChild(uiChild));
+        CDomainConfiguration *pDomainConfiguration =
+            static_cast<CDomainConfiguration *>(getChild(uiChild));
 
-        if (pDomainConfiguration != pValidDomainConfiguration && !pDomainConfiguration->isValid(pConfigurableElement)) {
+        if (pDomainConfiguration != pValidDomainConfiguration &&
+            !pDomainConfiguration->isValid(pConfigurableElement)) {
             // Validate
             pDomainConfiguration->validateAgainst(pValidDomainConfiguration, pConfigurableElement);
         }
     }
 }
 
-// Attempt configuration validation for all configurable elements' areas, relying on already existing valid configuration inside domain
-bool CConfigurableDomain::autoValidateConfiguration(CDomainConfiguration* pDomainConfiguration)
+// Attempt configuration validation for all configurable elements' areas, relying on already
+// existing valid configuration inside domain
+bool CConfigurableDomain::autoValidateConfiguration(CDomainConfiguration *pDomainConfiguration)
 {
     // Find another configuration than this one, that ought to be valid!
     size_t uiNbConfigurations = getNbChildren();
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        const CDomainConfiguration* pPotententialValidDomainConfiguration = static_cast<const CDomainConfiguration*>(getChild(uiChild));
+        const CDomainConfiguration *pPotententialValidDomainConfiguration =
+            static_cast<const CDomainConfiguration *>(getChild(uiChild));
 
         if (pPotententialValidDomainConfiguration != pDomainConfiguration) {
 
@@ -931,13 +981,15 @@ bool CConfigurableDomain::autoValidateConfiguration(CDomainConfiguration* pDomai
 }
 
 // Search for a valid configuration for given configurable element
-const CDomainConfiguration* CConfigurableDomain::findValidDomainConfiguration(const CConfigurableElement* pConfigurableElement) const
+const CDomainConfiguration *CConfigurableDomain::findValidDomainConfiguration(
+    const CConfigurableElement *pConfigurableElement) const
 {
     size_t uiNbConfigurations = getNbChildren();
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        const CDomainConfiguration* pDomainConfiguration = static_cast<const CDomainConfiguration*>(getChild(uiChild));
+        const CDomainConfiguration *pDomainConfiguration =
+            static_cast<const CDomainConfiguration *>(getChild(uiChild));
 
         if (pDomainConfiguration->isValid(pConfigurableElement)) {
 
@@ -948,13 +1000,14 @@ const CDomainConfiguration* CConfigurableDomain::findValidDomainConfiguration(co
 }
 
 // Search for an applicable configuration
-const CDomainConfiguration* CConfigurableDomain::findApplicableDomainConfiguration() const
+const CDomainConfiguration *CConfigurableDomain::findApplicableDomainConfiguration() const
 {
     size_t uiNbConfigurations = getNbChildren();
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        const CDomainConfiguration* pDomainConfiguration = static_cast<const CDomainConfiguration*>(getChild(uiChild));
+        const CDomainConfiguration *pDomainConfiguration =
+            static_cast<const CDomainConfiguration *>(getChild(uiChild));
 
         if (pDomainConfiguration->isApplicable()) {
 
@@ -965,14 +1018,16 @@ const CDomainConfiguration* CConfigurableDomain::findApplicableDomainConfigurati
 }
 
 // Gather set of configurable elements
-void CConfigurableDomain::gatherConfigurableElements(std::set<const CConfigurableElement*>& configurableElementSet) const
+void CConfigurableDomain::gatherConfigurableElements(
+    std::set<const CConfigurableElement *> &configurableElementSet) const
 {
     // Insert all configurable elements
     configurableElementSet.insert(_configurableElementList.begin(), _configurableElementList.end());
 }
 
 // Check configurable element already attached
-bool CConfigurableDomain::containsConfigurableElement(const CConfigurableElement* pConfigurableCandidateElement) const
+bool CConfigurableDomain::containsConfigurableElement(
+    const CConfigurableElement *pConfigurableCandidateElement) const
 {
     ConfigurableElementListIterator it;
 
@@ -989,24 +1044,23 @@ bool CConfigurableDomain::containsConfigurableElement(const CConfigurableElement
 
 // Merge any descended configurable element to this one with this one
 void CConfigurableDomain::mergeAlreadyAssociatedDescendantConfigurableElements(
-                                                                CConfigurableElement* newElement,
-                                                                core::Results& infos)
+    CConfigurableElement *newElement, core::Results &infos)
 {
-    std::list<CConfigurableElement*> mergedConfigurableElementList;
+    std::list<CConfigurableElement *> mergedConfigurableElementList;
 
     ConfigurableElementListIterator it;
 
     // Browse all configurable elements (new one not yet in the list!)
     for (it = _configurableElementList.begin(); it != _configurableElementList.end(); ++it) {
 
-        CConfigurableElement* pConfigurablePotentialDescendantElement = *it;
+        CConfigurableElement *pConfigurablePotentialDescendantElement = *it;
 
         if (pConfigurablePotentialDescendantElement->isDescendantOf(newElement)) {
 
-            infos.push_back("In domain '" + getName()
-                    + "', merging descendant configurable element's configurations '"
-                    + pConfigurablePotentialDescendantElement->getName()
-                    + "' into its ascendant '" + newElement->getName() + "' ones");
+            infos.push_back("In domain '" + getName() +
+                            "', merging descendant configurable element's configurations '" +
+                            pConfigurablePotentialDescendantElement->getName() +
+                            "' into its ascendant '" + newElement->getName() + "' ones");
 
             // Merge configuration data
             mergeConfigurations(newElement, pConfigurablePotentialDescendantElement);
@@ -1017,24 +1071,28 @@ void CConfigurableDomain::mergeAlreadyAssociatedDescendantConfigurableElements(
     }
 
     // Remove all merged elements (new one not yet in the list!)
-    for (it = mergedConfigurableElementList.begin(); it != mergedConfigurableElementList.end(); ++it) {
+    for (it = mergedConfigurableElementList.begin(); it != mergedConfigurableElementList.end();
+         ++it) {
 
-        CConfigurableElement* pMergedConfigurableElement = *it;
+        CConfigurableElement *pMergedConfigurableElement = *it;
 
         // Remove merged from configurable element from internal tracking list
-        // Note: we shouldn't need to recompute the sync set in that case, as the merged to element should include the syncers of merged from elements
+        // Note: we shouldn't need to recompute the sync set in that case, as the merged to element
+        // should include the syncers of merged from elements
         doRemoveConfigurableElement(pMergedConfigurableElement, false);
     }
 }
 
-void CConfigurableDomain::mergeConfigurations(CConfigurableElement* pToConfigurableElement, CConfigurableElement* pFromConfigurableElement)
+void CConfigurableDomain::mergeConfigurations(CConfigurableElement *pToConfigurableElement,
+                                              CConfigurableElement *pFromConfigurableElement)
 {
     // Propagate to domain configurations
     size_t uiNbConfigurations = getNbChildren();
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(getChild(uiChild));
+        CDomainConfiguration *pDomainConfiguration =
+            static_cast<CDomainConfiguration *>(getChild(uiChild));
 
         // Do the merge.
         pDomainConfiguration->merge(pToConfigurableElement, pFromConfigurableElement);
@@ -1042,15 +1100,15 @@ void CConfigurableDomain::mergeConfigurations(CConfigurableElement* pToConfigura
 }
 
 // Configurable elements association
-void CConfigurableDomain::doAddConfigurableElement(CConfigurableElement* pConfigurableElement,
-                                                   core::Results& infos,
-                                                   const CParameterBlackboard* pMainBlackboard)
+void CConfigurableDomain::doAddConfigurableElement(CConfigurableElement *pConfigurableElement,
+                                                   core::Results &infos,
+                                                   const CParameterBlackboard *pMainBlackboard)
 {
     // Inform configurable element
     pConfigurableElement->addAttachedConfigurableDomain(this);
 
     // Create associated syncer set
-    CSyncerSet* pSyncerSet = new CSyncerSet;
+    CSyncerSet *pSyncerSet = new CSyncerSet;
 
     // Add to sync set the configurable element one
     pConfigurableElement->fillSyncerSet(*pSyncerSet);
@@ -1066,7 +1124,8 @@ void CConfigurableDomain::doAddConfigurableElement(CConfigurableElement* pConfig
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(getChild(uiChild));
+        CDomainConfiguration *pDomainConfiguration =
+            static_cast<CDomainConfiguration *>(getChild(uiChild));
 
         pDomainConfiguration->addConfigurableElement(pConfigurableElement, pSyncerSet);
     }
@@ -1074,9 +1133,9 @@ void CConfigurableDomain::doAddConfigurableElement(CConfigurableElement* pConfig
     // Ensure area validity for that configurable element (if main blackboard provided)
     if (pMainBlackboard) {
 
-        infos.push_back("Validating domain '" + getName()
-                + "' against main blackboard for configurable element '"
-                + pConfigurableElement->getPath() + "'");
+        infos.push_back("Validating domain '" + getName() +
+                        "' against main blackboard for configurable element '" +
+                        pConfigurableElement->getPath() + "'");
         // Need to validate against main blackboard
         validateAreas(pConfigurableElement, pMainBlackboard);
     }
@@ -1088,13 +1147,14 @@ void CConfigurableDomain::doAddConfigurableElement(CConfigurableElement* pConfig
     _configurableElementList.push_back(pConfigurableElement);
 }
 
-void CConfigurableDomain::doRemoveConfigurableElement(CConfigurableElement* pConfigurableElement, bool bRecomputeSyncSet)
+void CConfigurableDomain::doRemoveConfigurableElement(CConfigurableElement *pConfigurableElement,
+                                                      bool bRecomputeSyncSet)
 {
     // Remove from list
     _configurableElementList.remove(pConfigurableElement);
 
     // Remove associated syncer set
-    CSyncerSet* pSyncerSet = getSyncerSet(pConfigurableElement);
+    CSyncerSet *pSyncerSet = getSyncerSet(pConfigurableElement);
 
     _configurableElementToSyncerSetMap.erase(pConfigurableElement);
 
@@ -1108,7 +1168,8 @@ void CConfigurableDomain::doRemoveConfigurableElement(CConfigurableElement* pCon
 
     for (size_t uiChild = 0; uiChild < uiNbConfigurations; uiChild++) {
 
-        CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(getChild(uiChild));
+        CDomainConfiguration *pDomainConfiguration =
+            static_cast<CDomainConfiguration *>(getChild(uiChild));
 
         pDomainConfiguration->removeConfigurableElement(pConfigurableElement);
     }
@@ -1120,9 +1181,11 @@ void CConfigurableDomain::doRemoveConfigurableElement(CConfigurableElement* pCon
 }
 
 // Syncer set retrieval from configurable element
-CSyncerSet* CConfigurableDomain::getSyncerSet(const CConfigurableElement* pConfigurableElement) const
+CSyncerSet *CConfigurableDomain::getSyncerSet(
+    const CConfigurableElement *pConfigurableElement) const
 {
-    ConfigurableElementToSyncerSetMapIterator mapIt = _configurableElementToSyncerSetMap.find(pConfigurableElement);
+    ConfigurableElementToSyncerSetMapIterator mapIt =
+        _configurableElementToSyncerSetMap.find(pConfigurableElement);
 
     ALWAYS_ASSERT(mapIt != _configurableElementToSyncerSetMap.end(),
                   "Could not find syncer set for " << getName() << " configurable domain");
@@ -1131,9 +1194,11 @@ CSyncerSet* CConfigurableDomain::getSyncerSet(const CConfigurableElement* pConfi
 }
 
 // Configuration retrieval
-CDomainConfiguration* CConfigurableDomain::findConfiguration(const string& strConfiguration, string& strError)
+CDomainConfiguration *CConfigurableDomain::findConfiguration(const string &strConfiguration,
+                                                             string &strError)
 {
-    CDomainConfiguration* pDomainConfiguration = static_cast<CDomainConfiguration*>(findChild(strConfiguration));
+    CDomainConfiguration *pDomainConfiguration =
+        static_cast<CDomainConfiguration *>(findChild(strConfiguration));
 
     if (!pDomainConfiguration) {
 
@@ -1144,9 +1209,11 @@ CDomainConfiguration* CConfigurableDomain::findConfiguration(const string& strCo
     return pDomainConfiguration;
 }
 
-const CDomainConfiguration* CConfigurableDomain::findConfiguration(const string& strConfiguration, string& strError) const
+const CDomainConfiguration *CConfigurableDomain::findConfiguration(const string &strConfiguration,
+                                                                   string &strError) const
 {
-    const CDomainConfiguration* pDomainConfiguration = static_cast<const CDomainConfiguration*>(findChild(strConfiguration));
+    const CDomainConfiguration *pDomainConfiguration =
+        static_cast<const CDomainConfiguration *>(findChild(strConfiguration));
 
     if (!pDomainConfiguration) {
 

--- a/parameter/ConfigurableDomain.h
+++ b/parameter/ConfigurableDomain.h
@@ -46,11 +46,13 @@ class CSelectionCriteriaDefinition;
 
 class CConfigurableDomain : public CElement
 {
-    typedef std::list<CConfigurableElement*>::const_iterator ConfigurableElementListIterator;
-    typedef std::map<const CConfigurableElement*, CSyncerSet*>::const_iterator ConfigurableElementToSyncerSetMapIterator;
+    typedef std::list<CConfigurableElement *>::const_iterator ConfigurableElementListIterator;
+    typedef std::map<const CConfigurableElement *, CSyncerSet *>::const_iterator
+        ConfigurableElementToSyncerSetMapIterator;
+
 public:
     CConfigurableDomain() = default;
-    CConfigurableDomain(const std::string& strName);
+    CConfigurableDomain(const std::string &strName);
     virtual ~CConfigurableDomain();
 
     // Sequence awareness
@@ -58,9 +60,11 @@ public:
     bool getSequenceAwareness() const;
 
     // Configuration Management
-    bool createConfiguration(const std::string& strName, const CParameterBlackboard* pMainBlackboard, std::string& strError);
-    bool deleteConfiguration(const std::string& strName, std::string& strError);
-    bool renameConfiguration(const std::string& strName, const std::string& strNewName, std::string& strError);
+    bool createConfiguration(const std::string &strName,
+                             const CParameterBlackboard *pMainBlackboard, std::string &strError);
+    bool deleteConfiguration(const std::string &strName, std::string &strError);
+    bool renameConfiguration(const std::string &strName, const std::string &strNewName,
+                             std::string &strError);
 
     /** Restore a configuration
      *
@@ -70,17 +74,22 @@ public:
      * @param[out] errors, errors encountered during restoration
      * @return true if success false otherwise
      */
-    bool restoreConfiguration(const std::string& configurationName,
-                              CParameterBlackboard* mainBlackboard,
-                              bool autoSync,
-                              core::Results& errors) const;
+    bool restoreConfiguration(const std::string &configurationName,
+                              CParameterBlackboard *mainBlackboard, bool autoSync,
+                              core::Results &errors) const;
 
-    bool saveConfiguration(const std::string& strName, const CParameterBlackboard* pMainBlackboard, std::string& strError);
-    bool setElementSequence(const std::string& strConfiguration, const std::vector<std::string>& astrNewElementSequence, std::string& strError);
-    bool getElementSequence(const std::string& strConfiguration, std::string& strResult) const;
-    bool setApplicationRule(const std::string& strConfiguration, const std::string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition, std::string& strError);
-    bool clearApplicationRule(const std::string& strConfiguration, std::string& strError);
-    bool getApplicationRule(const std::string& strConfiguration, std::string& strResult) const;
+    bool saveConfiguration(const std::string &strName, const CParameterBlackboard *pMainBlackboard,
+                           std::string &strError);
+    bool setElementSequence(const std::string &strConfiguration,
+                            const std::vector<std::string> &astrNewElementSequence,
+                            std::string &strError);
+    bool getElementSequence(const std::string &strConfiguration, std::string &strResult) const;
+    bool setApplicationRule(const std::string &strConfiguration,
+                            const std::string &strApplicationRule,
+                            const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition,
+                            std::string &strError);
+    bool clearApplicationRule(const std::string &strConfiguration, std::string &strError);
+    bool getApplicationRule(const std::string &strConfiguration, std::string &strResult) const;
 
     // Last applied configuration name
     std::string getLastAppliedConfigurationName() const;
@@ -89,8 +98,9 @@ public:
     std::string getPendingConfigurationName() const;
 
     // Associated Configurable elements
-    void gatherConfigurableElements(std::set<const CConfigurableElement*>& configurableElementSet) const;
-    void listAssociatedToElements(std::string& strResult) const;
+    void gatherConfigurableElements(
+        std::set<const CConfigurableElement *> &configurableElementSet) const;
+    void listAssociatedToElements(std::string &strResult) const;
 
     /** Add a configurable element to the domain
      *
@@ -99,18 +109,16 @@ public:
      * @param[out] infos useful information we can provide to client
      * @return true if succeed false otherwise
      */
-    bool addConfigurableElement(CConfigurableElement* pConfigurableElement,
-                                const CParameterBlackboard* pMainBlackboard,
-                                core::Results& infos);
+    bool addConfigurableElement(CConfigurableElement *pConfigurableElement,
+                                const CParameterBlackboard *pMainBlackboard, core::Results &infos);
 
-    bool removeConfigurableElement(CConfigurableElement* pConfigurableElement, std::string& strError);
+    bool removeConfigurableElement(CConfigurableElement *pConfigurableElement,
+                                   std::string &strError);
 
     // Blackboard Configuration and Base Offset retrieval
-    CParameterBlackboard* findConfigurationBlackboard(const std::string& strConfiguration,
-                                                      const CConfigurableElement* pConfigurableElement,
-                                                      size_t& baseOffset,
-                                                      bool& bIsLastApplied,
-                                                      std::string& strError) const;
+    CParameterBlackboard *findConfigurationBlackboard(
+        const std::string &strConfiguration, const CConfigurableElement *pConfigurableElement,
+        size_t &baseOffset, bool &bIsLastApplied, std::string &strError) const;
 
     /** Split the domain in two.
      * Remove an element of a domain and create a new domain which owns the element.
@@ -119,10 +127,10 @@ public:
      * @param[out] infos useful information we can provide to client
      * @return true if succeed false otherwise
      */
-    bool split(CConfigurableElement* pConfigurableElement, core::Results& infos);
+    bool split(CConfigurableElement *pConfigurableElement, core::Results &infos);
 
     // Ensure validity on whole domain from main blackboard
-    void validate(const CParameterBlackboard* pMainBlackboard);
+    void validate(const CParameterBlackboard *pMainBlackboard);
 
     /** Apply the configuration if required
      *
@@ -131,70 +139,75 @@ public:
      * @param[in] bForced boolean used to force configuration application
      * @param[out] info string containing useful information we can provide to client
      */
-    void apply(CParameterBlackboard* pParameterBlackboard,
-               CSyncerSet* pSyncerSet,
-               bool bForced,
-               std::string& info) const;
+    void apply(CParameterBlackboard *pParameterBlackboard, CSyncerSet *pSyncerSet, bool bForced,
+               std::string &info) const;
 
     // Return applicable configuration validity for given configurable element
-    bool isApplicableConfigurationValid(const CConfigurableElement* pConfigurableElement) const;
+    bool isApplicableConfigurationValid(const CConfigurableElement *pConfigurableElement) const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
-    virtual void childrenToXml(CXmlElement& xmlElement,
-                               CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
+    virtual void childrenToXml(CXmlElement &xmlElement,
+                               CXmlSerializingContext &serializingContext) const;
 
     // Class kind
     virtual std::string getKind() const;
 
 protected:
     // Content dumping
-    std::string logValue(utility::ErrorContext& errorContext) const override;
+    std::string logValue(utility::ErrorContext &errorContext) const override;
 
 private:
     // Get pending configuration
-    const CDomainConfiguration* getPendingConfiguration() const;
+    const CDomainConfiguration *getPendingConfiguration() const;
 
     // Search for an applicable configuration
-    const CDomainConfiguration* findApplicableDomainConfiguration() const;
+    const CDomainConfiguration *findApplicableDomainConfiguration() const;
 
-    // Returns true if children dynamic creation is to be dealt with (here, will allow child deletion upon clean)
+    // Returns true if children dynamic creation is to be dealt with (here, will allow child
+    // deletion upon clean)
     virtual bool childrenAreDynamic() const;
 
     // Ensure validity on areas related to configurable element
-    void validateAreas(const CConfigurableElement* pConfigurableElement, const CParameterBlackboard* pMainBlackboard);
+    void validateAreas(const CConfigurableElement *pConfigurableElement,
+                       const CParameterBlackboard *pMainBlackboard);
 
-    // Attempt validation for all configurable element's areas, relying on already existing valid configuration inside domain
+    // Attempt validation for all configurable element's areas, relying on already existing valid
+    // configuration inside domain
     void autoValidateAll();
 
-    // Attempt validation for one configurable element's areas, relying on already existing valid configuration inside domain
-    void autoValidateAreas(const CConfigurableElement* pConfigurableElement);
+    // Attempt validation for one configurable element's areas, relying on already existing valid
+    // configuration inside domain
+    void autoValidateAreas(const CConfigurableElement *pConfigurableElement);
 
-    // Attempt configuration validation for all configurable elements' areas, relying on already existing valid configuration inside domain
-    bool autoValidateConfiguration(CDomainConfiguration* pDomainConfiguration);
+    // Attempt configuration validation for all configurable elements' areas, relying on already
+    // existing valid configuration inside domain
+    bool autoValidateConfiguration(CDomainConfiguration *pDomainConfiguration);
 
     // Search for a valid configuration for given configurable element
-    const CDomainConfiguration* findValidDomainConfiguration(const CConfigurableElement* pConfigurableElement) const;
-
+    const CDomainConfiguration *findValidDomainConfiguration(
+        const CConfigurableElement *pConfigurableElement) const;
 
     // In case configurable element was removed
     void computeSyncSet();
 
     // Check configurable element already attached
-    bool containsConfigurableElement(const CConfigurableElement* pConfigurableCandidateElement) const;
+    bool containsConfigurableElement(
+        const CConfigurableElement *pConfigurableCandidateElement) const;
 
     /** Merge any descended configurable element to this one
      *
      * @param[in] newElement pointer to element which has potential descendants which can be merged
      * @param[out] infos useful information we can provide to client
      */
-    void mergeAlreadyAssociatedDescendantConfigurableElements(CConfigurableElement* newElement,
-                                                              core::Results& infos);
+    void mergeAlreadyAssociatedDescendantConfigurableElements(CConfigurableElement *newElement,
+                                                              core::Results &infos);
 
-    void mergeConfigurations(CConfigurableElement* pToConfigurableElement, CConfigurableElement* pFromConfigurableElement);
+    void mergeConfigurations(CConfigurableElement *pToConfigurableElement,
+                             CConfigurableElement *pFromConfigurableElement);
 
     /** Actually realize the association between the domain and a configurable  element
      *
@@ -204,11 +217,11 @@ private:
      *            Default value is NULL, when provided, blackboard area concerning the configurable
      *            element are validated.
      */
-    void doAddConfigurableElement(CConfigurableElement* pConfigurableElement,
-                                  core::Results& infos,
-                                  const CParameterBlackboard* pMainBlackboard = NULL);
+    void doAddConfigurableElement(CConfigurableElement *pConfigurableElement, core::Results &infos,
+                                  const CParameterBlackboard *pMainBlackboard = NULL);
 
-    void doRemoveConfigurableElement(CConfigurableElement* pConfigurableElement, bool bRecomputeSyncSet);
+    void doRemoveConfigurableElement(CConfigurableElement *pConfigurableElement,
+                                     bool bRecomputeSyncSet);
 
     // XML parsing
     /**
@@ -220,8 +233,8 @@ private:
      *
      * @return false if an error occurs, true otherwise.
      */
-    bool parseDomainConfigurations(const CXmlElement& xmlElement,
-                                   CXmlDomainImportContext& serializingContext);
+    bool parseDomainConfigurations(const CXmlElement &xmlElement,
+                                   CXmlDomainImportContext &serializingContext);
     /**
      * Deserialize domain elements from an Xml document and add them to
      * the domain.
@@ -231,8 +244,8 @@ private:
      *
      * @return false if an error occurs, true otherwise.
      */
-    bool parseConfigurableElements(const CXmlElement& xmlElement,
-                                   CXmlDomainImportContext& serializingContext);
+    bool parseConfigurableElements(const CXmlElement &xmlElement,
+                                   CXmlDomainImportContext &serializingContext);
     /**
      * Deserialize settings from an Xml document and add them to
      * the domain.
@@ -242,26 +255,28 @@ private:
      *
      * @return false if an error occurs, true otherwise.
      */
-    bool parseSettings(const CXmlElement& xmlElement,
-                       CXmlDomainImportContext& serializingContext);
+    bool parseSettings(const CXmlElement &xmlElement, CXmlDomainImportContext &serializingContext);
 
     // XML composing
-    void composeDomainConfigurations(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
-    void composeConfigurableElements(CXmlElement& xmlElement) const;
-    void composeSettings(CXmlElement& xmlElement, CXmlDomainExportContext& context) const;
+    void composeDomainConfigurations(CXmlElement &xmlElement,
+                                     CXmlSerializingContext &serializingContext) const;
+    void composeConfigurableElements(CXmlElement &xmlElement) const;
+    void composeSettings(CXmlElement &xmlElement, CXmlDomainExportContext &context) const;
 
     // Syncer set retrieval from configurable element
-    CSyncerSet* getSyncerSet(const CConfigurableElement* pConfigurableElement) const;
+    CSyncerSet *getSyncerSet(const CConfigurableElement *pConfigurableElement) const;
 
     // Configuration retrieval
-    CDomainConfiguration* findConfiguration(const std::string& strConfiguration, std::string& strError);
-    const CDomainConfiguration* findConfiguration(const std::string& strConfiguration, std::string& strError) const;
+    CDomainConfiguration *findConfiguration(const std::string &strConfiguration,
+                                            std::string &strError);
+    const CDomainConfiguration *findConfiguration(const std::string &strConfiguration,
+                                                  std::string &strError) const;
 
     // Configurable elements
-    std::list<CConfigurableElement*> _configurableElementList;
+    std::list<CConfigurableElement *> _configurableElementList;
 
     // Associated syncer sets
-    std::map<const CConfigurableElement*, CSyncerSet*> _configurableElementToSyncerSetMap;
+    std::map<const CConfigurableElement *, CSyncerSet *> _configurableElementToSyncerSetMap;
 
     // Sequence awareness
     bool _bSequenceAware{false};
@@ -270,6 +285,5 @@ private:
     CSyncerSet _syncerSet;
 
     // Last applied configuration
-    mutable const CDomainConfiguration* _pLastAppliedConfiguration{nullptr};
+    mutable const CDomainConfiguration *_pLastAppliedConfiguration{nullptr};
 };
-

--- a/parameter/ConfigurableDomains.cpp
+++ b/parameter/ConfigurableDomains.cpp
@@ -47,24 +47,23 @@ bool CConfigurableDomains::childrenAreDynamic() const
 }
 
 // Ensure validity on whole domains from main blackboard
-void CConfigurableDomains::validate(const CParameterBlackboard* pMainBlackboard)
+void CConfigurableDomains::validate(const CParameterBlackboard *pMainBlackboard)
 {
     // Delegate to domains
     size_t uiNbConfigurableDomains = getNbChildren();
 
     for (size_t child = 0; child < uiNbConfigurableDomains; child++) {
 
-        CConfigurableDomain* pChildConfigurableDomain = static_cast<CConfigurableDomain*>(getChild(child));
+        CConfigurableDomain *pChildConfigurableDomain =
+            static_cast<CConfigurableDomain *>(getChild(child));
 
         pChildConfigurableDomain->validate(pMainBlackboard);
     }
 }
 
 // Configuration application if required
-void CConfigurableDomains::apply(CParameterBlackboard* pParameterBlackboard,
-                                 CSyncerSet& syncerSet,
-                                 bool bForce,
-                                 core::Results& infos) const
+void CConfigurableDomains::apply(CParameterBlackboard *pParameterBlackboard, CSyncerSet &syncerSet,
+                                 bool bForce, core::Results &infos) const
 {
     /// Delegate to domains
 
@@ -73,7 +72,8 @@ void CConfigurableDomains::apply(CParameterBlackboard* pParameterBlackboard,
 
     for (size_t child = 0; child < uiNbConfigurableDomains; child++) {
 
-        const CConfigurableDomain* pChildConfigurableDomain = static_cast<const CConfigurableDomain*>(getChild(child));
+        const CConfigurableDomain *pChildConfigurableDomain =
+            static_cast<const CConfigurableDomain *>(getChild(child));
 
         std::string info;
         // Apply and collect syncers when relevant
@@ -89,7 +89,8 @@ void CConfigurableDomains::apply(CParameterBlackboard* pParameterBlackboard,
     // Then deal with domains that need to synchronize along apply
     for (size_t child = 0; child < uiNbConfigurableDomains; child++) {
 
-        const CConfigurableDomain* pChildConfigurableDomain = static_cast<const CConfigurableDomain*>(getChild(child));
+        const CConfigurableDomain *pChildConfigurableDomain =
+            static_cast<const CConfigurableDomain *>(getChild(child));
 
         std::string info;
         // Apply and synchronize when relevant
@@ -101,7 +102,8 @@ void CConfigurableDomains::apply(CParameterBlackboard* pParameterBlackboard,
 }
 
 // From IXmlSource
-void CConfigurableDomains::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CConfigurableDomains::toXml(CXmlElement &xmlElement,
+                                 CXmlSerializingContext &serializingContext) const
 {
     // Set attribute
     xmlElement.setAttribute("SystemClassName", getName());
@@ -111,7 +113,7 @@ void CConfigurableDomains::toXml(CXmlElement& xmlElement, CXmlSerializingContext
 
 // Configuration/Domains handling
 /// Domains
-bool CConfigurableDomains::createDomain(const string& strName, string& strError)
+bool CConfigurableDomains::createDomain(const string &strName, string &strError)
 {
     // Already exists?
     if (findChild(strName)) {
@@ -127,18 +129,17 @@ bool CConfigurableDomains::createDomain(const string& strName, string& strError)
     return true;
 }
 
-bool CConfigurableDomains::addDomain(CConfigurableDomain& domain, bool bOverwrite,
-                                     string& strError)
+bool CConfigurableDomains::addDomain(CConfigurableDomain &domain, bool bOverwrite, string &strError)
 {
     string strErrorDrop;
 
     string strDomainName(domain.getName());
-    CConfigurableDomain* pExistingDomain = findConfigurableDomain(strDomainName, strErrorDrop);
+    CConfigurableDomain *pExistingDomain = findConfigurableDomain(strDomainName, strErrorDrop);
 
     if (pExistingDomain) {
         if (!bOverwrite) {
             strError = "Can't add domain \"" + strDomainName +
-                "\" because it already exists and overwrite was not requested.";
+                       "\" because it already exists and overwrite was not requested.";
             return false;
         }
 
@@ -150,16 +151,16 @@ bool CConfigurableDomains::addDomain(CConfigurableDomain& domain, bool bOverwrit
     return true;
 }
 
-void CConfigurableDomains::deleteDomain(CConfigurableDomain& configurableDomain)
+void CConfigurableDomains::deleteDomain(CConfigurableDomain &configurableDomain)
 {
     removeChild(&configurableDomain);
 
     delete &configurableDomain;
 }
 
-bool CConfigurableDomains::deleteDomain(const string& strName, string& strError)
+bool CConfigurableDomains::deleteDomain(const string &strName, string &strError)
 {
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strName, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strName, strError);
 
     if (pConfigurableDomain) {
         deleteDomain(*pConfigurableDomain);
@@ -171,13 +172,14 @@ bool CConfigurableDomains::deleteDomain(const string& strName, string& strError)
 
 void CConfigurableDomains::deleteAllDomains()
 {
-    //remove Children
+    // remove Children
     clean();
 }
 
-bool CConfigurableDomains::renameDomain(const string& strName, const string& strNewName, string& strError)
+bool CConfigurableDomains::renameDomain(const string &strName, const string &strNewName,
+                                        string &strError)
 {
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strName, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strName, strError);
 
     if (!pConfigurableDomain) {
 
@@ -188,9 +190,10 @@ bool CConfigurableDomains::renameDomain(const string& strName, const string& str
     return pConfigurableDomain->rename(strNewName, strError);
 }
 
-bool CConfigurableDomains::setSequenceAwareness(const string& strDomain, bool bSequenceAware, string& strError)
+bool CConfigurableDomains::setSequenceAwareness(const string &strDomain, bool bSequenceAware,
+                                                string &strError)
 {
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -202,9 +205,10 @@ bool CConfigurableDomains::setSequenceAwareness(const string& strDomain, bool bS
     return true;
 }
 
-bool CConfigurableDomains::getSequenceAwareness(const string& strDomain, bool& bSequenceAware, string& strError) const
+bool CConfigurableDomains::getSequenceAwareness(const string &strDomain, bool &bSequenceAware,
+                                                string &strError) const
 {
-    const CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    const CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -217,9 +221,9 @@ bool CConfigurableDomains::getSequenceAwareness(const string& strDomain, bool& b
 }
 
 /// Configurations
-bool CConfigurableDomains::listConfigurations(const string& strDomain, string& strResult) const
+bool CConfigurableDomains::listConfigurations(const string &strDomain, string &strResult) const
 {
-    const CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strResult);
+    const CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strResult);
 
     if (!pConfigurableDomain) {
 
@@ -231,10 +235,13 @@ bool CConfigurableDomains::listConfigurations(const string& strDomain, string& s
     return true;
 }
 
-bool CConfigurableDomains::createConfiguration(const string& strDomain, const string& strConfiguration, const CParameterBlackboard* pMainBlackboard, string& strError)
+bool CConfigurableDomains::createConfiguration(const string &strDomain,
+                                               const string &strConfiguration,
+                                               const CParameterBlackboard *pMainBlackboard,
+                                               string &strError)
 {
     // Find domain
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -244,10 +251,11 @@ bool CConfigurableDomains::createConfiguration(const string& strDomain, const st
     return pConfigurableDomain->createConfiguration(strConfiguration, pMainBlackboard, strError);
 }
 
-bool CConfigurableDomains::deleteConfiguration(const string& strDomain, const string& strConfiguration, string& strError)
+bool CConfigurableDomains::deleteConfiguration(const string &strDomain,
+                                               const string &strConfiguration, string &strError)
 {
     // Find domain
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -257,23 +265,27 @@ bool CConfigurableDomains::deleteConfiguration(const string& strDomain, const st
     return pConfigurableDomain->deleteConfiguration(strConfiguration, strError);
 }
 
-bool CConfigurableDomains::renameConfiguration(const string& strDomain, const string& strConfigurationName, const string& strNewConfigurationName, string& strError)
+bool CConfigurableDomains::renameConfiguration(const string &strDomain,
+                                               const string &strConfigurationName,
+                                               const string &strNewConfigurationName,
+                                               string &strError)
 {
     // Find domain
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
         return false;
     }
     // Delegate
-    return pConfigurableDomain->renameConfiguration(strConfigurationName, strNewConfigurationName, strError);
+    return pConfigurableDomain->renameConfiguration(strConfigurationName, strNewConfigurationName,
+                                                    strError);
 }
 
-bool CConfigurableDomains::listDomainElements(const string& strDomain, string& strResult) const
+bool CConfigurableDomains::listDomainElements(const string &strDomain, string &strResult) const
 {
     // Find domain
-    const CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strResult);
+    const CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strResult);
 
     if (!pConfigurableDomain) {
 
@@ -285,13 +297,12 @@ bool CConfigurableDomains::listDomainElements(const string& strDomain, string& s
     return true;
 }
 
-bool CConfigurableDomains::split(const string& domainName,
-                                 CConfigurableElement* element,
-                                 core::Results& infos)
+bool CConfigurableDomains::split(const string &domainName, CConfigurableElement *element,
+                                 core::Results &infos)
 {
     // Find domain
     std::string error;
-    CConfigurableDomain* domain = findConfigurableDomain(domainName, error);
+    CConfigurableDomain *domain = findConfigurableDomain(domainName, error);
 
     if (domain == NULL) {
 
@@ -304,21 +315,21 @@ bool CConfigurableDomains::split(const string& domainName,
     return true;
 }
 
-void CConfigurableDomains::listAssociatedElements(string& strResult) const
+void CConfigurableDomains::listAssociatedElements(string &strResult) const
 {
     strResult = "\n";
 
-    std::set<const CConfigurableElement*> configurableElementSet;
+    std::set<const CConfigurableElement *> configurableElementSet;
 
     // Get all owned configurable elements
     gatherAllOwnedConfigurableElements(configurableElementSet);
 
     // Fill result
-    std::set<const CConfigurableElement*>::const_iterator it;
+    std::set<const CConfigurableElement *>::const_iterator it;
 
     for (it = configurableElementSet.begin(); it != configurableElementSet.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;
+        const CConfigurableElement *pConfigurableElement = *it;
 
         string strAssociatedDomainList;
 
@@ -328,21 +339,21 @@ void CConfigurableDomains::listAssociatedElements(string& strResult) const
     }
 }
 
-void CConfigurableDomains::listConflictingElements(string& strResult) const
+void CConfigurableDomains::listConflictingElements(string &strResult) const
 {
     strResult = "\n";
 
-    std::set<const CConfigurableElement*> configurableElementSet;
+    std::set<const CConfigurableElement *> configurableElementSet;
 
     // Get all owned configurable elements
     gatherAllOwnedConfigurableElements(configurableElementSet);
 
     // Fill result
-    std::set<const CConfigurableElement*>::const_iterator it;
+    std::set<const CConfigurableElement *>::const_iterator it;
 
     for (it = configurableElementSet.begin(); it != configurableElementSet.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;
+        const CConfigurableElement *pConfigurableElement = *it;
 
         if (pConfigurableElement->getBelongingDomainCount() > 1) {
 
@@ -350,12 +361,13 @@ void CConfigurableDomains::listConflictingElements(string& strResult) const
 
             pConfigurableElement->listBelongingDomains(strBelongingDomainList, false);
 
-            strResult += pConfigurableElement->getPath() + " contained in multiple domains: " + strBelongingDomainList + "\n";
+            strResult += pConfigurableElement->getPath() + " contained in multiple domains: " +
+                         strBelongingDomainList + "\n";
         }
     }
 }
 
-void CConfigurableDomains::listDomains(string& strResult) const
+void CConfigurableDomains::listDomains(string &strResult) const
 {
     strResult = "\n";
 
@@ -364,7 +376,8 @@ void CConfigurableDomains::listDomains(string& strResult) const
 
     for (size_t child = 0; child < uiNbConfigurableDomains; child++) {
 
-        const CConfigurableDomain* pChildConfigurableDomain = static_cast<const CConfigurableDomain*>(getChild(child));
+        const CConfigurableDomain *pChildConfigurableDomain =
+            static_cast<const CConfigurableDomain *>(getChild(child));
 
         // Name
         strResult += pChildConfigurableDomain->getName();
@@ -379,29 +392,30 @@ void CConfigurableDomains::listDomains(string& strResult) const
 }
 
 // Gather configurable elements owned by any domain
-void CConfigurableDomains::gatherAllOwnedConfigurableElements(std::set<const CConfigurableElement*>& configurableElementSet) const
+void CConfigurableDomains::gatherAllOwnedConfigurableElements(
+    std::set<const CConfigurableElement *> &configurableElementSet) const
 {
     // Delegate to domains
     size_t uiNbConfigurableDomains = getNbChildren();
 
     for (size_t child = 0; child < uiNbConfigurableDomains; child++) {
 
-        const CConfigurableDomain* pChildConfigurableDomain = static_cast<const CConfigurableDomain*>(getChild(child));
+        const CConfigurableDomain *pChildConfigurableDomain =
+            static_cast<const CConfigurableDomain *>(getChild(child));
 
         pChildConfigurableDomain->gatherConfigurableElements(configurableElementSet);
     }
 }
 
 // Config restore
-bool CConfigurableDomains::restoreConfiguration(const string& domainName,
-                                                const string& configurationName,
-                                                CParameterBlackboard* mainBlackboard,
-                                                bool autoSync,
-                                                core::Results& errors) const
+bool CConfigurableDomains::restoreConfiguration(const string &domainName,
+                                                const string &configurationName,
+                                                CParameterBlackboard *mainBlackboard, bool autoSync,
+                                                core::Results &errors) const
 {
     string error;
     // Find domain
-    const CConfigurableDomain* domain = findConfigurableDomain(domainName, error);
+    const CConfigurableDomain *domain = findConfigurableDomain(domainName, error);
 
     if (domain == NULL) {
 
@@ -413,10 +427,13 @@ bool CConfigurableDomains::restoreConfiguration(const string& domainName,
 }
 
 // Config save
-bool CConfigurableDomains::saveConfiguration(const string& strDomain, const string& strConfiguration, const CParameterBlackboard* pMainBlackboard, string& strError)
+bool CConfigurableDomains::saveConfiguration(const string &strDomain,
+                                             const string &strConfiguration,
+                                             const CParameterBlackboard *pMainBlackboard,
+                                             string &strError)
 {
     // Find domain
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -426,10 +443,13 @@ bool CConfigurableDomains::saveConfiguration(const string& strDomain, const stri
     return pConfigurableDomain->saveConfiguration(strConfiguration, pMainBlackboard, strError);
 }
 
-bool CConfigurableDomains::setElementSequence(const string& strDomain, const string& strConfiguration, const std::vector<string>& astrNewElementSequence, string& strError)
+bool CConfigurableDomains::setElementSequence(const string &strDomain,
+                                              const string &strConfiguration,
+                                              const std::vector<string> &astrNewElementSequence,
+                                              string &strError)
 {
     // Find domain
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -437,13 +457,16 @@ bool CConfigurableDomains::setElementSequence(const string& strDomain, const str
     }
 
     // Delegate to domain
-    return pConfigurableDomain->setElementSequence(strConfiguration, astrNewElementSequence, strError);
+    return pConfigurableDomain->setElementSequence(strConfiguration, astrNewElementSequence,
+                                                   strError);
 }
 
-bool CConfigurableDomains::getElementSequence(const string& strDomain, const string& strConfiguration, string& strResult) const
+bool CConfigurableDomains::getElementSequence(const string &strDomain,
+                                              const string &strConfiguration,
+                                              string &strResult) const
 {
     // Find domain
-    const CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strResult);
+    const CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strResult);
 
     if (!pConfigurableDomain) {
 
@@ -453,9 +476,11 @@ bool CConfigurableDomains::getElementSequence(const string& strDomain, const str
     return pConfigurableDomain->getElementSequence(strConfiguration, strResult);
 }
 
-bool CConfigurableDomains::setApplicationRule(const string& strDomain, const string& strConfiguration, const string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition, string& strError)
+bool CConfigurableDomains::setApplicationRule(
+    const string &strDomain, const string &strConfiguration, const string &strApplicationRule,
+    const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition, string &strError)
 {
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -463,12 +488,14 @@ bool CConfigurableDomains::setApplicationRule(const string& strDomain, const str
     }
 
     // Delegate to domain
-    return pConfigurableDomain->setApplicationRule(strConfiguration, strApplicationRule, pSelectionCriteriaDefinition, strError);
+    return pConfigurableDomain->setApplicationRule(strConfiguration, strApplicationRule,
+                                                   pSelectionCriteriaDefinition, strError);
 }
 
-bool CConfigurableDomains::clearApplicationRule(const string& strDomain, const string& strConfiguration, string& strError)
+bool CConfigurableDomains::clearApplicationRule(const string &strDomain,
+                                                const string &strConfiguration, string &strError)
 {
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -479,9 +506,11 @@ bool CConfigurableDomains::clearApplicationRule(const string& strDomain, const s
     return pConfigurableDomain->clearApplicationRule(strConfiguration, strError);
 }
 
-bool CConfigurableDomains::getApplicationRule(const string& strDomain, const string& strConfiguration, string& strResult) const
+bool CConfigurableDomains::getApplicationRule(const string &strDomain,
+                                              const string &strConfiguration,
+                                              string &strResult) const
 {
-    const CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strResult);
+    const CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strResult);
 
     if (!pConfigurableDomain) {
 
@@ -493,29 +522,30 @@ bool CConfigurableDomains::getApplicationRule(const string& strDomain, const str
 }
 
 // Last applied configurations
-void CConfigurableDomains::listLastAppliedConfigurations(string& strResult) const
+void CConfigurableDomains::listLastAppliedConfigurations(string &strResult) const
 {
     // Browse domains
     size_t uiNbConfigurableDomains = getNbChildren();
 
     for (size_t child = 0; child < uiNbConfigurableDomains; child++) {
 
-        const CConfigurableDomain* pChildConfigurableDomain = static_cast<const CConfigurableDomain*>(getChild(child));
+        const CConfigurableDomain *pChildConfigurableDomain =
+            static_cast<const CConfigurableDomain *>(getChild(child));
 
-        strResult += pChildConfigurableDomain->getName() + ": " + pChildConfigurableDomain->getLastAppliedConfigurationName() + " [" + pChildConfigurableDomain->getPendingConfigurationName() + "]\n";
+        strResult += pChildConfigurableDomain->getName() + ": " +
+                     pChildConfigurableDomain->getLastAppliedConfigurationName() + " [" +
+                     pChildConfigurableDomain->getPendingConfigurationName() + "]\n";
     }
 }
 
 // Configurable element - domain association
 bool CConfigurableDomains::addConfigurableElementToDomain(
-        const string& domainName,
-        CConfigurableElement* element,
-        const CParameterBlackboard* mainBlackboard,
-        core::Results& infos)
+    const string &domainName, CConfigurableElement *element,
+    const CParameterBlackboard *mainBlackboard, core::Results &infos)
 {
     // Find domain
     std::string error;
-    CConfigurableDomain* domain = findConfigurableDomain(domainName, error);
+    CConfigurableDomain *domain = findConfigurableDomain(domainName, error);
 
     if (domain == NULL) {
 
@@ -526,10 +556,11 @@ bool CConfigurableDomains::addConfigurableElementToDomain(
     return domain->addConfigurableElement(element, mainBlackboard, infos);
 }
 
-bool CConfigurableDomains::removeConfigurableElementFromDomain(const string& strDomain, CConfigurableElement* pConfigurableElement, string& strError)
+bool CConfigurableDomains::removeConfigurableElementFromDomain(
+    const string &strDomain, CConfigurableElement *pConfigurableElement, string &strError)
 {
     // Find domain
-    CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -539,15 +570,13 @@ bool CConfigurableDomains::removeConfigurableElementFromDomain(const string& str
     return pConfigurableDomain->removeConfigurableElement(pConfigurableElement, strError);
 }
 
-CParameterBlackboard* CConfigurableDomains::findConfigurationBlackboard(const string& strDomain,
-                                                       const string& strConfiguration,
-                                                       const CConfigurableElement* pConfigurableElement,
-                                                       size_t& baseOffset,
-                                                       bool& bIsLastApplied,
-                                                       string& strError) const
+CParameterBlackboard *CConfigurableDomains::findConfigurationBlackboard(
+    const string &strDomain, const string &strConfiguration,
+    const CConfigurableElement *pConfigurableElement, size_t &baseOffset, bool &bIsLastApplied,
+    string &strError) const
 {
     // Find domain
-    const CConfigurableDomain* pConfigurableDomain = findConfigurableDomain(strDomain, strError);
+    const CConfigurableDomain *pConfigurableDomain = findConfigurableDomain(strDomain, strError);
 
     if (!pConfigurableDomain) {
 
@@ -557,28 +586,32 @@ CParameterBlackboard* CConfigurableDomains::findConfigurationBlackboard(const st
     // Check that element belongs to the domain
     if (!pConfigurableElement->belongsTo(pConfigurableDomain)) {
 
-        strError = "Element \"" + pConfigurableElement->getPath() + "\" does not belong to domain \"" + strDomain + "\"";
+        strError = "Element \"" + pConfigurableElement->getPath() +
+                   "\" does not belong to domain \"" + strDomain + "\"";
 
         return NULL;
     }
 
     // Find Configuration Blackboard and Base Offset
-    return pConfigurableDomain->findConfigurationBlackboard(strConfiguration, pConfigurableElement, baseOffset, bIsLastApplied, strError);
+    return pConfigurableDomain->findConfigurationBlackboard(strConfiguration, pConfigurableElement,
+                                                            baseOffset, bIsLastApplied, strError);
 }
 
 // Domain retrieval
-CConfigurableDomain* CConfigurableDomains::findConfigurableDomain(const string& strDomain, string& strError)
+CConfigurableDomain *CConfigurableDomains::findConfigurableDomain(const string &strDomain,
+                                                                  string &strError)
 {
     // Call the const equivalent
-    return const_cast<CConfigurableDomain*>(
-        static_cast<const CConfigurableDomains*>(this)->findConfigurableDomain(strDomain, strError)
-        );
+    return const_cast<CConfigurableDomain *>(static_cast<const CConfigurableDomains *>(this)
+                                                 ->findConfigurableDomain(strDomain, strError));
 }
 
-const CConfigurableDomain* CConfigurableDomains::findConfigurableDomain(const string& strDomain, string& strError) const
+const CConfigurableDomain *CConfigurableDomains::findConfigurableDomain(const string &strDomain,
+                                                                        string &strError) const
 {
     // Find domain
-    const CConfigurableDomain* pConfigurableDomain = static_cast<const CConfigurableDomain*>(findChild(strDomain));
+    const CConfigurableDomain *pConfigurableDomain =
+        static_cast<const CConfigurableDomain *>(findChild(strDomain));
 
     if (!pConfigurableDomain) {
 

--- a/parameter/ConfigurableDomains.h
+++ b/parameter/ConfigurableDomains.h
@@ -34,7 +34,6 @@
 #include <set>
 #include <string>
 
-
 class CParameterBlackboard;
 class CConfigurableElement;
 class CSyncerSet;
@@ -46,7 +45,7 @@ class CConfigurableDomains : public CElement
 public:
     // Configuration/Domains handling
     /// Domains
-    bool createDomain(const std::string& strName, std::string& strError);
+    bool createDomain(const std::string &strName, std::string &strError);
 
     /*
      * Adds a domain object to configurable domains. The ConfigurableDomains
@@ -60,7 +59,7 @@ public:
      *
      * @returns true if the domain was successfully added
      */
-    bool addDomain(CConfigurableDomain& domain, bool bOverwrite, std::string& strError);
+    bool addDomain(CConfigurableDomain &domain, bool bOverwrite, std::string &strError);
 
     /**
      * Delete a domain by name
@@ -71,12 +70,15 @@ public:
      * @returns true of the domain was sucessfully deleted, false otherwise (i.e.
      * the domain didn't exist).
      */
-    bool deleteDomain(const std::string& strName, std::string& strError);
+    bool deleteDomain(const std::string &strName, std::string &strError);
     void deleteAllDomains();
-    bool renameDomain(const std::string& strName, const std::string& strNewName, std::string& strError);
-    bool setSequenceAwareness(const std::string& strDomain, bool bSequenceAware, std::string& strError);
-    bool getSequenceAwareness(const std::string& strDomain, bool& bSequenceAware, std::string& strError) const;
-    bool listDomainElements(const std::string& strDomain, std::string& strResult) const;
+    bool renameDomain(const std::string &strName, const std::string &strNewName,
+                      std::string &strError);
+    bool setSequenceAwareness(const std::string &strDomain, bool bSequenceAware,
+                              std::string &strError);
+    bool getSequenceAwareness(const std::string &strDomain, bool &bSequenceAware,
+                              std::string &strError) const;
+    bool listDomainElements(const std::string &strDomain, std::string &strResult) const;
 
     /** Split a domain in two.
      * Remove an element of a domain and create a new domain which owns the element.
@@ -86,18 +88,19 @@ public:
      * @param[out] infos useful information we can provide to client
      * @return true if succeed false otherwise
      */
-    bool split(const std::string& domainName,
-               CConfigurableElement* element,
-               core::Results& infos);
+    bool split(const std::string &domainName, CConfigurableElement *element, core::Results &infos);
 
-    void listAssociatedElements(std::string& strResult) const;
-    void listConflictingElements(std::string& strResult) const;
-    void listDomains(std::string& strResult) const;
+    void listAssociatedElements(std::string &strResult) const;
+    void listConflictingElements(std::string &strResult) const;
+    void listDomains(std::string &strResult) const;
     /// Configurations
-    bool listConfigurations(const std::string& strDomain, std::string& strResult) const;
-    bool createConfiguration(const std::string& strDomain, const std::string& strConfiguration, const CParameterBlackboard* pMainBlackboard, std::string& strError);
-    bool deleteConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
-    bool renameConfiguration(const std::string& strDomain, const std::string& strConfigurationName, const std::string& strNewConfigurationName, std::string& strError);
+    bool listConfigurations(const std::string &strDomain, std::string &strResult) const;
+    bool createConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                             const CParameterBlackboard *pMainBlackboard, std::string &strError);
+    bool deleteConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                             std::string &strError);
+    bool renameConfiguration(const std::string &strDomain, const std::string &strConfigurationName,
+                             const std::string &strNewConfigurationName, std::string &strError);
 
     /** Restore a configuration
      *
@@ -108,21 +111,28 @@ public:
      * @param[out] errors, errors encountered during restoration
      * @return true if success false otherwise
      */
-    bool restoreConfiguration(const std::string& strDomain,
-                              const std::string& strConfiguration,
-                              CParameterBlackboard* pMainBlackboard,
-                              bool bAutoSync,
-                              core::Results& errors) const;
+    bool restoreConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                              CParameterBlackboard *pMainBlackboard, bool bAutoSync,
+                              core::Results &errors) const;
 
-    bool saveConfiguration(const std::string& strDomain, const std::string& strConfiguration, const CParameterBlackboard* pMainBlackboard, std::string& strError);
-    bool setElementSequence(const std::string& strDomain, const std::string& strConfiguration, const std::vector<std::string>& astrNewElementSequence, std::string& strError);
-    bool getElementSequence(const std::string& strDomain, const std::string& strConfiguration, std::string& strResult) const;
-    bool setApplicationRule(const std::string& strDomain, const std::string& strConfiguration, const std::string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition, std::string& strError);
-    bool clearApplicationRule(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
-    bool getApplicationRule(const std::string& strDomain, const std::string& strConfiguration, std::string& strResult) const;
+    bool saveConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                           const CParameterBlackboard *pMainBlackboard, std::string &strError);
+    bool setElementSequence(const std::string &strDomain, const std::string &strConfiguration,
+                            const std::vector<std::string> &astrNewElementSequence,
+                            std::string &strError);
+    bool getElementSequence(const std::string &strDomain, const std::string &strConfiguration,
+                            std::string &strResult) const;
+    bool setApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                            const std::string &strApplicationRule,
+                            const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition,
+                            std::string &strError);
+    bool clearApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                              std::string &strError);
+    bool getApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                            std::string &strResult) const;
 
     // Last applied configurations
-    void listLastAppliedConfigurations(std::string& strResult) const;
+    void listLastAppliedConfigurations(std::string &strResult) const;
 
     /** Associate a configurable element to a domain
      *
@@ -132,29 +142,29 @@ public:
      * @param[out] infos useful information we can provide to client
      * @return true if succeed false otherwise
      */
-    bool addConfigurableElementToDomain(const std::string& domainName,
-                                        CConfigurableElement* element,
-                                        const CParameterBlackboard* mainBlackboard,
-                                        core::Results& infos);
+    bool addConfigurableElementToDomain(const std::string &domainName,
+                                        CConfigurableElement *element,
+                                        const CParameterBlackboard *mainBlackboard,
+                                        core::Results &infos);
 
-    bool removeConfigurableElementFromDomain(const std::string& strDomain, CConfigurableElement* pConfigurableElement, std::string& strError);
+    bool removeConfigurableElementFromDomain(const std::string &strDomain,
+                                             CConfigurableElement *pConfigurableElement,
+                                             std::string &strError);
 
     // Configuration Blackboard for element
-    CParameterBlackboard* findConfigurationBlackboard(const std::string& strDomain,
-                                     const std::string& strConfiguration,
-                                     const CConfigurableElement* pConfigurableElement,
-                                     size_t& baseOffset,
-                                     bool& bIsLastApplied,
-                                     std::string& strError) const;
+    CParameterBlackboard *findConfigurationBlackboard(
+        const std::string &strDomain, const std::string &strConfiguration,
+        const CConfigurableElement *pConfigurableElement, size_t &baseOffset, bool &bIsLastApplied,
+        std::string &strError) const;
 
-    const CConfigurableDomain* findConfigurableDomain(const std::string& strDomain,
-                                                      std::string& strError) const;
+    const CConfigurableDomain *findConfigurableDomain(const std::string &strDomain,
+                                                      std::string &strError) const;
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // Ensure validity on whole domains from main blackboard
-    void validate(const CParameterBlackboard* pMainBlackboard);
+    void validate(const CParameterBlackboard *pMainBlackboard);
 
     /** Apply the configuration if required
      *
@@ -163,13 +173,12 @@ public:
      * @param[in] bForce boolean used to force configuration application
      * @param[out] infos useful information we can provide to client
      */
-    void apply(CParameterBlackboard* pParameterBlackboard,
-               CSyncerSet& syncerSet,
-               bool bForce,
-               core::Results& infos) const;
+    void apply(CParameterBlackboard *pParameterBlackboard, CSyncerSet &syncerSet, bool bForce,
+               core::Results &infos) const;
 
     // Class kind
     virtual std::string getKind() const;
+
 private:
     /** Delete a domain
      *
@@ -178,12 +187,13 @@ private:
      * @returns true of the domain was sucessfully deleted, false otherwise (i.e.
      * the domain didn't exist).
      */
-    void deleteDomain(CConfigurableDomain& configurableDomain);
+    void deleteDomain(CConfigurableDomain &configurableDomain);
     // Returns true if children dynamic creation is to be dealt with
     virtual bool childrenAreDynamic() const;
     // Gather owned configurable elements owned by any domain
-    void gatherAllOwnedConfigurableElements(std::set<const CConfigurableElement*>& configurableElementSet) const;
+    void gatherAllOwnedConfigurableElements(
+        std::set<const CConfigurableElement *> &configurableElementSet) const;
     // Domain retrieval
-    CConfigurableDomain* findConfigurableDomain(const std::string& strDomain, std::string& strError);
+    CConfigurableDomain *findConfigurableDomain(const std::string &strDomain,
+                                                std::string &strError);
 };
-

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -41,7 +41,7 @@
 
 #define base CElement
 
-CConfigurableElement::CConfigurableElement(const std::string& strName) : base(strName)
+CConfigurableElement::CConfigurableElement(const std::string &strName) : base(strName)
 {
 }
 
@@ -56,7 +56,7 @@ bool CConfigurableElement::fromXml(const CXmlElement &xmlElement,
         // the (de)serialize object can not be const in `serializeXmlSettings` signature.
         // As a result a const_cast is unavoidable :(.
         // Fixme: split serializeXmlSettings in two functions (in and out) to avoid the `const_cast`
-        return serializeXmlSettings(const_cast<CXmlElement&>(xmlElement),
+        return serializeXmlSettings(const_cast<CXmlElement &>(xmlElement),
                                     static_cast<CConfigurationAccessContext &>(accessContext));
     }
     return structureFromXml(xmlElement, serializingContext);
@@ -77,7 +77,9 @@ void CConfigurableElement::toXml(CXmlElement &xmlElement,
 }
 
 // XML configuration settings parsing
-bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const
+bool CConfigurableElement::serializeXmlSettings(
+    CXmlElement &xmlConfigurationSettingsElementContent,
+    CConfigurationAccessContext &configurationAccessContext) const
 {
     size_t uiNbChildren = getNbChildren();
 
@@ -91,15 +93,16 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
         for (size_t index = 0; index < uiNbChildren; index++) {
 
             // Get child
-            const CConfigurableElement* pChildConfigurableElement = static_cast<const CConfigurableElement*>(getChild(index));
+            const CConfigurableElement *pChildConfigurableElement =
+                static_cast<const CConfigurableElement *>(getChild(index));
 
             if (!it.next(xmlChildConfigurableElementSettingsElement)) {
 
                 // Structure error
                 configurationAccessContext.setError(
-                        "Configuration settings parsing: missing child node " +
-                        pChildConfigurableElement->getXmlElementName() +
-                        " (name:" + pChildConfigurableElement->getName() + ") in " + getName());
+                    "Configuration settings parsing: missing child node " +
+                    pChildConfigurableElement->getXmlElementName() + " (name:" +
+                    pChildConfigurableElement->getName() + ") in " + getName());
 
                 return false;
             }
@@ -121,8 +124,10 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
                 if (!compatibilityCase) {
 
                     // Type error
-                    configurationAccessContext.setError("Configuration settings parsing: Settings "
-                        "for configurable element " + pChildConfigurableElement->getQualifiedPath() +
+                    configurationAccessContext.setError(
+                        "Configuration settings parsing: Settings "
+                        "for configurable element " +
+                        pChildConfigurableElement->getQualifiedPath() +
                         " does not match expected type: " +
                         xmlChildConfigurableElementSettingsElement.getType() + " instead of " +
                         pChildConfigurableElement->getKind());
@@ -131,20 +136,22 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
             }
 
             // Check element type matches in name
-            if (xmlChildConfigurableElementSettingsElement.getNameAttribute() != pChildConfigurableElement->getName()) {
+            if (xmlChildConfigurableElementSettingsElement.getNameAttribute() !=
+                pChildConfigurableElement->getName()) {
 
                 // Name error
                 configurationAccessContext.setError(
-                        "Configuration settings parsing: Under configurable element " +
-                        getQualifiedPath() + ", expected element name " +
-                        pChildConfigurableElement->getName() + " but found " +
-                        xmlChildConfigurableElementSettingsElement.getNameAttribute() + " instead");
+                    "Configuration settings parsing: Under configurable element " +
+                    getQualifiedPath() + ", expected element name " +
+                    pChildConfigurableElement->getName() + " but found " +
+                    xmlChildConfigurableElementSettingsElement.getNameAttribute() + " instead");
 
                 return false;
             }
 
             // Parse child configurable element's settings
-            if (!pChildConfigurableElement->serializeXmlSettings(xmlChildConfigurableElementSettingsElement, configurationAccessContext)) {
+            if (!pChildConfigurableElement->serializeXmlSettings(
+                    xmlChildConfigurableElementSettingsElement, configurationAccessContext)) {
 
                 return false;
             }
@@ -154,9 +161,8 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
 
             // Structure error
             configurationAccessContext.setError(
-                    "Configuration settings parsing: Unexpected xml element node " +
-                    xmlChildConfigurableElementSettingsElement.getType() +
-                    " in " + getQualifiedPath());
+                "Configuration settings parsing: Unexpected xml element node " +
+                xmlChildConfigurableElementSettingsElement.getType() + " in " + getQualifiedPath());
 
             return false;
         }
@@ -167,15 +173,19 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
         // Propagate to children
         for (size_t index = 0; index < uiNbChildren; index++) {
 
-            const CConfigurableElement* pChildConfigurableElement = static_cast<const CConfigurableElement*>(getChild(index));
+            const CConfigurableElement *pChildConfigurableElement =
+                static_cast<const CConfigurableElement *>(getChild(index));
 
             // Create corresponding child element
             CXmlElement xmlChildConfigurableElementSettingsElement;
 
-            xmlConfigurationSettingsElementContent.createChild(xmlChildConfigurableElementSettingsElement, pChildConfigurableElement->getXmlElementName());
+            xmlConfigurationSettingsElementContent.createChild(
+                xmlChildConfigurableElementSettingsElement,
+                pChildConfigurableElement->getXmlElementName());
 
             // Propagate
-            pChildConfigurableElement->serializeXmlSettings(xmlChildConfigurableElementSettingsElement, configurationAccessContext);
+            pChildConfigurableElement->serializeXmlSettings(
+                xmlChildConfigurableElementSettingsElement, configurationAccessContext);
         }
     }
     // Done
@@ -183,24 +193,30 @@ bool CConfigurableElement::serializeXmlSettings(CXmlElement& xmlConfigurationSet
 }
 
 // AreaConfiguration creation
-CAreaConfiguration* CConfigurableElement::createAreaConfiguration(const CSyncerSet* pSyncerSet) const
+CAreaConfiguration *CConfigurableElement::createAreaConfiguration(
+    const CSyncerSet *pSyncerSet) const
 {
     return new CAreaConfiguration(this, pSyncerSet);
 }
 
 // Parameter access
-bool CConfigurableElement::accessValue(CPathNavigator& pathNavigator, std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CConfigurableElement::accessValue(CPathNavigator &pathNavigator, std::string &strValue,
+                                       bool bSet,
+                                       CParameterAccessContext &parameterAccessContext) const
 {
-    std::string* pStrChildName = pathNavigator.next();
+    std::string *pStrChildName = pathNavigator.next();
 
     if (!pStrChildName) {
 
-        parameterAccessContext.setError((bSet ? "Can't set " : "Can't get ") + pathNavigator.getCurrentPath() + " because it is not a parameter");
+        parameterAccessContext.setError((bSet ? "Can't set " : "Can't get ") +
+                                        pathNavigator.getCurrentPath() +
+                                        " because it is not a parameter");
 
         return false;
     }
 
-    const CConfigurableElement* pChild = static_cast<const CConfigurableElement*>(findChild(*pStrChildName));
+    const CConfigurableElement *pChild =
+        static_cast<const CConfigurableElement *>(findChild(*pStrChildName));
 
     if (!pChild) {
 
@@ -213,19 +229,19 @@ bool CConfigurableElement::accessValue(CPathNavigator& pathNavigator, std::strin
 }
 
 // Whole element access
-void CConfigurableElement::getSettingsAsBytes(std::vector<uint8_t>& bytes,
-                                              CParameterAccessContext& parameterAccessContext) const
+void CConfigurableElement::getSettingsAsBytes(std::vector<uint8_t> &bytes,
+                                              CParameterAccessContext &parameterAccessContext) const
 {
     bytes.resize(getFootPrint());
 
     parameterAccessContext.getParameterBlackboard()->readBytes(
-            bytes, getOffset() - parameterAccessContext.getBaseOffset());
+        bytes, getOffset() - parameterAccessContext.getBaseOffset());
 }
 
-bool CConfigurableElement::setSettingsAsBytes(const std::vector<uint8_t>& bytes,
-                                              CParameterAccessContext& parameterAccessContext) const
+bool CConfigurableElement::setSettingsAsBytes(const std::vector<uint8_t> &bytes,
+                                              CParameterAccessContext &parameterAccessContext) const
 {
-    CParameterBlackboard* pParameterBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pParameterBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Size
     size_t size = getFootPrint();
@@ -233,9 +249,9 @@ bool CConfigurableElement::setSettingsAsBytes(const std::vector<uint8_t>& bytes,
     // Check sizes match
     if (size != bytes.size()) {
 
-        parameterAccessContext.setError(std::string("Wrong size: Expected: ")
-                                        + std::to_string(size) + " Provided: "
-                                        + std::to_string(bytes.size()));
+        parameterAccessContext.setError(std::string("Wrong size: Expected: ") +
+                                        std::to_string(size) + " Provided: " +
+                                        std::to_string(bytes.size()));
 
         return false;
     }
@@ -260,35 +276,36 @@ bool CConfigurableElement::setSettingsAsBytes(const std::vector<uint8_t>& bytes,
 }
 
 void CConfigurableElement::getListOfElementsWithMapping(
-        std::list<const CConfigurableElement*>& configurableElementPath) const
+    std::list<const CConfigurableElement *> &configurableElementPath) const
 {
     // Check parent
-    const CElement* pParent = getParent();
+    const CElement *pParent = getParent();
     if (isOfConfigurableElementType(pParent)) {
 
-        const CConfigurableElement* pConfigurableElement =
-                static_cast<const CConfigurableElement*>(pParent);
+        const CConfigurableElement *pConfigurableElement =
+            static_cast<const CConfigurableElement *>(pParent);
 
         pConfigurableElement->getListOfElementsWithMapping(configurableElementPath);
     }
 }
 
 // Used for simulation and virtual subsystems
-void CConfigurableElement::setDefaultValues(CParameterAccessContext& parameterAccessContext) const
+void CConfigurableElement::setDefaultValues(CParameterAccessContext &parameterAccessContext) const
 {
     // Propagate to children
     size_t uiNbChildren = getNbChildren();
 
     for (size_t index = 0; index < uiNbChildren; index++) {
 
-        const CConfigurableElement* pConfigurableElement = static_cast<const CConfigurableElement*>(getChild(index));
+        const CConfigurableElement *pConfigurableElement =
+            static_cast<const CConfigurableElement *>(getChild(index));
 
         pConfigurableElement->setDefaultValues(parameterAccessContext);
     }
 }
 
 // Element properties
-void CConfigurableElement::showProperties(std::string& strResult) const
+void CConfigurableElement::showProperties(std::string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -300,7 +317,7 @@ std::string CConfigurableElement::logValue(utility::ErrorContext &context) const
     return logValue(static_cast<CParameterAccessContext &>(context));
 }
 
-std::string CConfigurableElement::logValue(CParameterAccessContext &/*ctx*/) const
+std::string CConfigurableElement::logValue(CParameterAccessContext & /*ctx*/) const
 {
     // By default, an element does not have a value. Only leaf elements have
     // one. This method could be pure virtual but then, several derived classes
@@ -319,7 +336,8 @@ void CConfigurableElement::setOffset(size_t offset)
 
     for (size_t index = 0; index < uiNbChildren; index++) {
 
-        CConfigurableElement* pConfigurableElement = static_cast<CConfigurableElement*>(getChild(index));
+        CConfigurableElement *pConfigurableElement =
+            static_cast<CConfigurableElement *>(getChild(index));
 
         pConfigurableElement->setOffset(offset);
 
@@ -340,7 +358,8 @@ size_t CConfigurableElement::getFootPrint() const
 
     for (size_t index = 0; index < uiNbChildren; index++) {
 
-        const CConfigurableElement* pConfigurableElement = static_cast<const CConfigurableElement*>(getChild(index));
+        const CConfigurableElement *pConfigurableElement =
+            static_cast<const CConfigurableElement *>(getChild(index));
 
         uiSize += pConfigurableElement->getFootPrint();
     }
@@ -349,23 +368,23 @@ size_t CConfigurableElement::getFootPrint() const
 }
 
 // Browse parent path to find syncer
-ISyncer* CConfigurableElement::getSyncer() const
+ISyncer *CConfigurableElement::getSyncer() const
 {
     // Check parent
-    const CElement* pParent = getParent();
+    const CElement *pParent = getParent();
 
     if (isOfConfigurableElementType(pParent)) {
 
-        return static_cast<const CConfigurableElement*>(pParent)->getSyncer();
+        return static_cast<const CConfigurableElement *>(pParent)->getSyncer();
     }
     return NULL;
 }
 
 // Syncer set (me, ascendant or descendant ones)
-void CConfigurableElement::fillSyncerSet(CSyncerSet& syncerSet) const
+void CConfigurableElement::fillSyncerSet(CSyncerSet &syncerSet) const
 {
     //  Try me or ascendants
-    ISyncer* pMineOrAscendantSyncer = getSyncer();
+    ISyncer *pMineOrAscendantSyncer = getSyncer();
 
     if (pMineOrAscendantSyncer) {
 
@@ -380,32 +399,35 @@ void CConfigurableElement::fillSyncerSet(CSyncerSet& syncerSet) const
 }
 
 // Syncer set (descendant)
-void CConfigurableElement::fillSyncerSetFromDescendant(CSyncerSet& syncerSet) const
+void CConfigurableElement::fillSyncerSetFromDescendant(CSyncerSet &syncerSet) const
 {
     // Dig
     size_t uiNbChildren = getNbChildren();
 
     for (size_t index = 0; index < uiNbChildren; index++) {
 
-        const CConfigurableElement* pConfigurableElement = static_cast<const CConfigurableElement*>(getChild(index));
+        const CConfigurableElement *pConfigurableElement =
+            static_cast<const CConfigurableElement *>(getChild(index));
 
         pConfigurableElement->fillSyncerSetFromDescendant(syncerSet);
     }
 }
 
 // Configurable domain association
-void CConfigurableElement::addAttachedConfigurableDomain(const CConfigurableDomain* pConfigurableDomain)
+void CConfigurableElement::addAttachedConfigurableDomain(
+    const CConfigurableDomain *pConfigurableDomain)
 {
     _configurableDomainList.push_back(pConfigurableDomain);
 }
 
-void CConfigurableElement::removeAttachedConfigurableDomain(const CConfigurableDomain* pConfigurableDomain)
+void CConfigurableElement::removeAttachedConfigurableDomain(
+    const CConfigurableDomain *pConfigurableDomain)
 {
     _configurableDomainList.remove(pConfigurableDomain);
 }
 
 // Belonging domain
-bool CConfigurableElement::belongsTo(const CConfigurableDomain* pConfigurableDomain) const
+bool CConfigurableElement::belongsTo(const CConfigurableDomain *pConfigurableDomain) const
 {
     if (containsConfigurableDomain(pConfigurableDomain)) {
 
@@ -415,23 +437,26 @@ bool CConfigurableElement::belongsTo(const CConfigurableDomain* pConfigurableDom
 }
 
 // Belonging domains
-void CConfigurableElement::getBelongingDomains(std::list<const CConfigurableDomain*>& configurableDomainList) const
+void CConfigurableElement::getBelongingDomains(
+    std::list<const CConfigurableDomain *> &configurableDomainList) const
 {
-    configurableDomainList.insert(configurableDomainList.end(), _configurableDomainList.begin(), _configurableDomainList.end());
+    configurableDomainList.insert(configurableDomainList.end(), _configurableDomainList.begin(),
+                                  _configurableDomainList.end());
 
     // Check parent
-    const CElement* pParent = getParent();
+    const CElement *pParent = getParent();
 
     if (isOfConfigurableElementType(pParent)) {
 
-        static_cast<const CConfigurableElement*>(pParent)->getBelongingDomains(configurableDomainList);
+        static_cast<const CConfigurableElement *>(pParent)
+            ->getBelongingDomains(configurableDomainList);
     }
 }
 
-void CConfigurableElement::listBelongingDomains(std::string& strResult, bool bVertical) const
+void CConfigurableElement::listBelongingDomains(std::string &strResult, bool bVertical) const
 {
     // Get belonging domain list
-    std::list<const CConfigurableDomain*> configurableDomainList;
+    std::list<const CConfigurableDomain *> configurableDomainList;
 
     getBelongingDomains(configurableDomainList);
 
@@ -440,23 +465,24 @@ void CConfigurableElement::listBelongingDomains(std::string& strResult, bool bVe
 }
 
 // Elements with no domains
-void CConfigurableElement::listRogueElements(std::string& strResult) const
+void CConfigurableElement::listRogueElements(std::string &strResult) const
 {
     strResult = "\n";
 
     // Get rogue element aggregate list (no associated domain)
-    std::list<const CConfigurableElement*> rogueElementList;
+    std::list<const CConfigurableElement *> rogueElementList;
 
-    CConfigurableElementAggregator configurableElementAggregator(rogueElementList, &CConfigurableElement::hasNoDomainAssociated);
+    CConfigurableElementAggregator configurableElementAggregator(
+        rogueElementList, &CConfigurableElement::hasNoDomainAssociated);
 
     configurableElementAggregator.aggegate(this);
 
     // Build list as std::string
-    std::list<const CConfigurableElement*>::const_iterator it;
+    std::list<const CConfigurableElement *>::const_iterator it;
 
     for (it = rogueElementList.begin(); it != rogueElementList.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;
+        const CConfigurableElement *pConfigurableElement = *it;
 
         strResult += pConfigurableElement->getPath() + "\n";
     }
@@ -471,9 +497,10 @@ bool CConfigurableElement::isRogue() const
     }
 
     // Get a list of elements (current + descendants) with no domains associated
-    std::list<const CConfigurableElement*> rogueElementList;
+    std::list<const CConfigurableElement *> rogueElementList;
 
-    CConfigurableElementAggregator agregator(rogueElementList, &CConfigurableElement::hasNoDomainAssociated);
+    CConfigurableElementAggregator agregator(rogueElementList,
+                                             &CConfigurableElement::hasNoDomainAssociated);
 
     agregator.aggegate(this);
 
@@ -508,7 +535,7 @@ bool CConfigurableElement::hasNoValidDomainAssociated() const
     // Browse all configurable domains for validity checking
     for (it = _configurableDomainList.begin(); it != _configurableDomainList.end(); ++it) {
 
-        const CConfigurableDomain* pConfigurableDomain = *it;
+        const CConfigurableDomain *pConfigurableDomain = *it;
 
         if (pConfigurableDomain->isApplicableConfigurationValid(this)) {
 
@@ -520,7 +547,7 @@ bool CConfigurableElement::hasNoValidDomainAssociated() const
 }
 
 // Owning domains
-void CConfigurableElement::listAssociatedDomains(std::string& strResult, bool bVertical) const
+void CConfigurableElement::listAssociatedDomains(std::string &strResult, bool bVertical) const
 {
     // Fill list
     listDomains(_configurableDomainList, strResult, bVertical);
@@ -529,14 +556,16 @@ void CConfigurableElement::listAssociatedDomains(std::string& strResult, bool bV
 size_t CConfigurableElement::getBelongingDomainCount() const
 {
     // Get belonging domain list
-    std::list<const CConfigurableDomain*> configurableDomainList;
+    std::list<const CConfigurableDomain *> configurableDomainList;
 
     getBelongingDomains(configurableDomainList);
 
     return configurableDomainList.size();
 }
 
-void CConfigurableElement::listDomains(const std::list<const CConfigurableDomain*>& configurableDomainList, std::string& strResult, bool bVertical) const
+void CConfigurableElement::listDomains(
+    const std::list<const CConfigurableDomain *> &configurableDomainList, std::string &strResult,
+    bool bVertical) const
 {
     if (bVertical && configurableDomainList.empty()) {
 
@@ -550,7 +579,7 @@ void CConfigurableElement::listDomains(const std::list<const CConfigurableDomain
     // Browse all configurable domains for comparison
     for (it = configurableDomainList.begin(); it != configurableDomainList.end(); ++it) {
 
-        const CConfigurableDomain* pConfigurableDomain = *it;
+        const CConfigurableDomain *pConfigurableDomain = *it;
 
         if (!bVertical && !bFirst) {
 
@@ -569,7 +598,8 @@ void CConfigurableElement::listDomains(const std::list<const CConfigurableDomain
     }
 }
 
-bool CConfigurableElement::containsConfigurableDomain(const CConfigurableDomain* pConfigurableDomain) const
+bool CConfigurableElement::containsConfigurableDomain(
+    const CConfigurableDomain *pConfigurableDomain) const
 {
     ConfigurableDomainListConstIterator it;
 
@@ -585,22 +615,23 @@ bool CConfigurableElement::containsConfigurableDomain(const CConfigurableDomain*
 }
 
 // Belonging domain ascending search
-bool CConfigurableElement::belongsToDomainAscending(const CConfigurableDomain* pConfigurableDomain) const
+bool CConfigurableElement::belongsToDomainAscending(
+    const CConfigurableDomain *pConfigurableDomain) const
 {
     // Check parent
-    const CElement* pParent = getParent();
+    const CElement *pParent = getParent();
 
     if (isOfConfigurableElementType(pParent)) {
 
-        return static_cast<const CConfigurableElement*>(pParent)->belongsTo(pConfigurableDomain);
+        return static_cast<const CConfigurableElement *>(pParent)->belongsTo(pConfigurableDomain);
     }
     return false;
 }
 
 // Belonging subsystem
-const CSubsystem* CConfigurableElement::getBelongingSubsystem() const
+const CSubsystem *CConfigurableElement::getBelongingSubsystem() const
 {
-    const CElement* pParent = getParent();
+    const CElement *pParent = getParent();
 
     // Stop at system class
     if (!pParent->getParent()) {
@@ -608,7 +639,7 @@ const CSubsystem* CConfigurableElement::getBelongingSubsystem() const
         return NULL;
     }
 
-    return static_cast<const CConfigurableElement*>(pParent)->getBelongingSubsystem();
+    return static_cast<const CConfigurableElement *>(pParent)->getBelongingSubsystem();
 }
 
 // Check element is a parameter
@@ -617,9 +648,8 @@ bool CConfigurableElement::isParameter() const
     return false;
 }
 
-
 // Check parent is still of current type (by structure knowledge)
-bool CConfigurableElement::isOfConfigurableElementType(const CElement* pParent) const
+bool CConfigurableElement::isOfConfigurableElementType(const CElement *pParent) const
 {
     assert(pParent);
 

--- a/parameter/ConfigurableElement.h
+++ b/parameter/ConfigurableElement.h
@@ -48,9 +48,11 @@ class PARAMETER_EXPORT CConfigurableElement : public CElement
 {
     friend class CConfigurableDomain;
     friend class CDomainConfiguration;
-    typedef std::list<const CConfigurableDomain*>::const_iterator ConfigurableDomainListConstIterator;
+    typedef std::list<const CConfigurableDomain *>::const_iterator
+        ConfigurableDomainListConstIterator;
+
 public:
-    CConfigurableElement(const std::string& strName = "");
+    CConfigurableElement(const std::string &strName = "");
     virtual ~CConfigurableElement() = default;
 
     // Offset in main blackboard
@@ -61,13 +63,13 @@ public:
     virtual size_t getFootPrint() const;
 
     // Syncer set (me, ascendant or descendant ones)
-    void fillSyncerSet(CSyncerSet& syncerSet) const;
+    void fillSyncerSet(CSyncerSet &syncerSet) const;
 
     // Belonging domain
-    bool belongsTo(const CConfigurableDomain* pConfigurableDomain) const;
+    bool belongsTo(const CConfigurableDomain *pConfigurableDomain) const;
 
     // Belonging domains
-    void listBelongingDomains(std::string& strResult, bool bVertical = true) const;
+    void listBelongingDomains(std::string &strResult, bool bVertical = true) const;
 
     // Matching check for domain association
     bool hasNoDomainAssociated() const;
@@ -76,11 +78,11 @@ public:
     bool hasNoValidDomainAssociated() const;
 
     // Owning domains
-    void listAssociatedDomains(std::string& strResult, bool bVertical = true) const;
+    void listAssociatedDomains(std::string &strResult, bool bVertical = true) const;
     size_t getBelongingDomainCount() const;
 
     // Elements with no domains
-    void listRogueElements(std::string& strResult) const;
+    void listRogueElements(std::string &strResult) const;
 
     /** @return true if element is rogue, false otherwise
      *
@@ -98,16 +100,17 @@ public:
     std::string getFootprintAsString() const;
 
     // Belonging subsystem
-    virtual const CSubsystem* getBelongingSubsystem() const;
+    virtual const CSubsystem *getBelongingSubsystem() const;
 
     // Check element is a parameter
     virtual bool isParameter() const;
 
     // AreaConfiguration creation
-    virtual CAreaConfiguration* createAreaConfiguration(const CSyncerSet* pSyncerSet) const;
+    virtual CAreaConfiguration *createAreaConfiguration(const CSyncerSet *pSyncerSet) const;
 
     // Parameter access
-    virtual bool accessValue(CPathNavigator& pathNavigator, std::string& strValue, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool accessValue(CPathNavigator &pathNavigator, std::string &strValue, bool bSet,
+                             CParameterAccessContext &parameterAccessContext) const;
 
     /** Gets the element as an array of bytes.
      *
@@ -117,8 +120,8 @@ public:
      * @param[in] parameterAccessContext Context containing the blackboard to
      *            read from.
      */
-    void getSettingsAsBytes(std::vector<uint8_t>& bytes,
-                            CParameterAccessContext& parameterAccessContext) const;
+    void getSettingsAsBytes(std::vector<uint8_t> &bytes,
+                            CParameterAccessContext &parameterAccessContext) const;
     /** Sets the element as if it was an array of bytes.
      *
      * This is like having a direct access to the blackboard.
@@ -127,13 +130,14 @@ public:
      * @param[in] parameterAccessContext Context containing the blackboard to
      *            write to.
      */
-    bool setSettingsAsBytes(const std::vector<uint8_t>& bytes,
-                            CParameterAccessContext& parameterAccessContext) const;
+    bool setSettingsAsBytes(const std::vector<uint8_t> &bytes,
+                            CParameterAccessContext &parameterAccessContext) const;
 
     /**
      * Get the list of all the ancestors that have a mapping.
      *
-     * The mapping is represented as a std::string of all the mapping data (key:value) defined in the
+     * The mapping is represented as a std::string of all the mapping data (key:value) defined in
+     * the
      * context of the element.
      * In this class, the method is generic and calls its parent getListOfElementsWithMappings(...)
      * method.
@@ -143,14 +147,14 @@ public:
      * the last one.
      *
      */
-    virtual void getListOfElementsWithMapping(std::list<const CConfigurableElement*>&
-                                               configurableElementPath) const;
+    virtual void getListOfElementsWithMapping(
+        std::list<const CConfigurableElement *> &configurableElementPath) const;
 
     // Used for simulation and virtual subsystems
-    virtual void setDefaultValues(CParameterAccessContext& parameterAccessContext) const;
+    virtual void setDefaultValues(CParameterAccessContext &parameterAccessContext) const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     /**
      * Get the value associated to a mapping key in the object's mapping
@@ -160,18 +164,22 @@ public:
      *
      * @return true if @p strKey is found in the object's mapping, false if not
      */
-    virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const = 0;
+    virtual bool getMappingData(const std::string &strKey, const std::string *&pStrValue) const = 0;
 
     // XML configuration settings parsing
-    virtual bool serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const;
+    virtual bool serializeXmlSettings(
+        CXmlElement &xmlConfigurationSettingsElementContent,
+        CConfigurationAccessContext &configurationAccessContext) const;
 
     bool fromXml(const CXmlElement &xmlElement,
-                         CXmlSerializingContext &serializingContext) override final;
+                 CXmlSerializingContext &serializingContext) override final;
 
-    void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const override final;
+    void toXml(CXmlElement &xmlElement,
+               CXmlSerializingContext &serializingContext) const override final;
 
     /** Deserialize the structure from xml. */
-    virtual bool structureFromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext)
+    virtual bool structureFromXml(const CXmlElement &xmlElement,
+                                  CXmlSerializingContext &serializingContext)
     {
         // Forward to Element::fromXml.
         // This is unfortunate as Element::fromXml will call back
@@ -188,7 +196,8 @@ public:
     }
 
     /** Serialize the structure to xml. */
-    virtual void structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+    virtual void structureToXml(CXmlElement &xmlElement,
+                                CXmlSerializingContext &serializingContext) const
     {
         // See structureFromXml implementation comment.
         CElement::toXml(xmlElement, serializingContext);
@@ -196,38 +205,38 @@ public:
 
 protected:
     // Syncer (me or ascendant)
-    virtual ISyncer* getSyncer() const;
+    virtual ISyncer *getSyncer() const;
     // Syncer set (descendant)
-    virtual void fillSyncerSetFromDescendant(CSyncerSet& syncerSet) const;
+    virtual void fillSyncerSetFromDescendant(CSyncerSet &syncerSet) const;
     // Configuration Domain local search
-    bool containsConfigurableDomain(const CConfigurableDomain* pConfigurableDomain) const;
+    bool containsConfigurableDomain(const CConfigurableDomain *pConfigurableDomain) const;
 
 private:
     // Content dumping. Override and stop further deriving: Configurable
     // Elements should be called with the overloaded version taking a
     // "Parameter Access Context" (The name is misleading as it is actually
     // used to access any Configurable Element).
-    std::string logValue(utility::ErrorContext& errorContext) const override final;
-    virtual std::string logValue(CParameterAccessContext& context) const;
+    std::string logValue(utility::ErrorContext &errorContext) const override final;
+    virtual std::string logValue(CParameterAccessContext &context) const;
 
     // Configurable domain association
-    void addAttachedConfigurableDomain(const CConfigurableDomain* pConfigurableDomain);
-    void removeAttachedConfigurableDomain(const CConfigurableDomain* pConfigurableDomain);
+    void addAttachedConfigurableDomain(const CConfigurableDomain *pConfigurableDomain);
+    void removeAttachedConfigurableDomain(const CConfigurableDomain *pConfigurableDomain);
 
     // Belonging domain ascending search
-    bool belongsToDomainAscending(const CConfigurableDomain* pConfigurableDomain) const;
+    bool belongsToDomainAscending(const CConfigurableDomain *pConfigurableDomain) const;
 
     // Belonging domains
-    void getBelongingDomains(std::list<const CConfigurableDomain*>& configurableDomainList) const;
-    void listDomains(const std::list<const CConfigurableDomain*>& configurableDomainList, std::string& strResult, bool bVertical) const;
+    void getBelongingDomains(std::list<const CConfigurableDomain *> &configurableDomainList) const;
+    void listDomains(const std::list<const CConfigurableDomain *> &configurableDomainList,
+                     std::string &strResult, bool bVertical) const;
 
     // Check parent is still of current type (by structure knowledge)
-    bool isOfConfigurableElementType(const CElement* pParent) const;
+    bool isOfConfigurableElementType(const CElement *pParent) const;
 
     // Offset in main blackboard
     size_t _offset{0};
 
     // Associated configurable domains
-    std::list<const CConfigurableDomain*> _configurableDomainList;
+    std::list<const CConfigurableDomain *> _configurableDomainList;
 };
-

--- a/parameter/ConfigurableElementAggregator.cpp
+++ b/parameter/ConfigurableElementAggregator.cpp
@@ -30,19 +30,23 @@
 #include "ConfigurableElementAggregator.h"
 #include "ConfigurableElement.h"
 
-CConfigurableElementAggregator::CConfigurableElementAggregator(std::list<const CConfigurableElement*>& aggregateList, MatchesAggregationCriterion pfnMatchesAggregationCriterion)
+CConfigurableElementAggregator::CConfigurableElementAggregator(
+    std::list<const CConfigurableElement *> &aggregateList,
+    MatchesAggregationCriterion pfnMatchesAggregationCriterion)
     : _aggregateList(aggregateList), _pfnMatchesAggregationCriterion(pfnMatchesAggregationCriterion)
 {
 }
 
 // Aggregate
-void CConfigurableElementAggregator::aggegate(const CConfigurableElement* pConfigurableElement)
+void CConfigurableElementAggregator::aggegate(const CConfigurableElement *pConfigurableElement)
 {
     doAggregate(pConfigurableElement, _aggregateList);
 }
 
 // Recursive aggregate
-bool CConfigurableElementAggregator::doAggregate(const CConfigurableElement* pConfigurableElement, std::list<const CConfigurableElement*>& aggregateList)
+bool CConfigurableElementAggregator::doAggregate(
+    const CConfigurableElement *pConfigurableElement,
+    std::list<const CConfigurableElement *> &aggregateList)
 {
     if (!(pConfigurableElement->*_pfnMatchesAggregationCriterion)()) {
 
@@ -50,14 +54,15 @@ bool CConfigurableElementAggregator::doAggregate(const CConfigurableElement* pCo
         return false;
     }
     // Check children
-    std::list<const CConfigurableElement*> childAggregateElementList;
+    std::list<const CConfigurableElement *> childAggregateElementList;
 
     size_t uiNbChildren = pConfigurableElement->getNbChildren();
     size_t uiNbMatchingChildren = 0;
 
     for (size_t index = 0; index < uiNbChildren; index++) {
 
-        const CConfigurableElement* pChildConfigurableElement = static_cast<const CConfigurableElement*>(pConfigurableElement->getChild(index));
+        const CConfigurableElement *pChildConfigurableElement =
+            static_cast<const CConfigurableElement *>(pConfigurableElement->getChild(index));
 
         uiNbMatchingChildren += doAggregate(pChildConfigurableElement, childAggregateElementList);
     }
@@ -70,7 +75,8 @@ bool CConfigurableElementAggregator::doAggregate(const CConfigurableElement* pCo
         return true;
     } else {
         // Add children if any
-        aggregateList.insert(aggregateList.end(), childAggregateElementList.begin(), childAggregateElementList.end());
+        aggregateList.insert(aggregateList.end(), childAggregateElementList.begin(),
+                             childAggregateElementList.end());
 
         return false;
     }

--- a/parameter/ConfigurableElementAggregator.h
+++ b/parameter/ConfigurableElementAggregator.h
@@ -35,7 +35,6 @@
 #include <list>
 #include <string>
 
-
 class CConfigurableElementAggregator : private utility::NonCopyable
 {
 public:
@@ -43,19 +42,20 @@ public:
     typedef bool (CConfigurableElement::*MatchesAggregationCriterion)() const;
 
     // Constructor
-    CConfigurableElementAggregator(std::list<const CConfigurableElement*>& aggregateList, MatchesAggregationCriterion pfnMatchesAggregationCriterion);
+    CConfigurableElementAggregator(std::list<const CConfigurableElement *> &aggregateList,
+                                   MatchesAggregationCriterion pfnMatchesAggregationCriterion);
 
     // Aggregate
-    void aggegate(const CConfigurableElement* pConfigurableElement);
+    void aggegate(const CConfigurableElement *pConfigurableElement);
 
 private:
     // Recursive aggregate
-    bool doAggregate(const CConfigurableElement* pConfigurableElement, std::list<const CConfigurableElement*>& aggregateList);
+    bool doAggregate(const CConfigurableElement *pConfigurableElement,
+                     std::list<const CConfigurableElement *> &aggregateList);
 
     // Aggegate list
-    std::list<const CConfigurableElement*>& _aggregateList;
+    std::list<const CConfigurableElement *> &_aggregateList;
 
     // Matching check method
     MatchesAggregationCriterion _pfnMatchesAggregationCriterion;
 };
-

--- a/parameter/ConfigurationAccessContext.cpp
+++ b/parameter/ConfigurationAccessContext.cpp
@@ -33,19 +33,18 @@
 
 using std::string;
 
-CConfigurationAccessContext::CConfigurationAccessContext(std::string& strError,
-                                                         CParameterBlackboard* pParameterBlackboard,
+CConfigurationAccessContext::CConfigurationAccessContext(std::string &strError,
+                                                         CParameterBlackboard *pParameterBlackboard,
                                                          bool bValueSpaceIsRaw,
                                                          bool bOutputRawFormatIsHex,
-                                                         bool bSerializeOut) :
-    base(strError, pParameterBlackboard, bValueSpaceIsRaw, bOutputRawFormatIsHex),
-    _bSerializeOut(bSerializeOut)
+                                                         bool bSerializeOut)
+    : base(strError, pParameterBlackboard, bValueSpaceIsRaw, bOutputRawFormatIsHex),
+      _bSerializeOut(bSerializeOut)
 {
 }
 
-CConfigurationAccessContext::CConfigurationAccessContext(string& strError, bool bSerializeOut) :
-    base(strError),
-    _bSerializeOut(bSerializeOut)
+CConfigurationAccessContext::CConfigurationAccessContext(string &strError, bool bSerializeOut)
+    : base(strError), _bSerializeOut(bSerializeOut)
 {
 }
 

--- a/parameter/ConfigurationAccessContext.h
+++ b/parameter/ConfigurationAccessContext.h
@@ -36,13 +36,11 @@
 class CConfigurationAccessContext : public CParameterAccessContext
 {
 public:
-    CConfigurationAccessContext(std::string& strError,
-                                CParameterBlackboard* pParameterBlackboard,
-                                bool bValueSpaceIsRaw,
-                                bool bOutputRawFormatIsHex,
+    CConfigurationAccessContext(std::string &strError, CParameterBlackboard *pParameterBlackboard,
+                                bool bValueSpaceIsRaw, bool bOutputRawFormatIsHex,
                                 bool bSerializeOut);
 
-    CConfigurationAccessContext(std::string& strError, bool bSerializeOut);
+    CConfigurationAccessContext(std::string &strError, bool bSerializeOut);
 
     // Serialization direction
     bool serializeOut() const;
@@ -53,4 +51,3 @@ private:
     // Serialization direction
     bool _bSerializeOut;
 };
-

--- a/parameter/DefaultElementLibrary.h
+++ b/parameter/DefaultElementLibrary.h
@@ -43,11 +43,10 @@
   * @tparam CDefaultElementBuilder is the class of the element builder to use if no corresponding
   *                                builder is found for a given xml element.
   */
-template<class CDefaultElementBuilder>
-class CDefaultElementLibrary: public CElementLibrary
+template <class CDefaultElementBuilder>
+class CDefaultElementLibrary : public CElementLibrary
 {
 public:
-
     virtual ~CDefaultElementLibrary() = default;
 
     /** Set the default builder used in fallback mechanism.
@@ -60,7 +59,6 @@ public:
         _defaultBuilder = std::move(defaultBuilder);
     }
 
-
     /** Create and return an element instanciated depending on an xmlElement.
       *
       * @param[in] xmlElement: The xml element used to find a matching builder
@@ -71,16 +69,17 @@ public:
       *                 create the elemen with the default element builder.
       *             otherwise, return NULL.
       */
-    CElement* createElement(const CXmlElement& xmlElement) const;
+    CElement *createElement(const CXmlElement &xmlElement) const;
 
 private:
     std::unique_ptr<CDefaultElementBuilder> _defaultBuilder;
 };
 
-template<class CDefaultElementBuilder>
-CElement* CDefaultElementLibrary<CDefaultElementBuilder>::createElement(const CXmlElement& xmlElement) const
+template <class CDefaultElementBuilder>
+CElement *CDefaultElementLibrary<CDefaultElementBuilder>::createElement(
+    const CXmlElement &xmlElement) const
 {
-    CElement* builtElement = CElementLibrary::createElement(xmlElement);
+    CElement *builtElement = CElementLibrary::createElement(xmlElement);
 
     if (builtElement != NULL) {
         // The element was created, return it
@@ -95,4 +94,3 @@ CElement* CDefaultElementLibrary<CDefaultElementBuilder>::createElement(const CX
     // Use the default builder
     return _defaultBuilder->createElement(xmlElement);
 }
-

--- a/parameter/DomainConfiguration.cpp
+++ b/parameter/DomainConfiguration.cpp
@@ -46,7 +46,7 @@
 
 using std::string;
 
-CDomainConfiguration::CDomainConfiguration(const string& strName) : base(strName)
+CDomainConfiguration::CDomainConfiguration(const string &strName) : base(strName)
 {
 }
 
@@ -63,7 +63,8 @@ bool CDomainConfiguration::childrenAreDynamic() const
 }
 
 // XML configuration settings parsing
-bool CDomainConfiguration::parseSettings(CXmlElement& xmlConfigurationSettingsElement, CXmlDomainImportContext& context)
+bool CDomainConfiguration::parseSettings(CXmlElement &xmlConfigurationSettingsElement,
+                                         CXmlDomainImportContext &context)
 {
     // Parse configurable element's configuration settings
     CXmlElement::CChildIterator it(xmlConfigurationSettingsElement);
@@ -80,12 +81,15 @@ bool CDomainConfiguration::parseSettings(CXmlElement& xmlConfigurationSettingsEl
         auto areaConfiguration = findAreaConfigurationByPath(configurableElementPath);
         if (areaConfiguration == end(mAreaConfigurationList)) {
 
-            context.setError("Configurable Element " + configurableElementPath  + " referred to by Configuration " + getPath() + " not associated to Domain");
+            context.setError("Configurable Element " + configurableElementPath +
+                             " referred to by Configuration " + getPath() +
+                             " not associated to Domain");
 
             return false;
         }
         // Parse
-        if (!importOneConfigurableElementSettings(areaConfiguration->get(), xmlConfigurableElementSettingsElement, context)) {
+        if (!importOneConfigurableElementSettings(areaConfiguration->get(),
+                                                  xmlConfigurableElementSettingsElement, context)) {
 
             return false;
         }
@@ -101,43 +105,45 @@ bool CDomainConfiguration::parseSettings(CXmlElement& xmlConfigurationSettingsEl
 }
 
 // XML configuration settings composing
-void CDomainConfiguration::composeSettings(CXmlElement& xmlConfigurationSettingsElement, CXmlDomainExportContext& context) const
+void CDomainConfiguration::composeSettings(CXmlElement &xmlConfigurationSettingsElement,
+                                           CXmlDomainExportContext &context) const
 {
     // Go through all are configurations
     for (auto &areaConfiguration : mAreaConfigurationList) {
 
         // Retrieve configurable element
-        const CConfigurableElement* pConfigurableElement = areaConfiguration->getConfigurableElement();
+        const CConfigurableElement *pConfigurableElement =
+            areaConfiguration->getConfigurableElement();
 
         // Create configurable element child element
         CXmlElement xmlConfigurableElementSettingsElement;
 
-        xmlConfigurationSettingsElement.createChild(xmlConfigurableElementSettingsElement, "ConfigurableElement");
+        xmlConfigurationSettingsElement.createChild(xmlConfigurableElementSettingsElement,
+                                                    "ConfigurableElement");
 
         // Set Path attribute
         xmlConfigurableElementSettingsElement.setAttribute("Path", pConfigurableElement->getPath());
 
         // Delegate composing to area configuration
-        exportOneConfigurableElementSettings(areaConfiguration.get(), xmlConfigurableElementSettingsElement, context);
+        exportOneConfigurableElementSettings(areaConfiguration.get(),
+                                             xmlConfigurableElementSettingsElement, context);
     }
 }
 
 // Serialize one configuration for one configurable element
 bool CDomainConfiguration::importOneConfigurableElementSettings(
-        CAreaConfiguration *areaConfiguration,
-        CXmlElement& xmlConfigurableElementSettingsElement,
-        CXmlDomainImportContext& context)
+    CAreaConfiguration *areaConfiguration, CXmlElement &xmlConfigurableElementSettingsElement,
+    CXmlDomainImportContext &context)
 {
-    const CConfigurableElement* destination = areaConfiguration->getConfigurableElement();
+    const CConfigurableElement *destination = areaConfiguration->getConfigurableElement();
 
     // Check structure
     if (xmlConfigurableElementSettingsElement.getNbChildElements() != 1) {
 
         // Structure error
-        context.setError(
-                "Struture error encountered while parsing settings of " +
-                destination->getKind() + " " + destination->getName() +
-                " in Configuration " + getPath());
+        context.setError("Struture error encountered while parsing settings of " +
+                         destination->getKind() + " " + destination->getName() +
+                         " in Configuration " + getPath());
 
         return false;
     }
@@ -146,9 +152,8 @@ bool CDomainConfiguration::importOneConfigurableElementSettings(
     CXmlElement xmlConfigurableElementSettingsElementContent;
     // Check name and kind
     if (!xmlConfigurableElementSettingsElement.getChildElement(
-                destination->getXmlElementName(),
-                destination->getName(),
-                xmlConfigurableElementSettingsElementContent)) {
+            destination->getXmlElementName(), destination->getName(),
+            xmlConfigurableElementSettingsElementContent)) {
 
         // "Component" tag has been renamed to "ParameterBlock", but retro-compatibility shall
         // be ensured.
@@ -156,18 +161,14 @@ bool CDomainConfiguration::importOneConfigurableElementSettings(
         // So checking if this case occurs, i.e. element name is "ParameterBlock"
         // but found xml setting name is "Component".
         bool compatibilityCase =
-                (destination->getXmlElementName() == "ParameterBlock") &&
-                xmlConfigurableElementSettingsElement.getChildElement(
-                    "Component",
-                    destination->getName(),
-                    xmlConfigurableElementSettingsElementContent);
+            (destination->getXmlElementName() == "ParameterBlock") &&
+            xmlConfigurableElementSettingsElement.getChildElement(
+                "Component", destination->getName(), xmlConfigurableElementSettingsElementContent);
 
         // Error if the compatibility case does not occur.
         if (!compatibilityCase) {
-            context.setError(
-                    "Couldn't find settings for " +
-                    destination->getXmlElementName() + " " + destination->getName() +
-                    " for Configuration " + getPath());
+            context.setError("Couldn't find settings for " + destination->getXmlElementName() +
+                             " " + destination->getName() + " for Configuration " + getPath());
 
             return false;
         }
@@ -179,23 +180,22 @@ bool CDomainConfiguration::importOneConfigurableElementSettings(
 
     // Have domain configuration parse settings for configurable element
     bool success = areaConfiguration->serializeXmlSettings(
-            xmlConfigurableElementSettingsElementContent,
-            configurationAccessContext);
+        xmlConfigurableElementSettingsElementContent, configurationAccessContext);
 
     context.appendToError(error);
     return success;
 }
 
 bool CDomainConfiguration::exportOneConfigurableElementSettings(
-        CAreaConfiguration *areaConfiguration,
-        CXmlElement& xmlConfigurableElementSettingsElement,
-        CXmlDomainExportContext& context) const
+    CAreaConfiguration *areaConfiguration, CXmlElement &xmlConfigurableElementSettingsElement,
+    CXmlDomainExportContext &context) const
 {
-    const CConfigurableElement* source = areaConfiguration->getConfigurableElement();
+    const CConfigurableElement *source = areaConfiguration->getConfigurableElement();
 
     // Create child XML element
     CXmlElement xmlConfigurableElementSettingsElementContent;
-    xmlConfigurableElementSettingsElement.createChild(xmlConfigurableElementSettingsElementContent, source->getXmlElementName());
+    xmlConfigurableElementSettingsElement.createChild(xmlConfigurableElementSettingsElementContent,
+                                                      source->getXmlElementName());
 
     // Create configuration access context
     string error;
@@ -205,26 +205,28 @@ bool CDomainConfiguration::exportOneConfigurableElementSettings(
 
     // Have domain configuration parse settings for configurable element
     bool success = areaConfiguration->serializeXmlSettings(
-            xmlConfigurableElementSettingsElementContent,
-            configurationAccessContext);
+        xmlConfigurableElementSettingsElementContent, configurationAccessContext);
 
     context.appendToError(error);
     return success;
 }
 
-void CDomainConfiguration::addConfigurableElement(const CConfigurableElement *configurableElement, const CSyncerSet *syncerSet)
+void CDomainConfiguration::addConfigurableElement(const CConfigurableElement *configurableElement,
+                                                  const CSyncerSet *syncerSet)
 {
     mAreaConfigurationList.emplace_back(configurableElement->createAreaConfiguration(syncerSet));
 }
 
-void CDomainConfiguration::removeConfigurableElement(const CConfigurableElement* pConfigurableElement)
+void CDomainConfiguration::removeConfigurableElement(
+    const CConfigurableElement *pConfigurableElement)
 {
     auto &areaConfigurationToRemove = getAreaConfiguration(pConfigurableElement);
 
     mAreaConfigurationList.remove(areaConfigurationToRemove);
 }
 
-bool CDomainConfiguration::setElementSequence(const std::vector<string> &newElementSequence, string &error)
+bool CDomainConfiguration::setElementSequence(const std::vector<string> &newElementSequence,
+                                              string &error)
 {
     std::vector<string> elementSequenceSet;
     auto insertLocation = begin(mAreaConfigurationList);
@@ -255,17 +257,19 @@ bool CDomainConfiguration::setElementSequence(const std::vector<string> &newElem
     return true;
 }
 
-void CDomainConfiguration::getElementSequence(string& strResult) const
+void CDomainConfiguration::getElementSequence(string &strResult) const
 {
     // List configurable element paths out of ordered area configuration list
-    strResult = accumulate(begin(mAreaConfigurationList), end(mAreaConfigurationList),
-                           string("\n"), [](const string &a, const AreaConfiguration &conf) {
-        return a + conf->getConfigurableElement()->getPath() + "\n";
-    });
+    strResult = accumulate(begin(mAreaConfigurationList), end(mAreaConfigurationList), string("\n"),
+                           [](const string &a, const AreaConfiguration &conf) {
+                               return a + conf->getConfigurableElement()->getPath() + "\n";
+                           });
 }
 
 // Application rule
-bool CDomainConfiguration::setApplicationRule(const string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition, string& strError)
+bool CDomainConfiguration::setApplicationRule(
+    const string &strApplicationRule,
+    const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition, string &strError)
 {
     // Parser
     CRuleParser ruleParser(strApplicationRule, pSelectionCriteriaDefinition);
@@ -289,7 +293,7 @@ void CDomainConfiguration::clearApplicationRule()
 
 string CDomainConfiguration::getApplicationRule() const
 {
-    const CCompoundRule* pRule = getRule();
+    const CCompoundRule *pRule = getRule();
     return pRule ? pRule->dump() : "<none>";
 }
 
@@ -305,39 +309,42 @@ string CDomainConfiguration::getApplicationRule() const
  *
  * return Pointer to the Blackboard of the Configuration.
  */
-CParameterBlackboard* CDomainConfiguration::getBlackboard(const CConfigurableElement* pConfigurableElement) const
+CParameterBlackboard *CDomainConfiguration::getBlackboard(
+    const CConfigurableElement *pConfigurableElement) const
 {
     const auto &it = find_if(begin(mAreaConfigurationList), end(mAreaConfigurationList),
-                      [&](const AreaConfiguration &conf) {
-        return conf != nullptr && conf->getConfigurableElement() == pConfigurableElement;
-    });
+                             [&](const AreaConfiguration &conf) {
+                                 return conf != nullptr &&
+                                        conf->getConfigurableElement() == pConfigurableElement;
+                             });
     ALWAYS_ASSERT(it != end(mAreaConfigurationList), "Configurable Element "
-                  << pConfigurableElement->getName() << " not found in any area Configuration");
+                                                         << pConfigurableElement->getName()
+                                                         << " not found in any area Configuration");
     return &(*it)->getBlackboard();
 }
 
 // Save data from current
-void CDomainConfiguration::save(const CParameterBlackboard* pMainBlackboard)
+void CDomainConfiguration::save(const CParameterBlackboard *pMainBlackboard)
 {
     // Just propagate to areas
-    for(auto &areaConfiguration : mAreaConfigurationList) {
+    for (auto &areaConfiguration : mAreaConfigurationList) {
         areaConfiguration->save(pMainBlackboard);
     }
 }
 
 // Apply data to current
-bool CDomainConfiguration::restore(CParameterBlackboard* pMainBlackboard,
-                                   bool bSync,
-                                   core::Results* errors) const
+bool CDomainConfiguration::restore(CParameterBlackboard *pMainBlackboard, bool bSync,
+                                   core::Results *errors) const
 {
-    return std::accumulate(begin(mAreaConfigurationList), end(mAreaConfigurationList),
-                           true, [&](bool accumulator, const AreaConfiguration &conf) {
-        return conf->restore(pMainBlackboard, bSync, errors) && accumulator;
-    });
+    return std::accumulate(begin(mAreaConfigurationList), end(mAreaConfigurationList), true,
+                           [&](bool accumulator, const AreaConfiguration &conf) {
+                               return conf->restore(pMainBlackboard, bSync, errors) && accumulator;
+                           });
 }
 
 // Ensure validity for configurable element area configuration
-void CDomainConfiguration::validate(const CConfigurableElement* pConfigurableElement, const CParameterBlackboard* pMainBlackboard)
+void CDomainConfiguration::validate(const CConfigurableElement *pConfigurableElement,
+                                    const CParameterBlackboard *pMainBlackboard)
 {
     auto &areaConfigurationToValidate = getAreaConfiguration(pConfigurableElement);
 
@@ -346,31 +353,34 @@ void CDomainConfiguration::validate(const CConfigurableElement* pConfigurableEle
 }
 
 // Ensure validity of all area configurations
-void CDomainConfiguration::validate(const CParameterBlackboard* pMainBlackboard)
+void CDomainConfiguration::validate(const CParameterBlackboard *pMainBlackboard)
 {
-    for(auto &areaConfiguration : mAreaConfigurationList) {
+    for (auto &areaConfiguration : mAreaConfigurationList) {
         areaConfiguration->validate(pMainBlackboard);
     }
 }
 
 // Return configuration validity for given configurable element
-bool CDomainConfiguration::isValid(const CConfigurableElement* pConfigurableElement) const
+bool CDomainConfiguration::isValid(const CConfigurableElement *pConfigurableElement) const
 {
     // Get child configurable elemnt's area configuration
     auto &areaConfiguration = getAreaConfiguration(pConfigurableElement);
 
     ALWAYS_ASSERT(areaConfiguration != nullptr, "Configurable Element "
-                  << pConfigurableElement->getName() << " not found in any area Configuration");
+                                                    << pConfigurableElement->getName()
+                                                    << " not found in any area Configuration");
 
     return areaConfiguration->isValid();
 }
 
 // Ensure validity of configurable element's area configuration by copying in from a valid one
-void CDomainConfiguration::validateAgainst(const CDomainConfiguration* pValidDomainConfiguration, const CConfigurableElement* pConfigurableElement)
+void CDomainConfiguration::validateAgainst(const CDomainConfiguration *pValidDomainConfiguration,
+                                           const CConfigurableElement *pConfigurableElement)
 {
     // Retrieve related area configurations
     auto &areaConfigurationToValidate = getAreaConfiguration(pConfigurableElement);
-    const auto &areaConfigurationToValidateAgainst = pValidDomainConfiguration->getAreaConfiguration(pConfigurableElement);
+    const auto &areaConfigurationToValidateAgainst =
+        pValidDomainConfiguration->getAreaConfiguration(pConfigurableElement);
 
     // Delegate to area
     areaConfigurationToValidate->validateAgainst(areaConfigurationToValidateAgainst.get());
@@ -378,11 +388,13 @@ void CDomainConfiguration::validateAgainst(const CDomainConfiguration* pValidDom
 
 void CDomainConfiguration::validateAgainst(const CDomainConfiguration *validDomainConfiguration)
 {
-    ALWAYS_ASSERT(mAreaConfigurationList.size() == validDomainConfiguration->mAreaConfigurationList.size(),
-                  "Cannot validate domain configuration " << getPath()
-                  << " since area configuration list does not have the same size"
-                     "than the configuration list to check against");
-    for (const auto &configurationToValidateAgainst : validDomainConfiguration->mAreaConfigurationList) {
+    ALWAYS_ASSERT(mAreaConfigurationList.size() ==
+                      validDomainConfiguration->mAreaConfigurationList.size(),
+                  "Cannot validate domain configuration "
+                      << getPath() << " since area configuration list does not have the same size"
+                                      "than the configuration list to check against");
+    for (const auto &configurationToValidateAgainst :
+         validDomainConfiguration->mAreaConfigurationList) {
         // Get the area configuration associated to the configurable element of the
         // valid area configuration, it will assert if none found.
         auto configurableElement = configurationToValidateAgainst->getConfigurableElement();
@@ -395,13 +407,14 @@ void CDomainConfiguration::validateAgainst(const CDomainConfiguration *validDoma
 // Dynamic data application
 bool CDomainConfiguration::isApplicable() const
 {
-    const CCompoundRule* pRule = getRule();
+    const CCompoundRule *pRule = getRule();
 
     return pRule && pRule->matches();
 }
 
 // Merge existing configurations to given configurable element ones
-void CDomainConfiguration::merge(CConfigurableElement* pToConfigurableElement, CConfigurableElement* pFromConfigurableElement)
+void CDomainConfiguration::merge(CConfigurableElement *pToConfigurableElement,
+                                 CConfigurableElement *pFromConfigurableElement)
 {
     // Retrieve related area configurations
     auto &areaConfigurationToMergeTo = getAreaConfiguration(pToConfigurableElement);
@@ -412,7 +425,7 @@ void CDomainConfiguration::merge(CConfigurableElement* pToConfigurableElement, C
 }
 
 // Domain splitting
-void CDomainConfiguration::split(CConfigurableElement* pFromConfigurableElement)
+void CDomainConfiguration::split(CConfigurableElement *pFromConfigurableElement)
 {
     // Retrieve related area configuration
     const auto &areaConfigurationToSplitFrom = getAreaConfiguration(pFromConfigurableElement);
@@ -423,7 +436,8 @@ void CDomainConfiguration::split(CConfigurableElement* pFromConfigurableElement)
 
     for (uiChild = 0; uiChild < uiNbConfigurableElementChildren; uiChild++) {
 
-        CConfigurableElement* pToChildConfigurableElement = static_cast<CConfigurableElement*>(pFromConfigurableElement->getChild(uiChild));
+        CConfigurableElement *pToChildConfigurableElement =
+            static_cast<CConfigurableElement *>(pFromConfigurableElement->getChild(uiChild));
 
         // Get child configurable elemnt's area configuration
         auto &childAreaConfiguration = getAreaConfiguration(pToChildConfigurableElement);
@@ -433,48 +447,52 @@ void CDomainConfiguration::split(CConfigurableElement* pFromConfigurableElement)
     }
 }
 
-const CDomainConfiguration::AreaConfiguration &CDomainConfiguration::getAreaConfiguration(const CConfigurableElement* pConfigurableElement) const
+const CDomainConfiguration::AreaConfiguration &CDomainConfiguration::getAreaConfiguration(
+    const CConfigurableElement *pConfigurableElement) const
 {
     const auto &it = find_if(begin(mAreaConfigurationList), end(mAreaConfigurationList),
-                      [&](const AreaConfiguration &conf) {
-        return conf->getConfigurableElement() == pConfigurableElement;
-    });
-    ALWAYS_ASSERT(it != end(mAreaConfigurationList), "Configurable Element "
-                  << pConfigurableElement->getName() << " not found in Domain Configuration list");
+                             [&](const AreaConfiguration &conf) {
+                                 return conf->getConfigurableElement() == pConfigurableElement;
+                             });
+    ALWAYS_ASSERT(it != end(mAreaConfigurationList),
+                  "Configurable Element " << pConfigurableElement->getName()
+                                          << " not found in Domain Configuration list");
     return *it;
 }
 
-CDomainConfiguration::AreaConfigurations::iterator CDomainConfiguration::findAreaConfigurationByPath(const std::string &configurableElementPath)
+CDomainConfiguration::AreaConfigurations::iterator CDomainConfiguration::
+    findAreaConfigurationByPath(const std::string &configurableElementPath)
 {
-    auto areaConfiguration = find_if(begin(mAreaConfigurationList), end(mAreaConfigurationList),
-                                         [&](const AreaConfiguration &conf) {
-        return conf->getConfigurableElement()->getPath() == configurableElementPath;
-    });
+    auto areaConfiguration =
+        find_if(begin(mAreaConfigurationList), end(mAreaConfigurationList),
+                [&](const AreaConfiguration &conf) {
+                    return conf->getConfigurableElement()->getPath() == configurableElementPath;
+                });
     return areaConfiguration;
 }
 
 // Rule
-const CCompoundRule* CDomainConfiguration::getRule() const
+const CCompoundRule *CDomainConfiguration::getRule() const
 {
     if (getNbChildren()) {
         // Rule created
-        return static_cast<const CCompoundRule*>(getChild(ECompoundRule));
+        return static_cast<const CCompoundRule *>(getChild(ECompoundRule));
     }
     return NULL;
 }
 
-CCompoundRule* CDomainConfiguration::getRule()
+CCompoundRule *CDomainConfiguration::getRule()
 {
     if (getNbChildren()) {
         // Rule created
-        return static_cast<CCompoundRule*>(getChild(ECompoundRule));
+        return static_cast<CCompoundRule *>(getChild(ECompoundRule));
     }
     return NULL;
 }
 
-void CDomainConfiguration::setRule(CCompoundRule* pRule)
+void CDomainConfiguration::setRule(CCompoundRule *pRule)
 {
-    CCompoundRule* pOldRule = getRule();
+    CCompoundRule *pOldRule = getRule();
 
     if (pOldRule) {
         // Remove previous rule

--- a/parameter/DomainConfiguration.h
+++ b/parameter/DomainConfiguration.h
@@ -47,15 +47,18 @@ class CSelectionCriteriaDefinition;
 
 class CDomainConfiguration : public CElement
 {
-    enum ChildElementType {
+    enum ChildElementType
+    {
         ECompoundRule
     };
+
 public:
-    CDomainConfiguration(const std::string& strName);
+    CDomainConfiguration(const std::string &strName);
 
     // Configurable Elements association
-    void addConfigurableElement(const CConfigurableElement *configurableElement, const CSyncerSet *syncerSet);
-    void removeConfigurableElement(const CConfigurableElement* pConfigurableElement);
+    void addConfigurableElement(const CConfigurableElement *configurableElement,
+                                const CSyncerSet *syncerSet);
+    void removeConfigurableElement(const CConfigurableElement *pConfigurableElement);
 
     /**
      * Sequence management: Prepend provided elements into internal list in the same order than
@@ -66,18 +69,20 @@ public:
      * set accordingly.
      */
     bool setElementSequence(const std::vector<std::string> &newElementSequence, std::string &error);
-    void getElementSequence(std::string& strResult) const;
+    void getElementSequence(std::string &strResult) const;
 
     // Application rule
-    bool setApplicationRule(const std::string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition, std::string& strError);
+    bool setApplicationRule(const std::string &strApplicationRule,
+                            const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition,
+                            std::string &strError);
     void clearApplicationRule();
     std::string getApplicationRule() const;
 
     // Get Blackboard for an element of the domain
-    CParameterBlackboard* getBlackboard(const CConfigurableElement* pConfigurableElement) const;
+    CParameterBlackboard *getBlackboard(const CConfigurableElement *pConfigurableElement) const;
 
     // Save data from current
-    void save(const CParameterBlackboard* pMainBlackboard);
+    void save(const CParameterBlackboard *pMainBlackboard);
 
     /** Restore the configuration
      *
@@ -86,30 +91,35 @@ public:
      * @param[out] errors, errors encountered during restoration
      * @return true if success false otherwise
      */
-    bool restore(CParameterBlackboard* pMainBlackboard,
-                 bool bSync,
-                 core::Results* errors = NULL) const;
+    bool restore(CParameterBlackboard *pMainBlackboard, bool bSync,
+                 core::Results *errors = NULL) const;
 
     // Ensure validity for configurable element area configuration
-    void validate(const CConfigurableElement* pConfigurableElement, const CParameterBlackboard* pMainBlackboard);
+    void validate(const CConfigurableElement *pConfigurableElement,
+                  const CParameterBlackboard *pMainBlackboard);
     // Ensure validity of all area configurations
-    void validate(const CParameterBlackboard* pMainBlackboard);
+    void validate(const CParameterBlackboard *pMainBlackboard);
     // Return configuration validity for given configurable element
-    bool isValid(const CConfigurableElement* pConfigurableElement) const;
+    bool isValid(const CConfigurableElement *pConfigurableElement) const;
     // Ensure validity of configurable element's area configuration by copying in from a valid one
-    void validateAgainst(const CDomainConfiguration* pValidDomainConfiguration, const CConfigurableElement* pConfigurableElement);
-    // Ensure validity of all configurable element's area configuration by copying in from a valid ones
+    void validateAgainst(const CDomainConfiguration *pValidDomainConfiguration,
+                         const CConfigurableElement *pConfigurableElement);
+    // Ensure validity of all configurable element's area configuration by copying in from a valid
+    // ones
     void validateAgainst(const CDomainConfiguration *validDomainConfiguration);
     // Applicability checking
     bool isApplicable() const;
     // Merge existing configurations to given configurable element ones
-    void merge(CConfigurableElement* pToConfigurableElement, CConfigurableElement* pFromConfigurableElement);
+    void merge(CConfigurableElement *pToConfigurableElement,
+               CConfigurableElement *pFromConfigurableElement);
     // Domain splitting
-    void split(CConfigurableElement* pFromConfigurableElement);
+    void split(CConfigurableElement *pFromConfigurableElement);
 
     // XML configuration settings parsing/composing
-    bool parseSettings(CXmlElement& xmlConfigurationSettingsElement, CXmlDomainImportContext& context);
-    void composeSettings(CXmlElement& xmlConfigurationSettingsElement, CXmlDomainExportContext& context) const;
+    bool parseSettings(CXmlElement &xmlConfigurationSettingsElement,
+                       CXmlDomainImportContext &context);
+    void composeSettings(CXmlElement &xmlConfigurationSettingsElement,
+                         CXmlDomainExportContext &context) const;
 
     // Class kind
     virtual std::string getKind() const;
@@ -118,13 +128,19 @@ private:
     using AreaConfiguration = std::unique_ptr<CAreaConfiguration>;
     using AreaConfigurations = std::list<AreaConfiguration>;
 
-    // Returns true if children dynamic creation is to be dealt with (here, will allow child deletion upon clean)
+    // Returns true if children dynamic creation is to be dealt with (here, will allow child
+    // deletion upon clean)
     virtual bool childrenAreDynamic() const;
     // XML configuration settings serializing
-    bool importOneConfigurableElementSettings(CAreaConfiguration *areaConfiguration, CXmlElement& xmlConfigurableElementSettingsElement, CXmlDomainImportContext& context);
-    bool exportOneConfigurableElementSettings(CAreaConfiguration *areaConfiguration, CXmlElement& xmlConfigurableElementSettingsElement, CXmlDomainExportContext& context) const;
+    bool importOneConfigurableElementSettings(CAreaConfiguration *areaConfiguration,
+                                              CXmlElement &xmlConfigurableElementSettingsElement,
+                                              CXmlDomainImportContext &context);
+    bool exportOneConfigurableElementSettings(CAreaConfiguration *areaConfiguration,
+                                              CXmlElement &xmlConfigurableElementSettingsElement,
+                                              CXmlDomainExportContext &context) const;
     // AreaConfiguration retrieval from configurable element
-    const AreaConfiguration &getAreaConfiguration(const CConfigurableElement* pConfigurableElement) const;
+    const AreaConfiguration &getAreaConfiguration(
+        const CConfigurableElement *pConfigurableElement) const;
 
     /**
      * Returns the AreaConfiguration iterator associated to the Element refered by its path
@@ -132,12 +148,13 @@ private:
      * @return iterator on the configuration associated to the Element with the given path,
      *                  last if not found
      */
-    AreaConfigurations::iterator findAreaConfigurationByPath(const std::string &configurableElementPath);
+    AreaConfigurations::iterator findAreaConfigurationByPath(
+        const std::string &configurableElementPath);
 
     // Rule
-    const CCompoundRule* getRule() const;
-    CCompoundRule* getRule();
-    void setRule(CCompoundRule* pRule);
+    const CCompoundRule *getRule() const;
+    CCompoundRule *getRule();
+    void setRule(CCompoundRule *pRule);
 
     AreaConfigurations mAreaConfigurationList;
 };

--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -41,7 +41,7 @@ using std::string;
 
 const std::string CElement::gDescriptionPropertyName = "Description";
 
-CElement::CElement(const string& strName) : _strName(strName)
+CElement::CElement(const string &strName) : _strName(strName)
 {
 }
 
@@ -50,12 +50,12 @@ CElement::~CElement()
     removeChildren();
 }
 
-void CElement::setDescription(const string& strDescription)
+void CElement::setDescription(const string &strDescription)
 {
     _strDescription = strDescription;
 }
 
-const string& CElement::getDescription() const
+const string &CElement::getDescription() const
 {
     return _strDescription;
 }
@@ -66,10 +66,10 @@ bool CElement::childrenAreDynamic() const
     return false;
 }
 
-bool CElement::init(string& strError)
+bool CElement::init(string &strError)
 {
 
-    for (CElement* child : _childArray) {
+    for (CElement *child : _childArray) {
 
         if (!child->init(strError)) {
 
@@ -80,7 +80,7 @@ bool CElement::init(string& strError)
     return true;
 }
 
-string CElement::dumpContent(utility::ErrorContext& errorContext, const size_t depth) const
+string CElement::dumpContent(utility::ErrorContext &errorContext, const size_t depth) const
 {
     string output;
     string strIndent;
@@ -111,7 +111,7 @@ string CElement::dumpContent(utility::ErrorContext& errorContext, const size_t d
 
     output += "\n";
 
-    for (CElement* pChild : _childArray) {
+    for (CElement *pChild : _childArray) {
 
         output += pChild->dumpContent(errorContext, depth + 1);
     }
@@ -120,7 +120,7 @@ string CElement::dumpContent(utility::ErrorContext& errorContext, const size_t d
 }
 
 // Element properties
-void CElement::showProperties(string& strResult) const
+void CElement::showProperties(string &strResult) const
 {
     strResult = "\n";
     strResult += "Kind: " + getKind() + "\n";
@@ -135,13 +135,13 @@ void CElement::showDescriptionProperty(std::string &strResult) const
 }
 
 // Content dumping
-string CElement::logValue(utility::ErrorContext& /*ctx*/) const
+string CElement::logValue(utility::ErrorContext & /*ctx*/) const
 {
     return "";
 }
 
 // From IXmlSink
-bool CElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CElement::fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext)
 {
     xmlElement.getAttribute(gDescriptionPropertyName, _strDescription);
 
@@ -152,7 +152,7 @@ bool CElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& se
 
     while (childIterator.next(childElement)) {
 
-        CElement* pChild;
+        CElement *pChild;
 
         if (!childrenAreDynamic()) {
 
@@ -160,7 +160,8 @@ bool CElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& se
 
             if (!pChild) {
 
-                serializingContext.setError("Unable to handle XML element: " + childElement.getPath());
+                serializingContext.setError("Unable to handle XML element: " +
+                                            childElement.getPath());
 
                 return false;
             }
@@ -185,11 +186,11 @@ bool CElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& se
     return true;
 }
 
-void CElement::childrenToXml(CXmlElement& xmlElement,
-                             CXmlSerializingContext& serializingContext) const
+void CElement::childrenToXml(CXmlElement &xmlElement,
+                             CXmlSerializingContext &serializingContext) const
 {
     // Browse children and propagate
-    for (CElement* pChild : _childArray) {
+    for (CElement *pChild : _childArray) {
 
         // Create corresponding child element
         CXmlElement xmlChildElement;
@@ -201,14 +202,14 @@ void CElement::childrenToXml(CXmlElement& xmlElement,
     }
 }
 
-void CElement::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CElement::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
 {
     setXmlNameAttribute(xmlElement);
     setXmlDescriptionAttribute(xmlElement);
     childrenToXml(xmlElement, serializingContext);
 }
 
-void CElement::setXmlDescriptionAttribute(CXmlElement& xmlElement) const
+void CElement::setXmlDescriptionAttribute(CXmlElement &xmlElement) const
 {
     const string &description = getDescription();
     if (!description.empty()) {
@@ -216,7 +217,7 @@ void CElement::setXmlDescriptionAttribute(CXmlElement& xmlElement) const
     }
 }
 
-void CElement::setXmlNameAttribute(CXmlElement& xmlElement) const
+void CElement::setXmlNameAttribute(CXmlElement &xmlElement) const
 {
     // By default, set Name attribute if any
     string strName = getName();
@@ -228,22 +229,22 @@ void CElement::setXmlNameAttribute(CXmlElement& xmlElement) const
 }
 
 // Name
-void CElement::setName(const string& strName)
+void CElement::setName(const string &strName)
 {
     _strName = strName;
 }
 
-const string& CElement::getName() const
+const string &CElement::getName() const
 {
     return _strName;
 }
 
-bool CElement::rename(const string& strName, string& strError)
+bool CElement::rename(const string &strName, string &strError)
 {
     // Check for conflict with brotherhood if relevant
     if (_pParent && _pParent->childrenAreDynamic()) {
 
-        for (CElement* pParentChild : _pParent->_childArray) {
+        for (CElement *pParentChild : _pParent->_childArray) {
 
             if (pParentChild != this && pParentChild->getName() == strName) {
 
@@ -272,41 +273,41 @@ string CElement::getPathName() const
 }
 
 // Hierarchy
-void CElement::addChild(CElement* pChild)
+void CElement::addChild(CElement *pChild)
 {
     _childArray.push_back(pChild);
 
     pChild->_pParent = this;
 }
 
-CElement* CElement::getChild(size_t index)
+CElement *CElement::getChild(size_t index)
 {
     assert(index <= _childArray.size());
 
     return _childArray[index];
 }
 
-const CElement* CElement::getChild(size_t index) const
+const CElement *CElement::getChild(size_t index) const
 {
     assert(index <= _childArray.size());
 
     return _childArray[index];
 }
 
-CElement* CElement::createChild(const CXmlElement& childElement,
-                                CXmlSerializingContext& serializingContext)
+CElement *CElement::createChild(const CXmlElement &childElement,
+                                CXmlSerializingContext &serializingContext)
 {
     // Context
-    CXmlElementSerializingContext& elementSerializingContext =
-            static_cast<CXmlElementSerializingContext&>(serializingContext);
+    CXmlElementSerializingContext &elementSerializingContext =
+        static_cast<CXmlElementSerializingContext &>(serializingContext);
 
     // Child needs creation
-    CElement* pChild = elementSerializingContext.getElementLibrary()->createElement(childElement);
+    CElement *pChild = elementSerializingContext.getElementLibrary()->createElement(childElement);
 
     if (!pChild) {
 
-        elementSerializingContext.setError(
-                    "Unable to create XML element " + childElement.getPath());
+        elementSerializingContext.setError("Unable to create XML element " +
+                                           childElement.getPath());
 
         return NULL;
     }
@@ -316,7 +317,7 @@ CElement* CElement::createChild(const CXmlElement& childElement,
     return pChild;
 }
 
-bool CElement::removeChild(CElement* pChild)
+bool CElement::removeChild(CElement *pChild)
 {
     auto childIt = find(begin(_childArray), end(_childArray), pChild);
     if (childIt != end(_childArray)) {
@@ -327,12 +328,12 @@ bool CElement::removeChild(CElement* pChild)
     return false;
 }
 
-void CElement::listChildren(string& strChildList) const
+void CElement::listChildren(string &strChildList) const
 {
     strChildList = "\n";
 
     // Get list of children names
-    for (CElement* pChild : _childArray) {
+    for (CElement *pChild : _childArray) {
 
         strChildList += pChild->getName() + "\n";
     }
@@ -350,7 +351,7 @@ string CElement::listQualifiedPaths(bool bDive, size_t level) const
 
     if (bDive || !level) {
         // Get list of children paths
-        for (CElement* pChild : _childArray) {
+        for (CElement *pChild : _childArray) {
 
             strResult += pChild->listQualifiedPaths(bDive, level + 1);
         }
@@ -358,10 +359,10 @@ string CElement::listQualifiedPaths(bool bDive, size_t level) const
     return strResult;
 }
 
-void CElement::listChildrenPaths(string& strChildList) const
+void CElement::listChildrenPaths(string &strChildList) const
 {
     // Get list of children paths
-    for (CElement* pChild : _childArray) {
+    for (CElement *pChild : _childArray) {
 
         strChildList += pChild->getPath() + "\n";
     }
@@ -372,12 +373,12 @@ size_t CElement::getNbChildren() const
     return _childArray.size();
 }
 
-const CElement* CElement::getParent() const
+const CElement *CElement::getParent() const
 {
     return _pParent;
 }
 
-CElement* CElement::getParent()
+CElement *CElement::getParent()
 {
     return _pParent;
 }
@@ -389,7 +390,7 @@ void CElement::clean()
         removeChildren();
     } else {
         // Just propagate
-        for (CElement* pChild : _childArray) {
+        for (CElement *pChild : _childArray) {
 
             pChild->clean();
         }
@@ -408,16 +409,16 @@ void CElement::removeChildren()
     _childArray.clear();
 }
 
-const CElement* CElement::findDescendant(CPathNavigator& pathNavigator) const
+const CElement *CElement::findDescendant(CPathNavigator &pathNavigator) const
 {
-    string* pStrChildName = pathNavigator.next();
+    string *pStrChildName = pathNavigator.next();
 
     if (!pStrChildName) {
 
         return this;
     }
 
-    const CElement* pChild = findChild(*pStrChildName);
+    const CElement *pChild = findChild(*pStrChildName);
 
     if (!pChild) {
 
@@ -427,16 +428,16 @@ const CElement* CElement::findDescendant(CPathNavigator& pathNavigator) const
     return pChild->findDescendant(pathNavigator);
 }
 
-CElement* CElement::findDescendant(CPathNavigator& pathNavigator)
+CElement *CElement::findDescendant(CPathNavigator &pathNavigator)
 {
-    string* pStrChildName = pathNavigator.next();
+    string *pStrChildName = pathNavigator.next();
 
     if (!pStrChildName) {
 
         return this;
     }
 
-    CElement* pChild = findChild(*pStrChildName);
+    CElement *pChild = findChild(*pStrChildName);
 
     if (!pChild) {
 
@@ -446,7 +447,7 @@ CElement* CElement::findDescendant(CPathNavigator& pathNavigator)
     return pChild->findDescendant(pathNavigator);
 }
 
-bool CElement::isDescendantOf(const CElement* pCandidateAscendant) const
+bool CElement::isDescendantOf(const CElement *pCandidateAscendant) const
 {
     if (!_pParent) {
 
@@ -459,10 +460,9 @@ bool CElement::isDescendantOf(const CElement* pCandidateAscendant) const
     return _pParent->isDescendantOf(pCandidateAscendant);
 }
 
-CElement* CElement::findChild(const string& strName)
+CElement *CElement::findChild(const string &strName)
 {
-    for (CElement* pChild : _childArray) {
-
+    for (CElement *pChild : _childArray) {
 
         if (pChild->getPathName() == strName) {
 
@@ -473,9 +473,9 @@ CElement* CElement::findChild(const string& strName)
     return NULL;
 }
 
-const CElement* CElement::findChild(const string& strName) const
+const CElement *CElement::findChild(const string &strName) const
 {
-    for (CElement* pChild : _childArray) {
+    for (CElement *pChild : _childArray) {
 
         if (pChild->getPathName() == strName) {
 
@@ -486,9 +486,9 @@ const CElement* CElement::findChild(const string& strName) const
     return NULL;
 }
 
-CElement* CElement::findChildOfKind(const string& strKind)
+CElement *CElement::findChildOfKind(const string &strKind)
 {
-    for (CElement* pChild : _childArray) {
+    for (CElement *pChild : _childArray) {
 
         if (pChild->getKind() == strKind) {
 
@@ -499,9 +499,9 @@ CElement* CElement::findChildOfKind(const string& strKind)
     return NULL;
 }
 
-const CElement* CElement::findChildOfKind(const string& strKind) const
+const CElement *CElement::findChildOfKind(const string &strKind) const
 {
-    for (CElement* pChild : _childArray) {
+    for (CElement *pChild : _childArray) {
 
         if (pChild->getKind() == strKind) {
 

--- a/parameter/Element.h
+++ b/parameter/Element.h
@@ -40,43 +40,44 @@
 #include "PathNavigator.h"
 
 class CXmlElementSerializingContext;
-namespace utility {
+namespace utility
+{
 class ErrorContext;
 }
 
 class PARAMETER_EXPORT CElement : public IXmlSink, public IXmlSource
 {
 public:
-    CElement(const std::string& strName = "");
+    CElement(const std::string &strName = "");
     virtual ~CElement();
 
     // Description
-    void setDescription(const std::string& strDescription);
-    const std::string& getDescription() const;
+    void setDescription(const std::string &strDescription);
+    const std::string &getDescription() const;
 
     // Name / Path
-    const std::string& getName() const;
-    void setName(const std::string& strName);
-    bool rename(const std::string& strName, std::string& strError);
+    const std::string &getName() const;
+    void setName(const std::string &strName);
+    bool rename(const std::string &strName, std::string &strError);
     std::string getPath() const;
     std::string getQualifiedPath() const;
 
     // Creation / build
-    virtual bool init(std::string& strError);
+    virtual bool init(std::string &strError);
     virtual void clean();
 
     // Children management
-    void addChild(CElement* pChild);
-    bool removeChild(CElement* pChild);
-    void listChildren(std::string& strChildList) const;
+    void addChild(CElement *pChild);
+    bool removeChild(CElement *pChild);
+    void listChildren(std::string &strChildList) const;
     std::string listQualifiedPaths(bool bDive, size_t level = 0) const;
-    void listChildrenPaths(std::string& strChildPathList) const;
+    void listChildrenPaths(std::string &strChildPathList) const;
 
     // Hierarchy query
     size_t getNbChildren() const;
-    CElement* findChildOfKind(const std::string& strKind);
-    const CElement* findChildOfKind(const std::string& strKind) const;
-    const CElement* getParent() const;
+    CElement *findChildOfKind(const std::string &strKind);
+    const CElement *findChildOfKind(const std::string &strKind) const;
+    const CElement *getParent() const;
 
     /**
      * Get a child element (const)
@@ -86,7 +87,7 @@ public:
      * @param[in] index the index of the child element from 0 to number of children - 1
      * @return the child element
      */
-    const CElement* getChild(size_t index) const;
+    const CElement *getChild(size_t index) const;
 
     /**
      * Get a child element
@@ -96,19 +97,19 @@ public:
      * @param[in] index the index of the child element from 0 to number of children - 1
      * @return the child element
      */
-    CElement* getChild(size_t index);
+    CElement *getChild(size_t index);
 
-    const CElement* findChild(const std::string& strName) const;
-    CElement* findChild(const std::string& strName);
-    const CElement* findDescendant(CPathNavigator& pathNavigator) const;
-    CElement* findDescendant(CPathNavigator& pathNavigator);
-    bool isDescendantOf(const CElement* pCandidateAscendant) const;
+    const CElement *findChild(const std::string &strName) const;
+    CElement *findChild(const std::string &strName);
+    const CElement *findDescendant(CPathNavigator &pathNavigator) const;
+    CElement *findDescendant(CPathNavigator &pathNavigator);
+    bool isDescendantOf(const CElement *pCandidateAscendant) const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     /**
      * Serialize the children to XML
@@ -121,14 +122,14 @@ public:
      *                object upon which this method is called)
      * @param[in,out] serializingContext information about the serialization
      */
-    virtual void childrenToXml(CXmlElement& xmlElement,
-                               CXmlSerializingContext& serializingContext) const;
+    virtual void childrenToXml(CXmlElement &xmlElement,
+                               CXmlSerializingContext &serializingContext) const;
 
     // Content structure dump
-    std::string dumpContent(utility::ErrorContext& errorContext, const size_t depth = 0) const;
+    std::string dumpContent(utility::ErrorContext &errorContext, const size_t depth = 0) const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // Class kind
     virtual std::string getKind() const = 0;
@@ -138,7 +139,7 @@ public:
      *
      * @param[in,out] xmlElement to fill with the description
      */
-    void setXmlDescriptionAttribute(CXmlElement& xmlElement) const;
+    void setXmlDescriptionAttribute(CXmlElement &xmlElement) const;
 
     /**
      * Appends if found human readable description property.
@@ -154,10 +155,10 @@ public:
 
 protected:
     // Content dumping
-    virtual std::string logValue(utility::ErrorContext& errorContext) const;
+    virtual std::string logValue(utility::ErrorContext &errorContext) const;
 
     // Hierarchy
-    CElement* getParent();
+    CElement *getParent();
 
     /**
      * Creates a child CElement from a child XML Element
@@ -167,8 +168,8 @@ protected:
      *
      * @return child a pointer on the CElement object that has been added to the tree
      */
-    CElement* createChild(const CXmlElement& childElement,
-                          CXmlSerializingContext& elementSerializingContext);
+    CElement *createChild(const CXmlElement &childElement,
+                          CXmlSerializingContext &elementSerializingContext);
 
     static const std::string gDescriptionPropertyName;
 
@@ -180,7 +181,7 @@ private:
     // House keeping
     void removeChildren();
     // Fill XmlElement during XML composing
-    void setXmlNameAttribute(CXmlElement& xmlElement) const;
+    void setXmlNameAttribute(CXmlElement &xmlElement) const;
 
     // Name
     std::string _strName;
@@ -189,10 +190,10 @@ private:
     std::string _strDescription;
 
     // Child iterators
-    typedef std::vector<CElement*>::iterator ChildArrayIterator;
-    typedef std::vector<CElement*>::reverse_iterator ChildArrayReverseIterator;
+    typedef std::vector<CElement *>::iterator ChildArrayIterator;
+    typedef std::vector<CElement *>::reverse_iterator ChildArrayReverseIterator;
     // Children
-    std::vector<CElement*> _childArray;
+    std::vector<CElement *> _childArray;
     // Parent
-    CElement* _pParent{nullptr};
+    CElement *_pParent{nullptr};
 };

--- a/parameter/ElementBuilder.h
+++ b/parameter/ElementBuilder.h
@@ -37,5 +37,5 @@ class CElementBuilder : private utility::NonCopyable
 public:
     virtual ~CElementBuilder() = default;
 
-    virtual CElement* createElement(const CXmlElement& xmlElement) const = 0;
+    virtual CElement *createElement(const CXmlElement &xmlElement) const = 0;
 };

--- a/parameter/ElementBuilderTemplate.h
+++ b/parameter/ElementBuilderTemplate.h
@@ -35,9 +35,5 @@ template <class ElementType>
 class TElementBuilderTemplate : public CElementBuilder
 {
 public:
-
-    virtual CElement* createElement(const CXmlElement& /*elem*/) const
-    {
-        return new ElementType;
-    }
+    virtual CElement *createElement(const CXmlElement & /*elem*/) const { return new ElementType; }
 };

--- a/parameter/ElementHandle.cpp
+++ b/parameter/ElementHandle.cpp
@@ -41,9 +41,10 @@ using std::string;
 using std::mutex;
 using std::lock_guard;
 
-ElementHandle::ElementHandle(CConfigurableElement& element, CParameterMgr& parameterMgr)
-    : mElement(element), mParameterMgr(parameterMgr) {}
-
+ElementHandle::ElementHandle(CConfigurableElement &element, CParameterMgr &parameterMgr)
+    : mElement(element), mParameterMgr(parameterMgr)
+{
+}
 
 string ElementHandle::getName() const
 {
@@ -79,7 +80,7 @@ bool ElementHandle::isArray() const
 size_t ElementHandle::getArrayLength() const
 {
     // Only instances can be arrays, SystemClass can not, nor subsystems
-    auto *instance = dynamic_cast<CInstanceConfigurableElement*>(&mElement);
+    auto *instance = dynamic_cast<CInstanceConfigurableElement *>(&mElement);
     if (instance == nullptr) {
         return 0;
     }
@@ -111,9 +112,9 @@ std::vector<ElementHandle> ElementHandle::getChildren()
     return children;
 }
 
-bool ElementHandle::getMappingData(const string& strKey, string& strValue) const
+bool ElementHandle::getMappingData(const string &strKey, string &strValue) const
 {
-    const std::string* pStrValue;
+    const std::string *pStrValue;
 
     if (!mElement.getMappingData(strKey, pStrValue)) {
         return false;
@@ -128,27 +129,32 @@ bool ElementHandle::getStructureAsXML(std::string &xmlSettings, std::string &err
     // Use default access context for structure export
     CParameterAccessContext accessContext(error);
     return mParameterMgr.exportElementToXMLString(
-                &mElement, mElement.getXmlElementName(),
-                CXmlParameterSerializingContext{accessContext, error},
-                xmlSettings);
+        &mElement, mElement.getXmlElementName(),
+        CXmlParameterSerializingContext{accessContext, error}, xmlSettings);
 }
 
 template <class T>
-struct isVector : std::false_type {};
+struct isVector : std::false_type
+{
+};
 template <class T>
-struct isVector<std::vector<T>> : std::true_type {};
+struct isVector<std::vector<T>> : std::true_type
+{
+};
 
 template <class T>
-size_t ElementHandle::getSize(T /*value*/) {
+size_t ElementHandle::getSize(T /*value*/)
+{
     return 0;
 }
 
 template <class T>
-size_t ElementHandle::getSize(std::vector<T> &values) {
+size_t ElementHandle::getSize(std::vector<T> &values)
+{
     return values.size();
 }
 
-bool ElementHandle::getAsXML(std::string& xmlValue, std::string& strError) const
+bool ElementHandle::getAsXML(std::string &xmlValue, std::string &strError) const
 {
     std::string result;
     if (not mParameterMgr.getSettingsAsXML(&mElement, result)) {
@@ -160,12 +166,12 @@ bool ElementHandle::getAsXML(std::string& xmlValue, std::string& strError) const
     return true;
 }
 
-bool ElementHandle::setAsXML(const std::string& xmlValue, std::string& error)
+bool ElementHandle::setAsXML(const std::string &xmlValue, std::string &error)
 {
     return mParameterMgr.setSettingsAsXML(&mElement, xmlValue, error);
 }
 
-bool ElementHandle::getAsBytes(std::vector<uint8_t>& bytesValue, std::string& /*error*/) const
+bool ElementHandle::getAsBytes(std::vector<uint8_t> &bytesValue, std::string & /*error*/) const
 {
     mParameterMgr.getSettingsAsBytes(mElement, bytesValue);
 
@@ -176,7 +182,7 @@ bool ElementHandle::getAsBytes(std::vector<uint8_t>& bytesValue, std::string& /*
     return true;
 }
 
-bool ElementHandle::setAsBytes(const std::vector<uint8_t>& bytesValue, std::string& error)
+bool ElementHandle::setAsBytes(const std::vector<uint8_t> &bytesValue, std::string &error)
 {
     return mParameterMgr.setSettingsAsBytes(mElement, bytesValue, error);
 }
@@ -188,7 +194,7 @@ bool ElementHandle::setAs(const T value, string &error) const
         return false;
     }
     // Safe downcast thanks to isParameter check in checkSetValidity
-    auto &parameter = static_cast<CBaseParameter&>(mElement);
+    auto &parameter = static_cast<CBaseParameter &>(mElement);
 
     // When in tuning mode, silently skip "set" requests
     if (mParameterMgr.tuningModeOn()) {
@@ -226,111 +232,111 @@ bool ElementHandle::getAs(T &value, string &error) const
 }
 
 // Boolean access
-bool ElementHandle::setAsBoolean(bool bValue, string& error)
+bool ElementHandle::setAsBoolean(bool bValue, string &error)
 {
     return setAs(bValue, error);
 }
 
-bool ElementHandle::getAsBoolean(bool& bValue, string& error) const
+bool ElementHandle::getAsBoolean(bool &bValue, string &error) const
 {
     return getAs(bValue, error);
 }
 
-bool ElementHandle::setAsBooleanArray(const std::vector<bool>& abValues, string& error)
+bool ElementHandle::setAsBooleanArray(const std::vector<bool> &abValues, string &error)
 {
     return setAs(abValues, error);
 }
 
-bool ElementHandle::getAsBooleanArray(std::vector<bool>& abValues, string& error) const
+bool ElementHandle::getAsBooleanArray(std::vector<bool> &abValues, string &error) const
 {
     return getAs(abValues, error);
 }
 
 // Integer Access
-bool ElementHandle::setAsInteger(uint32_t uiValue, string& error)
+bool ElementHandle::setAsInteger(uint32_t uiValue, string &error)
 {
     return setAs(uiValue, error);
 }
 
-bool ElementHandle::getAsInteger(uint32_t& uiValue, string& error) const
+bool ElementHandle::getAsInteger(uint32_t &uiValue, string &error) const
 {
     return getAs(uiValue, error);
 }
 
-bool ElementHandle::setAsIntegerArray(const std::vector<uint32_t>& auiValues, string& error)
+bool ElementHandle::setAsIntegerArray(const std::vector<uint32_t> &auiValues, string &error)
 {
     return setAs(auiValues, error);
 }
 
-bool ElementHandle::getAsIntegerArray(std::vector<uint32_t>& auiValues, string& error) const
+bool ElementHandle::getAsIntegerArray(std::vector<uint32_t> &auiValues, string &error) const
 {
     return getAs(auiValues, error);
 }
 
 // Signed Integer Access
-bool ElementHandle::setAsSignedInteger(int32_t iValue, string& error)
+bool ElementHandle::setAsSignedInteger(int32_t iValue, string &error)
 {
     return setAs(iValue, error);
 }
 
-bool ElementHandle::getAsSignedInteger(int32_t& iValue, string& error) const
+bool ElementHandle::getAsSignedInteger(int32_t &iValue, string &error) const
 {
     return getAs(iValue, error);
 }
 
-bool ElementHandle::setAsSignedIntegerArray(const std::vector<int32_t>& aiValues, string& error)
+bool ElementHandle::setAsSignedIntegerArray(const std::vector<int32_t> &aiValues, string &error)
 {
     return setAs(aiValues, error);
 }
 
-bool ElementHandle::getAsSignedIntegerArray(std::vector<int32_t>& aiValues, string& error) const
+bool ElementHandle::getAsSignedIntegerArray(std::vector<int32_t> &aiValues, string &error) const
 {
     return getAs(aiValues, error);
 }
 
 // Double Access
-bool ElementHandle::setAsDouble(double dValue, string& error)
+bool ElementHandle::setAsDouble(double dValue, string &error)
 {
     return setAs(dValue, error);
 }
 
-bool ElementHandle::getAsDouble(double& dValue, string& error) const
+bool ElementHandle::getAsDouble(double &dValue, string &error) const
 {
     return getAs(dValue, error);
 }
 
-bool ElementHandle::setAsDoubleArray(const std::vector<double>& adValues, string& error)
+bool ElementHandle::setAsDoubleArray(const std::vector<double> &adValues, string &error)
 {
     return setAs(adValues, error);
 }
 
-bool ElementHandle::getAsDoubleArray(std::vector<double>& adValues, string& error) const
+bool ElementHandle::getAsDoubleArray(std::vector<double> &adValues, string &error) const
 {
     return getAs(adValues, error);
 }
 
 // String Access
-bool ElementHandle::setAsString(const string& strValue, string& error)
+bool ElementHandle::setAsString(const string &strValue, string &error)
 {
     return setAs(strValue, error);
 }
 
-bool ElementHandle::getAsString(string& strValue, string& error) const
+bool ElementHandle::getAsString(string &strValue, string &error) const
 {
     return getAs(strValue, error);
 }
 
-bool ElementHandle::setAsStringArray(const std::vector<string>& astrValues, string& error)
+bool ElementHandle::setAsStringArray(const std::vector<string> &astrValues, string &error)
 {
     return setAs(astrValues, error);
 }
 
-bool ElementHandle::getAsStringArray(std::vector<string>& astrValues, string& error) const
+bool ElementHandle::getAsStringArray(std::vector<string> &astrValues, string &error) const
 {
     return getAs(astrValues, error);
 }
 
-bool ElementHandle::checkGetValidity(bool asArray, string& error) const
+bool ElementHandle::checkGetValidity(bool asArray, string &error) const
 {
     if (not isParameter()) {
         error = "Can not set element " + getPath() + " as it is not a parameter.";
@@ -340,8 +346,8 @@ bool ElementHandle::checkGetValidity(bool asArray, string& error) const
     if (asArray != isArray()) {
 
         auto toStr = [](bool array) { return array ? "an array" : "a scalar"; };
-        error = "Can not get \"" + getPath() + "\" as " + toStr(asArray) +
-                   " because it is " + toStr(isArray());
+        error = "Can not get \"" + getPath() + "\" as " + toStr(asArray) + " because it is " +
+                toStr(isArray());
         return false;
     }
 
@@ -349,7 +355,7 @@ bool ElementHandle::checkGetValidity(bool asArray, string& error) const
 }
 
 // Access validity
-bool ElementHandle::checkSetValidity(size_t arrayLength, string& error) const
+bool ElementHandle::checkSetValidity(size_t arrayLength, string &error) const
 {
     // Settings a parameter necessitates the right to get it
     if (not checkGetValidity(arrayLength != 0, error)) {
@@ -365,9 +371,8 @@ bool ElementHandle::checkSetValidity(size_t arrayLength, string& error) const
     if (arrayLength && (arrayLength != getArrayLength())) {
 
         using std::to_string;
-        error = "Array length mismatch for \"" + getPath() +
-                  "\", expected: " + to_string(getArrayLength()) +
-                  ", got: " + to_string(arrayLength);
+        error = "Array length mismatch for \"" + getPath() + "\", expected: " +
+                to_string(getArrayLength()) + ", got: " + to_string(arrayLength);
         return false;
     }
 

--- a/parameter/ElementLibrary.cpp
+++ b/parameter/ElementLibrary.cpp
@@ -30,7 +30,6 @@
 #include "ElementLibrary.h"
 #include "ElementBuilder.h"
 
-
 CElementLibrary::~CElementLibrary()
 {
     clean();
@@ -47,7 +46,7 @@ void CElementLibrary::clean()
     _elementBuilderMap.clear();
 }
 
-CElement* CElementLibrary::createElement(const CXmlElement& xmlElement) const
+CElement *CElementLibrary::createElement(const CXmlElement &xmlElement) const
 {
     ElementBuilderMapConstIterator it = _elementBuilderMap.find(getBuilderType(xmlElement));
 
@@ -58,12 +57,13 @@ CElement* CElementLibrary::createElement(const CXmlElement& xmlElement) const
     return NULL;
 }
 
-void CElementLibrary::addElementBuilder(const std::string& type, const CElementBuilder *pElementBuilder)
+void CElementLibrary::addElementBuilder(const std::string &type,
+                                        const CElementBuilder *pElementBuilder)
 {
     _elementBuilderMap[type] = pElementBuilder;
 }
 
-std::string CElementLibrary::getBuilderType(const CXmlElement& xmlElement) const
+std::string CElementLibrary::getBuilderType(const CXmlElement &xmlElement) const
 {
     // Defaulting to xml element name
     return xmlElement.getType();

--- a/parameter/ElementLibrary.h
+++ b/parameter/ElementLibrary.h
@@ -40,7 +40,7 @@ class CElementBuilder;
 
 class PARAMETER_EXPORT CElementLibrary
 {
-    typedef std::map<std::string, const CElementBuilder*> ElementBuilderMap;
+    typedef std::map<std::string, const CElementBuilder *> ElementBuilderMap;
     typedef ElementBuilderMap::iterator ElementBuilderMapIterator;
     typedef ElementBuilderMap::const_iterator ElementBuilderMapConstIterator;
 
@@ -53,15 +53,15 @@ public:
        *               create a new element.
        * @param[in] pElementBuilder is the tag associated element builder.
        */
-    void addElementBuilder(const std::string& type, const CElementBuilder *pElementBuilder);
+    void addElementBuilder(const std::string &type, const CElementBuilder *pElementBuilder);
     void clean();
 
     // Instantiation
-    CElement* createElement(const CXmlElement& xmlElement) const;
+    CElement *createElement(const CXmlElement &xmlElement) const;
 
 private:
     // Builder type
-    virtual std::string getBuilderType(const CXmlElement& xmlElement) const;
+    virtual std::string getBuilderType(const CXmlElement &xmlElement) const;
 
     // Builders
     ElementBuilderMap _elementBuilderMap;

--- a/parameter/ElementLibrarySet.cpp
+++ b/parameter/ElementLibrarySet.cpp
@@ -39,12 +39,12 @@ CElementLibrarySet::~CElementLibrarySet()
     }
 }
 
-void CElementLibrarySet::addElementLibrary(CElementLibrary* pElementLibrary)
+void CElementLibrarySet::addElementLibrary(CElementLibrary *pElementLibrary)
 {
     _elementLibraryArray.push_back(pElementLibrary);
 }
 
-CElementLibrary* CElementLibrarySet::getElementLibrary(size_t index) const
+CElementLibrary *CElementLibrarySet::getElementLibrary(size_t index) const
 {
     assert(index <= _elementLibraryArray.size());
 

--- a/parameter/ElementLibrarySet.h
+++ b/parameter/ElementLibrarySet.h
@@ -36,9 +36,9 @@ class CElementLibrarySet
 public:
     ~CElementLibrarySet();
 
-    void addElementLibrary(CElementLibrary* pElementLibrary);
-    CElementLibrary* getElementLibrary(size_t index) const;
+    void addElementLibrary(CElementLibrary *pElementLibrary);
+    CElementLibrary *getElementLibrary(size_t index) const;
 
 private:
-    std::vector<CElementLibrary*> _elementLibraryArray;
+    std::vector<CElementLibrary *> _elementLibraryArray;
 };

--- a/parameter/ElementLocator.cpp
+++ b/parameter/ElementLocator.cpp
@@ -32,12 +32,13 @@
 
 using std::string;
 
-CElementLocator::CElementLocator(CElement* pSubRootElement, bool bStrict) : _pSubRootElement(pSubRootElement), _bStrict(bStrict)
+CElementLocator::CElementLocator(CElement *pSubRootElement, bool bStrict)
+    : _pSubRootElement(pSubRootElement), _bStrict(bStrict)
 {
 }
 
 // Locate element
-bool CElementLocator::locate(const string& strPath, CElement** ppElement, string& strError)
+bool CElementLocator::locate(const string &strPath, CElement **ppElement, string &strError)
 {
     CPathNavigator pathNavigator(strPath);
 
@@ -49,7 +50,7 @@ bool CElementLocator::locate(const string& strPath, CElement** ppElement, string
     }
 
     // Sub root element?
-    string* pStrChildName = pathNavigator.next();
+    string *pStrChildName = pathNavigator.next();
 
     if (!pStrChildName) {
 
@@ -82,4 +83,3 @@ bool CElementLocator::locate(const string& strPath, CElement** ppElement, string
 
     return true;
 }
-

--- a/parameter/ElementLocator.h
+++ b/parameter/ElementLocator.h
@@ -36,16 +36,15 @@
 class CElementLocator
 {
 public:
-    CElementLocator(CElement* pSubRootElement, bool bStrict = true);
+    CElementLocator(CElement *pSubRootElement, bool bStrict = true);
 
     // Locate element
-    bool locate(const std::string& strPath, CElement** ppElement, std::string& strError);
+    bool locate(const std::string &strPath, CElement **ppElement, std::string &strError);
 
 private:
     // Subroot element
-    CElement* _pSubRootElement;
+    CElement *_pSubRootElement;
 
     // Strict means empty path will cause path not found error to be returned
     bool _bStrict;
 };
-

--- a/parameter/EnumParameterType.cpp
+++ b/parameter/EnumParameterType.cpp
@@ -36,7 +36,7 @@
 
 using std::string;
 
-CEnumParameterType::CEnumParameterType(const string& strName) : base(strName)
+CEnumParameterType::CEnumParameterType(const string &strName) : base(strName)
 {
 }
 
@@ -51,7 +51,7 @@ bool CEnumParameterType::childrenAreDynamic() const
 }
 
 // Element properties
-void CEnumParameterType::showProperties(string& strResult) const
+void CEnumParameterType::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -63,7 +63,7 @@ void CEnumParameterType::showProperties(string& strResult) const
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        const CEnumValuePair* pValuePair = static_cast<const CEnumValuePair*>(getChild(uiChild));
+        const CEnumValuePair *pValuePair = static_cast<const CEnumValuePair *>(getChild(uiChild));
 
         strResult += "\tLiteral: \"";
         strResult += pValuePair->getName();
@@ -73,7 +73,8 @@ void CEnumParameterType::showProperties(string& strResult) const
     }
 }
 
-bool CEnumParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CEnumParameterType::fromXml(const CXmlElement &xmlElement,
+                                 CXmlSerializingContext &serializingContext)
 {
     // Size in bits
     size_t sizeInBits = 0;
@@ -89,7 +90,8 @@ bool CEnumParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingC
 }
 
 // Conversion (tuning)
-bool CEnumParameterType::toBlackboard(const string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CEnumParameterType::toBlackboard(const string &strValue, uint32_t &uiValue,
+                                      CParameterAccessContext &parameterAccessContext) const
 {
     int32_t iParsedUserValue = 0;
 
@@ -115,16 +117,19 @@ bool CEnumParameterType::toBlackboard(const string& strValue, uint32_t& uiValue,
     return toBlackboard(iParsedUserValue, uiValue, parameterAccessContext);
 }
 
-int32_t CEnumParameterType::getMin() const {
+int32_t CEnumParameterType::getMin() const
+{
     // Enums are always signed, it means we have one less util bit
     return -getMax() - 1;
 }
 
-int32_t CEnumParameterType::getMax() const {
+int32_t CEnumParameterType::getMax() const
+{
     return getMaxValue<int32_t>();
 }
 
-bool CEnumParameterType::fromBlackboard(string& userValue, const uint32_t& value, CParameterAccessContext& /*ctx*/) const
+bool CEnumParameterType::fromBlackboard(string &userValue, const uint32_t &value,
+                                        CParameterAccessContext & /*ctx*/) const
 {
     // Convert the raw value from the blackboard
     int32_t signedValue = static_cast<int32_t>(value);
@@ -135,12 +140,13 @@ bool CEnumParameterType::fromBlackboard(string& userValue, const uint32_t& value
 }
 
 // Value access
-bool CEnumParameterType::toBlackboard(int32_t userValue, uint32_t& value, CParameterAccessContext& parameterAccessContext) const
+bool CEnumParameterType::toBlackboard(int32_t userValue, uint32_t &value,
+                                      CParameterAccessContext &parameterAccessContext) const
 {
     if (!checkValueAgainstSpace(userValue)) {
 
         parameterAccessContext.setError(std::to_string(userValue) +
-                " is not part of numerical space.");
+                                        " is not part of numerical space.");
 
         return false;
     }
@@ -150,9 +156,8 @@ bool CEnumParameterType::toBlackboard(int32_t userValue, uint32_t& value, CParam
         // FIXME: values provided as hexa (either on command line or in a config
         // file will appear in decimal base instead of hexa base...
         parameterAccessContext.setError(
-                "Value " + std::to_string(userValue) + " standing out of admitted range [" +
-                std::to_string(getMin()) + ", " + std::to_string(getMax()) + "] for " + getKind()
-                );
+            "Value " + std::to_string(userValue) + " standing out of admitted range [" +
+            std::to_string(getMin()) + ", " + std::to_string(getMax()) + "] for " + getKind());
         return false;
     }
 
@@ -161,7 +166,8 @@ bool CEnumParameterType::toBlackboard(int32_t userValue, uint32_t& value, CParam
     return true;
 }
 
-bool CEnumParameterType::fromBlackboard(int32_t& userValue, uint32_t value, CParameterAccessContext& /*ctx*/) const
+bool CEnumParameterType::fromBlackboard(int32_t &userValue, uint32_t value,
+                                        CParameterAccessContext & /*ctx*/) const
 {
     int32_t signedValue = static_cast<int32_t>(value);
 
@@ -182,18 +188,18 @@ uint32_t CEnumParameterType::getDefaultValue() const
     }
 
     // Return first available numerical
-    return static_cast<const CEnumValuePair*>(getChild(0))->getNumerical();
+    return static_cast<const CEnumValuePair *>(getChild(0))->getNumerical();
 }
 
 // Literal - numerical conversions
-bool CEnumParameterType::getLiteral(int32_t iNumerical, string& strLiteral) const
+bool CEnumParameterType::getLiteral(int32_t iNumerical, string &strLiteral) const
 {
     size_t uiChild;
     size_t uiNbChildren = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        const CEnumValuePair* pValuePair = static_cast<const CEnumValuePair*>(getChild(uiChild));
+        const CEnumValuePair *pValuePair = static_cast<const CEnumValuePair *>(getChild(uiChild));
 
         if (pValuePair->getNumerical() == iNumerical) {
 
@@ -206,14 +212,14 @@ bool CEnumParameterType::getLiteral(int32_t iNumerical, string& strLiteral) cons
     return false;
 }
 
-bool CEnumParameterType::getNumerical(const string& strLiteral, int32_t& iNumerical) const
+bool CEnumParameterType::getNumerical(const string &strLiteral, int32_t &iNumerical) const
 {
     size_t uiChild;
     size_t uiNbChildren = getNbChildren();
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        const CEnumValuePair* pValuePair = static_cast<const CEnumValuePair*>(getChild(uiChild));
+        const CEnumValuePair *pValuePair = static_cast<const CEnumValuePair *>(getChild(uiChild));
 
         if (pValuePair->getName() == strLiteral) {
 
@@ -235,7 +241,7 @@ bool CEnumParameterType::checkValueAgainstSpace(int32_t iNumerical) const
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        const CEnumValuePair* pValuePair = static_cast<const CEnumValuePair*>(getChild(uiChild));
+        const CEnumValuePair *pValuePair = static_cast<const CEnumValuePair *>(getChild(uiChild));
 
         if (pValuePair->getNumerical() == iNumerical) {
 
@@ -247,7 +253,8 @@ bool CEnumParameterType::checkValueAgainstSpace(int32_t iNumerical) const
 }
 
 // From IXmlSource
-void CEnumParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CEnumParameterType::toXml(CXmlElement &xmlElement,
+                               CXmlSerializingContext &serializingContext) const
 {
     // Size
     xmlElement.setAttribute("Size", getSize() * 8);

--- a/parameter/EnumParameterType.h
+++ b/parameter/EnumParameterType.h
@@ -36,42 +36,47 @@
 class CEnumParameterType : public CParameterType
 {
 public:
-    CEnumParameterType(const std::string& strName);
+    CEnumParameterType(const std::string &strName);
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     /// Conversion
     // String
-    virtual bool toBlackboard(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(std::string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(const std::string &strValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(std::string &strValue, const uint32_t &uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Integer
-    virtual bool toBlackboard(int32_t iUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(int32_t& iUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(int32_t iUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(int32_t &iUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
 
     // Default value handling (simulation only)
     virtual uint32_t getDefaultValue() const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // CElement
     virtual std::string getKind() const;
+
 private:
     // Specialized version of toBlackboard in case the access context is in raw
     // value space
-    bool toBlackboardFromRaw(const std::string& strUserValue, uint32_t& uiValue,
-                             CParameterAccessContext& parameterAccessContext) const;
+    bool toBlackboardFromRaw(const std::string &strUserValue, uint32_t &uiValue,
+                             CParameterAccessContext &parameterAccessContext) const;
 
     // Returns true if children dynamic creation is to be dealt with
     virtual bool childrenAreDynamic() const;
 
     // Literal - numerical conversions
-    bool getLiteral(int32_t iNumerical, std::string& strLiteral) const;
-    bool getNumerical(const std::string& strLiteral, int& iNumerical) const;
+    bool getLiteral(int32_t iNumerical, std::string &strLiteral) const;
+    bool getNumerical(const std::string &strLiteral, int &iNumerical) const;
 
     // Numerical validity
     bool checkValueAgainstSpace(int32_t iNumerical) const;

--- a/parameter/EnumValuePair.cpp
+++ b/parameter/EnumValuePair.cpp
@@ -51,7 +51,8 @@ string CEnumValuePair::getNumericalAsString() const
 }
 
 // From IXmlSink
-bool CEnumValuePair::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CEnumValuePair::fromXml(const CXmlElement &xmlElement,
+                             CXmlSerializingContext &serializingContext)
 {
     // Literal
     std::string name;
@@ -66,14 +67,15 @@ bool CEnumValuePair::fromXml(const CXmlElement& xmlElement, CXmlSerializingConte
 }
 
 // Content dumping
-string CEnumValuePair::logValue(utility::ErrorContext& /*ctx*/) const
+string CEnumValuePair::logValue(utility::ErrorContext & /*ctx*/) const
 {
     // Convert value
     return getNumericalAsString();
 }
 
 // From IXmlSource
-void CEnumValuePair::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CEnumValuePair::toXml(CXmlElement &xmlElement,
+                           CXmlSerializingContext &serializingContext) const
 {
     // Literal
     xmlElement.setAttribute("Literal", this->getName());

--- a/parameter/EnumValuePair.h
+++ b/parameter/EnumValuePair.h
@@ -39,18 +39,19 @@ public:
     std::string getNumericalAsString() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // CElement
     virtual std::string getKind() const;
+
 protected:
     // Content dumping
-    std::string logValue(utility::ErrorContext& errorContext) const override;
+    std::string logValue(utility::ErrorContext &errorContext) const override;
+
 private:
     // Numerical
     int32_t _iNumerical{0};
 };
-

--- a/parameter/FileIncluderElementBuilder.h
+++ b/parameter/FileIncluderElementBuilder.h
@@ -41,15 +41,15 @@
 class CFileIncluderElementBuilder : public CElementBuilder
 {
 public:
-    CFileIncluderElementBuilder(bool bValidateWithSchemas) :
-        CElementBuilder(),
-        _bValidateWithSchemas(bValidateWithSchemas)
-    {}
+    CFileIncluderElementBuilder(bool bValidateWithSchemas)
+        : CElementBuilder(), _bValidateWithSchemas(bValidateWithSchemas)
+    {
+    }
 
     virtual CElement *createElement(const CXmlElement &xmlElement) const
     {
-        return new CXmlFileIncluderElement(xmlElement.getNameAttribute(),
-                                           xmlElement.getType(), _bValidateWithSchemas);
+        return new CXmlFileIncluderElement(xmlElement.getNameAttribute(), xmlElement.getType(),
+                                           _bValidateWithSchemas);
     }
 
 private:

--- a/parameter/FixedPointParameterType.cpp
+++ b/parameter/FixedPointParameterType.cpp
@@ -44,7 +44,7 @@
 
 using std::string;
 
-CFixedPointParameterType::CFixedPointParameterType(const string& strName) : base(strName)
+CFixedPointParameterType::CFixedPointParameterType(const string &strName) : base(strName)
 {
 }
 
@@ -54,7 +54,7 @@ string CFixedPointParameterType::getKind() const
 }
 
 // Element properties
-void CFixedPointParameterType::showProperties(string& strResult) const
+void CFixedPointParameterType::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -68,7 +68,9 @@ void CFixedPointParameterType::showProperties(string& strResult) const
 
 // XML Serialization value space handling
 // Value space handling for configuration import
-void CFixedPointParameterType::handleValueSpaceAttribute(CXmlElement& xmlConfigurableElementSettingsElement, CConfigurationAccessContext& configurationAccessContext) const
+void CFixedPointParameterType::handleValueSpaceAttribute(
+    CXmlElement &xmlConfigurableElementSettingsElement,
+    CConfigurationAccessContext &configurationAccessContext) const
 {
     // Direction?
     if (!configurationAccessContext.serializeOut()) {
@@ -85,7 +87,8 @@ void CFixedPointParameterType::handleValueSpaceAttribute(CXmlElement& xmlConfigu
     }
 }
 
-bool CFixedPointParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CFixedPointParameterType::fromXml(const CXmlElement &xmlElement,
+                                       CXmlSerializingContext &serializingContext)
 {
     // Size
     size_t sizeInBits = 0;
@@ -101,9 +104,8 @@ bool CFixedPointParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerial
         std::string size;
         xmlElement.getAttribute("Size", size);
         serializingContext.setError(
-                "Inconsistent Size vs. Q notation for " + getKind() + " " + xmlElement.getPath() +
-                ": Summing (Integral + _uiFractional + 1) should not exceed given Size (" +
-                size + ")");
+            "Inconsistent Size vs. Q notation for " + getKind() + " " + xmlElement.getPath() +
+            ": Summing (Integral + _uiFractional + 1) should not exceed given Size (" + size + ")");
 
         return false;
     }
@@ -114,14 +116,16 @@ bool CFixedPointParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerial
     return base::fromXml(xmlElement, serializingContext);
 }
 
-bool CFixedPointParameterType::toBlackboard(const string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CFixedPointParameterType::toBlackboard(const string &strValue, uint32_t &uiValue,
+                                            CParameterAccessContext &parameterAccessContext) const
 {
     bool bValueProvidedAsHexa = utility::isHexadecimal(strValue);
 
     // Check data integrity
     if (bValueProvidedAsHexa && !parameterAccessContext.valueSpaceIsRaw()) {
 
-        parameterAccessContext.setError("Hexadecimal values are not supported for " + getKind() + " when selected value space is real:");
+        parameterAccessContext.setError("Hexadecimal values are not supported for " + getKind() +
+                                        " when selected value space is real:");
 
         return false;
     }
@@ -131,14 +135,14 @@ bool CFixedPointParameterType::toBlackboard(const string& strValue, uint32_t& ui
         if (bValueProvidedAsHexa) {
 
             return convertFromHexadecimal(strValue, uiValue, parameterAccessContext);
-
         }
         return convertFromDecimal(strValue, uiValue, parameterAccessContext);
     }
     return convertFromQnm(strValue, uiValue, parameterAccessContext);
 }
 
-void CFixedPointParameterType::setOutOfRangeError(const string& strValue, CParameterAccessContext& parameterAccessContext) const
+void CFixedPointParameterType::setOutOfRangeError(
+    const string &strValue, CParameterAccessContext &parameterAccessContext) const
 {
     std::ostringstream stream;
 
@@ -151,8 +155,8 @@ void CFixedPointParameterType::setOutOfRangeError(const string& strValue, CParam
         double dMax = 0;
         getRange(dMin, dMax);
 
-        stream << std::fixed << std::setprecision(_uiFractional) <<
-               "real range [" << dMin << ", " << dMax << "]";
+        stream << std::fixed << std::setprecision(_uiFractional) << "real range [" << dMin << ", "
+               << dMax << "]";
     } else {
 
         // Min/Max computation
@@ -163,8 +167,8 @@ void CFixedPointParameterType::setOutOfRangeError(const string& strValue, CParam
 
         if (utility::isHexadecimal(strValue)) {
 
-            stream << std::hex << std::uppercase <<
-                   std::setw(static_cast<int>(getSize()) * 2) << std::setfill('0');
+            stream << std::hex << std::uppercase << std::setw(static_cast<int>(getSize()) * 2)
+                   << std::setfill('0');
 
             // Format Min
             stream << "0x" << makeEncodable(iMin);
@@ -183,7 +187,8 @@ void CFixedPointParameterType::setOutOfRangeError(const string& strValue, CParam
     parameterAccessContext.setError(stream.str());
 }
 
-bool CFixedPointParameterType::fromBlackboard(string& strValue, const uint32_t& value, CParameterAccessContext& parameterAccessContext) const
+bool CFixedPointParameterType::fromBlackboard(string &strValue, const uint32_t &value,
+                                              CParameterAccessContext &parameterAccessContext) const
 {
     // Check encodability
     assert(isEncodable(value, false));
@@ -197,9 +202,8 @@ bool CFixedPointParameterType::fromBlackboard(string& strValue, const uint32_t& 
         if (parameterAccessContext.outputRawFormatIsHex()) {
             uint32_t data = static_cast<uint32_t>(value);
 
-            stream << "0x" << std::hex << std::uppercase <<
-                   std::setw(static_cast<int>(getSize() * 2)) <<
-                   std::setfill('0') << data;
+            stream << "0x" << std::hex << std::uppercase
+                   << std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0') << data;
         } else {
             int32_t data = value;
 
@@ -215,8 +219,7 @@ bool CFixedPointParameterType::fromBlackboard(string& strValue, const uint32_t& 
         signExtend(data);
 
         // Conversion
-        stream << std::fixed << std::setprecision(_uiFractional) <<
-               binaryQnmToDouble(data);
+        stream << std::fixed << std::setprecision(_uiFractional) << binaryQnmToDouble(data);
     }
 
     strValue = stream.str();
@@ -225,7 +228,8 @@ bool CFixedPointParameterType::fromBlackboard(string& strValue, const uint32_t& 
 }
 
 // Value access
-bool CFixedPointParameterType::toBlackboard(double dUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CFixedPointParameterType::toBlackboard(double dUserValue, uint32_t &uiValue,
+                                            CParameterAccessContext &parameterAccessContext) const
 {
     // Check that the value is within the allowed range for this type
     if (!checkValueAgainstRange(dUserValue)) {
@@ -247,7 +251,8 @@ bool CFixedPointParameterType::toBlackboard(double dUserValue, uint32_t& uiValue
     return true;
 }
 
-bool CFixedPointParameterType::fromBlackboard(double& dUserValue, uint32_t uiValue, CParameterAccessContext& /*ctx*/) const
+bool CFixedPointParameterType::fromBlackboard(double &dUserValue, uint32_t uiValue,
+                                              CParameterAccessContext & /*ctx*/) const
 {
     int32_t iData = uiValue;
 
@@ -269,13 +274,15 @@ size_t CFixedPointParameterType::getUtilSizeInBits() const
 }
 
 // Compute the range for the type (minimum and maximum values)
-void CFixedPointParameterType::getRange(double& dMin, double& dMax) const
+void CFixedPointParameterType::getRange(double &dMin, double &dMax) const
 {
     dMax = ((1U << (_uiIntegral + _uiFractional)) - 1) / double(1U << _uiFractional);
     dMin = -((1U << (_uiIntegral + _uiFractional)) / double(1U << _uiFractional));
 }
 
-bool CFixedPointParameterType::convertFromHexadecimal(const string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CFixedPointParameterType::convertFromHexadecimal(
+    const string &strValue, uint32_t &uiValue,
+    CParameterAccessContext &parameterAccessContext) const
 {
     // For hexadecimal representation, we need full 32 bit range conversion.
     if (!convertTo(strValue, uiValue) || !isEncodable(uiValue, false)) {
@@ -291,7 +298,9 @@ bool CFixedPointParameterType::convertFromHexadecimal(const string& strValue, ui
     return true;
 }
 
-bool CFixedPointParameterType::convertFromDecimal(const string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CFixedPointParameterType::convertFromDecimal(
+    const string &strValue, uint32_t &uiValue,
+    CParameterAccessContext &parameterAccessContext) const
 {
     if (!convertTo(strValue, reinterpret_cast<int32_t &>(uiValue)) || !isEncodable(uiValue, true)) {
 
@@ -301,8 +310,8 @@ bool CFixedPointParameterType::convertFromDecimal(const string& strValue, uint32
     return true;
 }
 
-bool CFixedPointParameterType::convertFromQnm(const string& strValue, uint32_t& uiValue,
-                                              CParameterAccessContext& parameterAccessContext) const
+bool CFixedPointParameterType::convertFromQnm(const string &strValue, uint32_t &uiValue,
+                                              CParameterAccessContext &parameterAccessContext) const
 {
     double dData = 0;
 
@@ -342,7 +351,6 @@ int32_t CFixedPointParameterType::doubleToBinaryQnm(double dValue) const
     return iData;
 }
 
-
 double CFixedPointParameterType::binaryQnmToDouble(int32_t iValue) const
 {
     // Unjustify
@@ -351,7 +359,8 @@ double CFixedPointParameterType::binaryQnmToDouble(int32_t iValue) const
 }
 
 // From IXmlSource
-void CFixedPointParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CFixedPointParameterType::toXml(CXmlElement &xmlElement,
+                                     CXmlSerializingContext &serializingContext) const
 {
     // Size
     xmlElement.setAttribute("Size", getSize() * 8);

--- a/parameter/FixedPointParameterType.h
+++ b/parameter/FixedPointParameterType.h
@@ -36,36 +36,43 @@
 class CFixedPointParameterType : public CParameterType
 {
 public:
-    CFixedPointParameterType(const std::string& strName);
+    CFixedPointParameterType(const std::string &strName);
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // XML Serialization value space handling
     // Value space handling for configuration import
-    virtual void handleValueSpaceAttribute(CXmlElement& xmlConfigurableElementSettingsElement, CConfigurationAccessContext& configurationAccessContext) const;
+    virtual void handleValueSpaceAttribute(
+        CXmlElement &xmlConfigurableElementSettingsElement,
+        CConfigurationAccessContext &configurationAccessContext) const;
 
     /// Conversion
     // String
-    virtual bool toBlackboard(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(std::string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(const std::string &strValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(std::string &strValue, const uint32_t &uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Double
-    virtual bool toBlackboard(double dUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(double& dUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(double dUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(double &dUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // CElement
     virtual std::string getKind() const;
+
 private:
     // Util size
     size_t getUtilSizeInBits() const;
     // Range computation
-    void getRange(double& dMin, double& dMax) const;
+    void getRange(double &dMin, double &dMax) const;
 
     /**
      * Convert a decimal raw represented string into an unsigned long integer.
@@ -79,7 +86,8 @@ private:
      *
      * @return true if the string was successfully converted, false otherwise.
      */
-    bool convertFromDecimal(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    bool convertFromDecimal(const std::string &strValue, uint32_t &uiValue,
+                            CParameterAccessContext &parameterAccessContext) const;
 
     /**
      * Convert an hexadecimal raw represented string into an unsigned long integer.
@@ -93,7 +101,8 @@ private:
      *
      * @return true if the string was successfully converted, false otherwise.
      */
-    bool convertFromHexadecimal(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    bool convertFromHexadecimal(const std::string &strValue, uint32_t &uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
 
     /**
      * Convert a Qn.m represented string into an unsigned long integer.
@@ -107,7 +116,8 @@ private:
      *
      * @return true if the string was successfully converted, false otherwise.
      */
-    bool convertFromQnm(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    bool convertFromQnm(const std::string &strValue, uint32_t &uiValue,
+                        CParameterAccessContext &parameterAccessContext) const;
 
     /**
      * Set the out of range error.
@@ -117,7 +127,8 @@ private:
      * @param[in] strValue Parameter read from the XML file representated as a string
      * @param[in:out] parameterAccessContext Parameter Access Context
      */
-    void setOutOfRangeError(const std::string& strValue, CParameterAccessContext& parameterAccessContext) const;
+    void setOutOfRangeError(const std::string &strValue,
+                            CParameterAccessContext &parameterAccessContext) const;
 
     // Check if data is encodable
     bool checkValueAgainstRange(double dValue) const;

--- a/parameter/FloatingPointParameterType.cpp
+++ b/parameter/FloatingPointParameterType.cpp
@@ -40,8 +40,7 @@
 
 using std::string;
 
-CFloatingPointParameterType::CFloatingPointParameterType(const string& strName)
-    : base(strName)
+CFloatingPointParameterType::CFloatingPointParameterType(const string &strName) : base(strName)
 {
 }
 
@@ -51,17 +50,16 @@ string CFloatingPointParameterType::getKind() const
 }
 
 // Element properties
-void CFloatingPointParameterType::showProperties(string& strResult) const
+void CFloatingPointParameterType::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
-    strResult += "Min:" + std::to_string(_fMin) + "\n" +
-                 "Max:" + std::to_string(_fMax) + "\n";
+    strResult += "Min:" + std::to_string(_fMin) + "\n" + "Max:" + std::to_string(_fMax) + "\n";
 }
 
 void CFloatingPointParameterType::handleValueSpaceAttribute(
-        CXmlElement& xmlConfigurableElementSettingsElement,
-        CConfigurationAccessContext& configurationAccessContext) const
+    CXmlElement &xmlConfigurableElementSettingsElement,
+    CConfigurationAccessContext &configurationAccessContext) const
 {
     if (!configurationAccessContext.serializeOut()) {
 
@@ -83,8 +81,8 @@ void CFloatingPointParameterType::handleValueSpaceAttribute(
     }
 }
 
-bool CFloatingPointParameterType::fromXml(const CXmlElement& xmlElement,
-                                          CXmlSerializingContext& serializingContext)
+bool CFloatingPointParameterType::fromXml(const CXmlElement &xmlElement,
+                                          CXmlSerializingContext &serializingContext)
 {
     // Size. The XSD fixes it to 32
     size_t sizeInBits = 32;
@@ -94,8 +92,9 @@ bool CFloatingPointParameterType::fromXml(const CXmlElement& xmlElement,
     // (e.g. doubles are not supported)
     if (sizeInBits != sizeof(float) * CHAR_BIT) {
 
-        serializingContext.setError("Unsupported size (" + std::to_string(sizeInBits) +
-            ") for " + getKind() + " " + xmlElement.getPath() + ". For now, only 32 is supported.");
+        serializingContext.setError("Unsupported size (" + std::to_string(sizeInBits) + ") for " +
+                                    getKind() + " " + xmlElement.getPath() +
+                                    ". For now, only 32 is supported.");
 
         return false;
     }
@@ -107,7 +106,7 @@ bool CFloatingPointParameterType::fromXml(const CXmlElement& xmlElement,
 
     if (_fMin > _fMax) {
         serializingContext.setError("Min (" + std::to_string(_fMin) +
-                ") can't be greater than Max (" + std::to_string(_fMax) + ")");
+                                    ") can't be greater than Max (" + std::to_string(_fMax) + ")");
         return false;
     }
 
@@ -115,17 +114,14 @@ bool CFloatingPointParameterType::fromXml(const CXmlElement& xmlElement,
 }
 
 bool CFloatingPointParameterType::toBlackboard(
-        const string& strValue,
-        uint32_t& uiValue,
-        CParameterAccessContext& parameterAccessContext) const
+    const string &strValue, uint32_t &uiValue,
+    CParameterAccessContext &parameterAccessContext) const
 {
     // Check Value integrity
     if (utility::isHexadecimal(strValue) && !parameterAccessContext.valueSpaceIsRaw()) {
 
-        parameterAccessContext.setError("Hexadecimal values are not supported for "
-                                        + getKind()
-                                        + " when selected value space is real: "
-                                        + strValue);
+        parameterAccessContext.setError("Hexadecimal values are not supported for " + getKind() +
+                                        " when selected value space is real: " + strValue);
 
         return false;
     }
@@ -154,8 +150,7 @@ bool CFloatingPointParameterType::toBlackboard(
             return false;
         }
         return true;
-    }
-    else {
+    } else {
 
         float fValue = 0.0f;
 
@@ -179,8 +174,7 @@ bool CFloatingPointParameterType::toBlackboard(
 }
 
 void CFloatingPointParameterType::setOutOfRangeError(
-        const string& strValue,
-        CParameterAccessContext& parameterAccessContext) const
+    const string &strValue, CParameterAccessContext &parameterAccessContext) const
 {
     // error message buffer
     std::ostringstream ostrStream;
@@ -197,8 +191,8 @@ void CFloatingPointParameterType::setOutOfRangeError(
 
         if (utility::isHexadecimal(strValue)) {
 
-            ostrStream << std::showbase << std::hex
-                       << std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0');
+            ostrStream << std::showbase << std::hex << std::setw(static_cast<int>(getSize() * 2))
+                       << std::setfill('0');
         }
 
         ostrStream << "raw range [" << uiMin << ", " << uiMax << "]";
@@ -209,9 +203,8 @@ void CFloatingPointParameterType::setOutOfRangeError(
 }
 
 bool CFloatingPointParameterType::fromBlackboard(
-        string& strValue,
-        const uint32_t& uiValue,
-        CParameterAccessContext& parameterAccessContext) const
+    string &strValue, const uint32_t &uiValue,
+    CParameterAccessContext &parameterAccessContext) const
 {
     std::ostringstream ostrStream;
 
@@ -219,8 +212,8 @@ bool CFloatingPointParameterType::fromBlackboard(
 
         if (parameterAccessContext.outputRawFormatIsHex()) {
 
-            ostrStream << std::showbase << std::hex
-                       << std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0');
+            ostrStream << std::showbase << std::hex << std::setw(static_cast<int>(getSize() * 2))
+                       << std::setfill('0');
         }
 
         ostrStream << uiValue;
@@ -239,9 +232,7 @@ bool CFloatingPointParameterType::fromBlackboard(
 
 // Value access
 bool CFloatingPointParameterType::toBlackboard(
-        double dUserValue,
-        uint32_t& uiValue,
-        CParameterAccessContext& parameterAccessContext) const
+    double dUserValue, uint32_t &uiValue, CParameterAccessContext &parameterAccessContext) const
 {
     if (!checkValueAgainstRange(dUserValue)) {
 
@@ -255,10 +246,8 @@ bool CFloatingPointParameterType::toBlackboard(
     return true;
 }
 
-bool CFloatingPointParameterType::fromBlackboard(
-        double& dUserValue,
-        uint32_t uiValue,
-        CParameterAccessContext& /*ctx*/) const
+bool CFloatingPointParameterType::fromBlackboard(double &dUserValue, uint32_t uiValue,
+                                                 CParameterAccessContext & /*ctx*/) const
 {
     // Move from "raw memory" value space to real space
     auto fValue = utility::binaryCopy<float>(uiValue);
@@ -271,9 +260,9 @@ bool CFloatingPointParameterType::checkValueAgainstRange(double dValue) const
 {
     // Check that dValue can safely be cast to a float
     // (otherwise, behaviour is undefined)
-    if ((dValue < -std::numeric_limits<float>::max())
-        || (dValue > std::numeric_limits<float>::max())) {
-            return false;
+    if ((dValue < -std::numeric_limits<float>::max()) ||
+        (dValue > std::numeric_limits<float>::max())) {
+        return false;
     }
 
     return checkValueAgainstRange(static_cast<float>(dValue));
@@ -284,8 +273,8 @@ bool CFloatingPointParameterType::checkValueAgainstRange(float fValue) const
     return fValue <= _fMax && fValue >= _fMin;
 }
 
-void CFloatingPointParameterType::toXml(CXmlElement& xmlElement,
-                                        CXmlSerializingContext& serializingContext) const
+void CFloatingPointParameterType::toXml(CXmlElement &xmlElement,
+                                        CXmlSerializingContext &serializingContext) const
 {
     xmlElement.setAttribute("Size", getSize() * CHAR_BIT);
     xmlElement.setAttribute("Min", _fMin);

--- a/parameter/FloatingPointParameterType.h
+++ b/parameter/FloatingPointParameterType.h
@@ -35,33 +35,29 @@
 class CFloatingPointParameterType : public CParameterType
 {
 public:
-    CFloatingPointParameterType(const std::string& strName);
+    CFloatingPointParameterType(const std::string &strName);
 
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     virtual void handleValueSpaceAttribute(
-            CXmlElement& xmlConfigurableElementSettingsElement,
-            CConfigurationAccessContext& configurationAccessContext) const;
+        CXmlElement &xmlConfigurableElementSettingsElement,
+        CConfigurationAccessContext &configurationAccessContext) const;
 
-    virtual bool toBlackboard(const std::string& strValue,
-                              uint32_t& uiValue,
-                              CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(std::string& strValue,
-                                const uint32_t& uiValue,
-                                CParameterAccessContext& parameterAccessContext) const;
-    virtual bool toBlackboard(double dUserValue,
-                              uint32_t& uiValue,
-                              CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(double& dUserValue,
-                                uint32_t uiValue,
-                                CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(const std::string &strValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(std::string &strValue, const uint32_t &uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
+    virtual bool toBlackboard(double dUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(double &dUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
 
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     virtual std::string getKind() const;
-private:
 
+private:
     typedef CParameterType base;
 
     /**
@@ -70,7 +66,8 @@ private:
      * @param[in] strValue the user provided value
      * @param[in,out] parameterAccessContext Parameter Access Context
      */
-    void setOutOfRangeError(const std::string& strValue, CParameterAccessContext& parameterAccessContext) const;
+    void setOutOfRangeError(const std::string &strValue,
+                            CParameterAccessContext &parameterAccessContext) const;
 
     /**
      * Check value validity against range.

--- a/parameter/FormattedSubsystemObject.cpp
+++ b/parameter/FormattedSubsystemObject.cpp
@@ -38,29 +38,22 @@
 using std::string;
 
 CFormattedSubsystemObject::CFormattedSubsystemObject(
-        CInstanceConfigurableElement* pInstanceConfigurableElement,
-        core::log::Logger& logger)
+    CInstanceConfigurableElement *pInstanceConfigurableElement, core::log::Logger &logger)
     : base(pInstanceConfigurableElement, logger)
 {
 }
 
 CFormattedSubsystemObject::CFormattedSubsystemObject(
-        CInstanceConfigurableElement* pInstanceConfigurableElement,
-        core::log::Logger& logger,
-        const string& strMappingValue)
+    CInstanceConfigurableElement *pInstanceConfigurableElement, core::log::Logger &logger,
+    const string &strMappingValue)
     : base(pInstanceConfigurableElement, logger), _strFormattedMappingValue(strMappingValue)
 {
-
 }
 
-
 CFormattedSubsystemObject::CFormattedSubsystemObject(
-        CInstanceConfigurableElement* pInstanceConfigurableElement,
-        core::log::Logger& logger,
-        const string& strMappingValue,
-        size_t firstAmendKey,
-        size_t nbAmendKeys,
-        const CMappingContext& context)
+    CInstanceConfigurableElement *pInstanceConfigurableElement, core::log::Logger &logger,
+    const string &strMappingValue, size_t firstAmendKey, size_t nbAmendKeys,
+    const CMappingContext &context)
     : base(pInstanceConfigurableElement, logger), _strFormattedMappingValue(strMappingValue)
 {
     // Cope with quotes in the name
@@ -68,8 +61,8 @@ CFormattedSubsystemObject::CFormattedSubsystemObject(
 
         _strFormattedMappingValue = strMappingValue.substr(1, strMappingValue.length() - 2);
     }
-    _strFormattedMappingValue = formatMappingValue(_strFormattedMappingValue, firstAmendKey,
-                                                   nbAmendKeys, context);
+    _strFormattedMappingValue =
+        formatMappingValue(_strFormattedMappingValue, firstAmendKey, nbAmendKeys, context);
 }
 
 string CFormattedSubsystemObject::getFormattedMappingValue() const
@@ -83,10 +76,9 @@ bool CFormattedSubsystemObject::isAmendKeyValid(size_t uiAmendKey)
     return (uiAmendKey > 0) && (uiAmendKey <= 9);
 }
 
-string CFormattedSubsystemObject::formatMappingValue(const string& strMappingValue,
-                                                     size_t firstAmendKey,
-                                                     size_t nbAmendKeys,
-                                                     const CMappingContext& context)
+string CFormattedSubsystemObject::formatMappingValue(const string &strMappingValue,
+                                                     size_t firstAmendKey, size_t nbAmendKeys,
+                                                     const CMappingContext &context)
 {
     string strFormattedValue = strMappingValue;
 
@@ -111,19 +103,17 @@ string CFormattedSubsystemObject::formatMappingValue(const string& strMappingVal
             if (context.iSet(uiAmendType)) {
 
                 // Make the amendment on the part of the string after the current Amend
-                string strEndOfLine = strFormattedValue.substr(uiPercentPos + 2,
-                                                               strFormattedValue.size()
-                                                               - uiPercentPos - 2);
-                string strEndOfLineAmended = formatMappingValue(strEndOfLine, firstAmendKey,
-                                                                nbAmendKeys, context);
+                string strEndOfLine = strFormattedValue.substr(
+                    uiPercentPos + 2, strFormattedValue.size() - uiPercentPos - 2);
+                string strEndOfLineAmended =
+                    formatMappingValue(strEndOfLine, firstAmendKey, nbAmendKeys, context);
 
                 // Get current Amend value
                 string strAmendValue = context.getItem(uiAmendType);
 
                 // Make the amendment
-                strFormattedValue = strFormattedValue.substr(0, uiPercentPos) + strAmendValue
-                        + strEndOfLineAmended;
-
+                strFormattedValue =
+                    strFormattedValue.substr(0, uiPercentPos) + strAmendValue + strEndOfLineAmended;
             }
         }
     }

--- a/parameter/FormattedSubsystemObject.h
+++ b/parameter/FormattedSubsystemObject.h
@@ -42,8 +42,8 @@ public:
      * @param[in] pInstanceConfigurableElement Instance of the element linked to the SubsytemObject.
      * @param[in] logger the logger provided by the client
      */
-    CFormattedSubsystemObject(CInstanceConfigurableElement* pInstanceConfigurableElement,
-                              core::log::Logger& logger);
+    CFormattedSubsystemObject(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                              core::log::Logger &logger);
 
     /**
      * Builds a new CFormattedSubsystemObject instance, using a simple mapping value without Amends.
@@ -53,9 +53,8 @@ public:
      * @param[in] strFormattedMapping A std::string corresponding to the mapping of the element. The
      * std::string does not contain any Amend (%) and does not need to be formatted.
      */
-    CFormattedSubsystemObject(CInstanceConfigurableElement* pInstanceConfigurableElement,
-                              core::log::Logger& logger,
-                              const std::string& strFormattedMapping);
+    CFormattedSubsystemObject(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                              core::log::Logger &logger, const std::string &strFormattedMapping);
 
     /**
      * Builds a new CFormattedSubsystemObject instance, using a mapping value containing Amends.
@@ -68,12 +67,10 @@ public:
      * @param[in] nbAmendKeys Number of Amends
      * @param[in] context Contains values associated to Amend keys
      */
-    CFormattedSubsystemObject(CInstanceConfigurableElement* pInstanceConfigurableElement,
-                              core::log::Logger& logger,
-                              const std::string& strMappingValue,
-                              size_t firstAmendKey,
-                              size_t nbAmendKeys,
-                              const CMappingContext& context);
+    CFormattedSubsystemObject(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                              core::log::Logger &logger, const std::string &strMappingValue,
+                              size_t firstAmendKey, size_t nbAmendKeys,
+                              const CMappingContext &context);
     virtual ~CFormattedSubsystemObject() = default;
 
     /**
@@ -84,7 +81,6 @@ public:
     virtual std::string getFormattedMappingValue() const;
 
 private:
-
     /**
      * Check if the index of Amend key is valid.
      *
@@ -105,13 +101,12 @@ private:
      * @param[in] nbAmendKeys Number of Amend keys in the context
      * @param[in] context The context containing Amend values
      *
-     * @return The formatted std::string, corresponding to the input strMappingValue where %n have been
+     * @return The formatted std::string, corresponding to the input strMappingValue where %n have
+     * been
      * replaced by their value
      */
-    static std::string formatMappingValue(const std::string& strMappingValue,
-                                     size_t firstAmendKey,
-                                     size_t nbAmendKeys,
-                                     const CMappingContext& context);
+    static std::string formatMappingValue(const std::string &strMappingValue, size_t firstAmendKey,
+                                          size_t nbAmendKeys, const CMappingContext &context);
 
     /**
      * std::string containing the formatted mapping value

--- a/parameter/FrameworkConfigurationGroup.h
+++ b/parameter/FrameworkConfigurationGroup.h
@@ -36,15 +36,11 @@
 class CFrameworkConfigurationGroup : public CKindElement
 {
 public:
-    CFrameworkConfigurationGroup(const std::string& strName, const std::string& strKind) : CKindElement(strName, strKind)
+    CFrameworkConfigurationGroup(const std::string &strName, const std::string &strKind)
+        : CKindElement(strName, strKind)
     {
     }
 
 private:
-    virtual bool childrenAreDynamic() const
-    {
-        return true;
-    }
-
-
+    virtual bool childrenAreDynamic() const { return true; }
 };

--- a/parameter/FrameworkConfigurationLocation.cpp
+++ b/parameter/FrameworkConfigurationLocation.cpp
@@ -33,12 +33,15 @@
 
 #define base CKindElement
 
-CFrameworkConfigurationLocation::CFrameworkConfigurationLocation(const std::string& strName, const std::string& strKind) : base(strName, strKind)
+CFrameworkConfigurationLocation::CFrameworkConfigurationLocation(const std::string &strName,
+                                                                 const std::string &strKind)
+    : base(strName, strKind)
 {
 }
 
 // From IXmlSink
-bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CFrameworkConfigurationLocation::fromXml(const CXmlElement &xmlElement,
+                                              CXmlSerializingContext &serializingContext)
 {
     xmlElement.getAttribute("Path", _configurationUri);
 
@@ -51,7 +54,7 @@ bool CFrameworkConfigurationLocation::fromXml(const CXmlElement& xmlElement, CXm
     return true;
 }
 
-const std::string& CFrameworkConfigurationLocation::getUri() const
+const std::string &CFrameworkConfigurationLocation::getUri() const
 {
     return _configurationUri;
 }

--- a/parameter/FrameworkConfigurationLocation.h
+++ b/parameter/FrameworkConfigurationLocation.h
@@ -36,15 +36,15 @@
 class CFrameworkConfigurationLocation : public CKindElement
 {
 public:
-    CFrameworkConfigurationLocation(const std::string& strName, const std::string& strKind);
+    CFrameworkConfigurationLocation(const std::string &strName, const std::string &strKind);
 
     /** Get Configuration file URI
      */
-    const std::string& getUri() const;
+    const std::string &getUri() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
-private:
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
+private:
     std::string _configurationUri;
 };

--- a/parameter/HardwareBackSynchronizer.cpp
+++ b/parameter/HardwareBackSynchronizer.cpp
@@ -32,15 +32,16 @@
 
 #define base CBackSynchronizer
 
-CHardwareBackSynchronizer::CHardwareBackSynchronizer(const CConfigurableElement* pConfigurableElement, CParameterBlackboard* pParameterBlackboard)
+CHardwareBackSynchronizer::CHardwareBackSynchronizer(
+    const CConfigurableElement *pConfigurableElement, CParameterBlackboard *pParameterBlackboard)
     : base(pConfigurableElement), _pParameterBlackboard(pParameterBlackboard)
 {
     // Fill back syncer set
-    std::list<const CConfigurableElement*>::const_iterator it;
+    std::list<const CConfigurableElement *>::const_iterator it;
 
     for (it = _needingBackSyncList.begin(); it != _needingBackSyncList.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;
+        const CConfigurableElement *pConfigurableElement = *it;
 
         pConfigurableElement->fillSyncerSet(_backSyncerSet);
     }

--- a/parameter/HardwareBackSynchronizer.h
+++ b/parameter/HardwareBackSynchronizer.h
@@ -35,7 +35,8 @@
 class CHardwareBackSynchronizer : public CBackSynchronizer
 {
 public:
-    CHardwareBackSynchronizer(const CConfigurableElement* pConfigurableElement, CParameterBlackboard* pParameterBlackboard);
+    CHardwareBackSynchronizer(const CConfigurableElement *pConfigurableElement,
+                              CParameterBlackboard *pParameterBlackboard);
 
     // Back synchronization
     virtual void sync();
@@ -44,6 +45,5 @@ private:
     // Back syncer set
     CSyncerSet _backSyncerSet;
     // Parameter blackboard
-    CParameterBlackboard* _pParameterBlackboard;
+    CParameterBlackboard *_pParameterBlackboard;
 };
-

--- a/parameter/InstanceConfigurableElement.cpp
+++ b/parameter/InstanceConfigurableElement.cpp
@@ -37,7 +37,9 @@
 
 #define base CConfigurableElement
 
-CInstanceConfigurableElement::CInstanceConfigurableElement(const std::string& strName, const CTypeElement* pTypeElement) : base(strName), _pTypeElement(pTypeElement)
+CInstanceConfigurableElement::CInstanceConfigurableElement(const std::string &strName,
+                                                           const CTypeElement *pTypeElement)
+    : base(strName), _pTypeElement(pTypeElement)
 {
 }
 
@@ -54,13 +56,14 @@ std::string CInstanceConfigurableElement::getXmlElementName() const
 }
 
 // Type element
-const CTypeElement* CInstanceConfigurableElement::getTypeElement() const
+const CTypeElement *CInstanceConfigurableElement::getTypeElement() const
 {
     return _pTypeElement;
 }
 
 // Mapping
-bool CInstanceConfigurableElement::getMappingData(const std::string& strKey, const std::string*& pStrValue) const
+bool CInstanceConfigurableElement::getMappingData(const std::string &strKey,
+                                                  const std::string *&pStrValue) const
 {
     // Delegate
     return getTypeElement()->getMappingData(strKey, pStrValue);
@@ -73,7 +76,7 @@ std::string CInstanceConfigurableElement::getFormattedMapping() const
     return getTypeElement()->getFormattedMapping();
 }
 
-bool CInstanceConfigurableElement::map(IMapper& mapper, std::string& strError)
+bool CInstanceConfigurableElement::map(IMapper &mapper, std::string &strError)
 {
     bool bHasMappingData = getTypeElement()->hasMappingData();
     bool bKeepDiving = true;
@@ -93,8 +96,8 @@ bool CInstanceConfigurableElement::map(IMapper& mapper, std::string& strError)
 
         for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-            CInstanceConfigurableElement* pInstanceConfigurableChildElement =
-                    static_cast<CInstanceConfigurableElement*>(getChild(uiChild));
+            CInstanceConfigurableElement *pInstanceConfigurableChildElement =
+                static_cast<CInstanceConfigurableElement *>(getChild(uiChild));
 
             if (!pInstanceConfigurableChildElement->map(mapper, strError)) {
 
@@ -112,9 +115,9 @@ bool CInstanceConfigurableElement::map(IMapper& mapper, std::string& strError)
 }
 
 void CInstanceConfigurableElement::getListOfElementsWithMapping(
-        std::list<const CConfigurableElement*>& configurableElementPath) const
+    std::list<const CConfigurableElement *> &configurableElementPath) const
 {
-    const CTypeElement* pTypeElement = getTypeElement();
+    const CTypeElement *pTypeElement = getTypeElement();
 
     if (pTypeElement && pTypeElement->hasMappingData()) {
 
@@ -125,7 +128,7 @@ void CInstanceConfigurableElement::getListOfElementsWithMapping(
 }
 
 // Element properties
-void CInstanceConfigurableElement::showProperties(std::string& strResult) const
+void CInstanceConfigurableElement::showProperties(std::string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -146,7 +149,7 @@ size_t CInstanceConfigurableElement::getArrayLength() const
 }
 
 // Sync to HW
-void CInstanceConfigurableElement::setSyncer(ISyncer* pSyncer)
+void CInstanceConfigurableElement::setSyncer(ISyncer *pSyncer)
 {
     assert(!_pSyncer);
 
@@ -159,7 +162,7 @@ void CInstanceConfigurableElement::unsetSyncer()
 }
 
 // Syncer
-ISyncer* CInstanceConfigurableElement::getSyncer() const
+ISyncer *CInstanceConfigurableElement::getSyncer() const
 {
     if (_pSyncer) {
 
@@ -170,7 +173,7 @@ ISyncer* CInstanceConfigurableElement::getSyncer() const
 }
 
 // Syncer set (descendant)
-void CInstanceConfigurableElement::fillSyncerSetFromDescendant(CSyncerSet& syncerSet) const
+void CInstanceConfigurableElement::fillSyncerSetFromDescendant(CSyncerSet &syncerSet) const
 {
     if (_pSyncer) {
 
@@ -181,7 +184,7 @@ void CInstanceConfigurableElement::fillSyncerSetFromDescendant(CSyncerSet& synce
     }
 }
 
-bool CInstanceConfigurableElement::sync(CParameterAccessContext& parameterAccessContext) const
+bool CInstanceConfigurableElement::sync(CParameterAccessContext &parameterAccessContext) const
 {
     if (!parameterAccessContext.getAutoSync()) {
 
@@ -189,11 +192,12 @@ bool CInstanceConfigurableElement::sync(CParameterAccessContext& parameterAccess
         // This is not an error, but the expected behavior so return true anyway.
         return true;
     }
-    ISyncer* pSyncer = getSyncer();
+    ISyncer *pSyncer = getSyncer();
 
     if (!pSyncer) {
 
-        parameterAccessContext.setError("Unable to synchronize modification. No Syncer object associated to configurable element:");
+        parameterAccessContext.setError("Unable to synchronize modification. No Syncer object "
+                                        "associated to configurable element:");
 
         return false;
     }
@@ -209,9 +213,10 @@ bool CInstanceConfigurableElement::sync(CParameterAccessContext& parameterAccess
 }
 
 // Check parameter access path well formed for leaf elements
-bool CInstanceConfigurableElement::checkPathExhausted(CPathNavigator& pathNavigator, utility::ErrorContext& errorContext)
+bool CInstanceConfigurableElement::checkPathExhausted(CPathNavigator &pathNavigator,
+                                                      utility::ErrorContext &errorContext)
 {
-    std::string* pStrChildName = pathNavigator.next();
+    std::string *pStrChildName = pathNavigator.next();
 
     if (pStrChildName) {
 

--- a/parameter/InstanceConfigurableElement.h
+++ b/parameter/InstanceConfigurableElement.h
@@ -44,7 +44,8 @@ class CParameterAccessContext;
 class PARAMETER_EXPORT CInstanceConfigurableElement : public CConfigurableElement
 {
 public:
-    enum Type {
+    enum Type
+    {
         EBitParameter,
         EBitParameterBlock,
         EParameter,
@@ -53,12 +54,12 @@ public:
         EComponent
     };
 
-    CInstanceConfigurableElement(const std::string& strName, const CTypeElement* pTypeElement);
+    CInstanceConfigurableElement(const std::string &strName, const CTypeElement *pTypeElement);
 
     // Instantiated type
-    const CTypeElement* getTypeElement() const;
+    const CTypeElement *getTypeElement() const;
 
-    virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const;
+    virtual bool getMappingData(const std::string &strKey, const std::string *&pStrValue) const;
 
     /**
      * Returns the mapping data associated to the type element of the current
@@ -73,17 +74,17 @@ public:
     std::string getXmlElementName() const override;
 
     // Syncer to/from HW
-    void setSyncer(ISyncer* pSyncer);
+    void setSyncer(ISyncer *pSyncer);
     void unsetSyncer();
 
     // Type
     virtual Type getType() const = 0;
 
     // Mapping execution
-    bool map(IMapper& mapper, std::string& strError);
+    bool map(IMapper &mapper, std::string &strError);
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // Scalar or Array?
     bool isScalar() const;
@@ -94,7 +95,8 @@ public:
     /**
      * Get the list of all the ancestors that have a mapping.
      *
-     * The mapping is represented as a std::string of all the mapping data (key:value) defined in the
+     * The mapping is represented as a std::string of all the mapping data (key:value) defined in
+     * the
      * context of the element.
      * In this class, the method is generic and calls its parent getListOfElementsWithMappings(...)
      * method.
@@ -103,16 +105,17 @@ public:
      * that have a mapping. Elements are added at the end of the list, so the root Element will be
      * the last one.
      */
-    virtual void getListOfElementsWithMapping(std::list<const CConfigurableElement*>&
-                                               configurableElementPath) const;
+    virtual void getListOfElementsWithMapping(
+        std::list<const CConfigurableElement *> &configurableElementPath) const;
 
-    virtual void structureToXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
+    virtual void structureToXml(CXmlElement &xmlElement,
+                                CXmlSerializingContext &serializingContext) const;
 
 protected:
     // Syncer
-    virtual ISyncer* getSyncer() const;
+    virtual ISyncer *getSyncer() const;
     // Syncer set (descendant)
-    virtual void fillSyncerSetFromDescendant(CSyncerSet& syncerSet) const;
+    virtual void fillSyncerSetFromDescendant(CSyncerSet &syncerSet) const;
 
     /**
      * Performs the sync if the AutoSync is enabled.
@@ -123,15 +126,16 @@ protected:
      *
      * @return true if the synchronization succeded or if the AutoSync is off, false otherwise.
      */
-    bool sync(CParameterAccessContext& parameterAccessContext) const;
+    bool sync(CParameterAccessContext &parameterAccessContext) const;
 
     // Check parameter access path well formed for leaf elements
-    static bool checkPathExhausted(CPathNavigator& pathNavigator, utility::ErrorContext& errorContext);
+    static bool checkPathExhausted(CPathNavigator &pathNavigator,
+                                   utility::ErrorContext &errorContext);
+
 private:
     // Type Element
-    const CTypeElement* _pTypeElement;
+    const CTypeElement *_pTypeElement;
 
     // Sync to HW
-    ISyncer* _pSyncer{nullptr};
+    ISyncer *_pSyncer{nullptr};
 };
-

--- a/parameter/InstanceDefinition.cpp
+++ b/parameter/InstanceDefinition.cpp
@@ -42,7 +42,7 @@ bool CInstanceDefinition::childrenAreDynamic() const
     return true;
 }
 
-CInstanceConfigurableElement* CInstanceDefinition::doInstantiate() const
+CInstanceConfigurableElement *CInstanceDefinition::doInstantiate() const
 {
     // Element not supposed to be instantiated direcly
     assert(0);
@@ -50,7 +50,7 @@ CInstanceConfigurableElement* CInstanceDefinition::doInstantiate() const
     return NULL;
 }
 
-void CInstanceDefinition::createInstances(CElement* pFatherElement)
+void CInstanceDefinition::createInstances(CElement *pFatherElement)
 {
     populate(pFatherElement);
 }

--- a/parameter/InstanceDefinition.h
+++ b/parameter/InstanceDefinition.h
@@ -36,10 +36,11 @@
 class CInstanceDefinition : public CTypeElement
 {
 public:
-    void createInstances(CElement* pFatherElement);
+    void createInstances(CElement *pFatherElement);
 
     virtual std::string getKind() const;
+
 private:
     virtual bool childrenAreDynamic() const;
-    virtual CInstanceConfigurableElement* doInstantiate() const;
+    virtual CInstanceConfigurableElement *doInstantiate() const;
 };

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -42,7 +42,7 @@
 using std::string;
 using std::ostringstream;
 
-CIntegerParameterType::CIntegerParameterType(const string& strName) : base(strName)
+CIntegerParameterType::CIntegerParameterType(const string &strName) : base(strName)
 {
 }
 
@@ -59,7 +59,7 @@ bool CIntegerParameterType::childrenAreDynamic() const
 }
 
 // Element properties
-void CIntegerParameterType::showProperties(string& strResult) const
+void CIntegerParameterType::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -79,7 +79,7 @@ void CIntegerParameterType::showProperties(string& strResult) const
     strResult += "\n";
 
     // Check if there's an adaptation object available
-    const CParameterAdaptation* pParameterAdaption = getParameterAdaptation();
+    const CParameterAdaptation *pParameterAdaption = getParameterAdaptation();
 
     if (pParameterAdaption) {
 
@@ -90,7 +90,8 @@ void CIntegerParameterType::showProperties(string& strResult) const
     }
 }
 
-bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CIntegerParameterType::fromXml(const CXmlElement &xmlElement,
+                                    CXmlSerializingContext &serializingContext)
 {
     // Sign
     xmlElement.getAttribute("Signed", _bSigned);
@@ -118,8 +119,8 @@ bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializi
 
             _uiMax = (1U << sizeInBits) - 1;
         }
-        signExtend((int32_t&)_uiMin);
-        signExtend((int32_t&)_uiMax);
+        signExtend((int32_t &)_uiMin);
+        signExtend((int32_t &)_uiMax);
     } else {
         if (!xmlElement.getAttribute("Min", _uiMin)) {
 
@@ -137,7 +138,8 @@ bool CIntegerParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializi
 }
 
 // Conversion (tuning)
-bool CIntegerParameterType::toBlackboard(const string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CIntegerParameterType::toBlackboard(const string &strValue, uint32_t &uiValue,
+                                         CParameterAccessContext &parameterAccessContext) const
 {
     // Hexa
     bool bValueProvidedAsHexa = utility::isHexadecimal(strValue);
@@ -159,13 +161,15 @@ bool CIntegerParameterType::toBlackboard(const string& strValue, uint32_t& uiVal
             signExtend(iData);
         }
 
-        if (!checkValueAgainstRange<int64_t>(strValue, iData, (int32_t)_uiMin, (int32_t)_uiMax, parameterAccessContext, bValueProvidedAsHexa)) {
+        if (!checkValueAgainstRange<int64_t>(strValue, iData, (int32_t)_uiMin, (int32_t)_uiMax,
+                                             parameterAccessContext, bValueProvidedAsHexa)) {
 
             return false;
         }
     } else {
 
-        if (!checkValueAgainstRange<uint64_t>(strValue, iData, _uiMin, _uiMax, parameterAccessContext, bValueProvidedAsHexa)) {
+        if (!checkValueAgainstRange<uint64_t>(strValue, iData, _uiMin, _uiMax,
+                                              parameterAccessContext, bValueProvidedAsHexa)) {
 
             return false;
         }
@@ -176,7 +180,8 @@ bool CIntegerParameterType::toBlackboard(const string& strValue, uint32_t& uiVal
     return true;
 }
 
-bool CIntegerParameterType::fromBlackboard(string& strValue, const uint32_t& value, CParameterAccessContext& parameterAccessContext) const
+bool CIntegerParameterType::fromBlackboard(string &strValue, const uint32_t &value,
+                                           CParameterAccessContext &parameterAccessContext) const
 {
     // Check unsigned value is encodable
     assert(isEncodable(value, false));
@@ -188,8 +193,8 @@ bool CIntegerParameterType::fromBlackboard(string& strValue, const uint32_t& val
     if (parameterAccessContext.valueSpaceIsRaw() && parameterAccessContext.outputRawFormatIsHex()) {
 
         // Hexa display with unecessary bits cleared out
-        stream << "0x" << std::hex << std::uppercase <<
-               std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0') << value;
+        stream << "0x" << std::hex << std::uppercase << std::setw(static_cast<int>(getSize() * 2))
+               << std::setfill('0') << value;
     } else {
 
         if (_bSigned) {
@@ -213,7 +218,8 @@ bool CIntegerParameterType::fromBlackboard(string& strValue, const uint32_t& val
 
 // Value access
 // Integer
-bool CIntegerParameterType::toBlackboard(uint32_t uiUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CIntegerParameterType::toBlackboard(uint32_t uiUserValue, uint32_t &uiValue,
+                                         CParameterAccessContext &parameterAccessContext) const
 {
     if (uiUserValue < _uiMin || uiUserValue > _uiMax) {
 
@@ -227,7 +233,8 @@ bool CIntegerParameterType::toBlackboard(uint32_t uiUserValue, uint32_t& uiValue
     return true;
 }
 
-bool CIntegerParameterType::fromBlackboard(uint32_t& uiUserValue, uint32_t uiValue, CParameterAccessContext& /*ctx*/) const
+bool CIntegerParameterType::fromBlackboard(uint32_t &uiUserValue, uint32_t uiValue,
+                                           CParameterAccessContext & /*ctx*/) const
 {
     // Do assign
     uiUserValue = uiValue;
@@ -236,7 +243,8 @@ bool CIntegerParameterType::fromBlackboard(uint32_t& uiUserValue, uint32_t uiVal
 }
 
 // Signed Integer
-bool CIntegerParameterType::toBlackboard(int32_t iUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CIntegerParameterType::toBlackboard(int32_t iUserValue, uint32_t &uiValue,
+                                         CParameterAccessContext &parameterAccessContext) const
 {
     if (iUserValue < (int32_t)_uiMin || iUserValue > (int32_t)_uiMax) {
 
@@ -250,7 +258,8 @@ bool CIntegerParameterType::toBlackboard(int32_t iUserValue, uint32_t& uiValue, 
     return true;
 }
 
-bool CIntegerParameterType::fromBlackboard(int32_t& iUserValue, uint32_t uiValue, CParameterAccessContext& /*ctx*/) const
+bool CIntegerParameterType::fromBlackboard(int32_t &iUserValue, uint32_t uiValue,
+                                           CParameterAccessContext & /*ctx*/) const
 {
     int32_t iValue = uiValue;
 
@@ -264,10 +273,11 @@ bool CIntegerParameterType::fromBlackboard(int32_t& iUserValue, uint32_t uiValue
 }
 
 // Double
-bool CIntegerParameterType::toBlackboard(double dUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CIntegerParameterType::toBlackboard(double dUserValue, uint32_t &uiValue,
+                                         CParameterAccessContext &parameterAccessContext) const
 {
     // Check if there's an adaptation object available
-    const CParameterAdaptation* pParameterAdaption = getParameterAdaptation();
+    const CParameterAdaptation *pParameterAdaption = getParameterAdaptation();
 
     if (!pParameterAdaption) {
 
@@ -303,10 +313,11 @@ bool CIntegerParameterType::toBlackboard(double dUserValue, uint32_t& uiValue, C
     return true;
 }
 
-bool CIntegerParameterType::fromBlackboard(double& dUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const
+bool CIntegerParameterType::fromBlackboard(double &dUserValue, uint32_t uiValue,
+                                           CParameterAccessContext &parameterAccessContext) const
 {
     // Check if there's an adaptation object available
-    const CParameterAdaptation* pParameterAdaption = getParameterAdaptation();
+    const CParameterAdaptation *pParameterAdaption = getParameterAdaptation();
 
     if (!pParameterAdaption) {
 
@@ -352,7 +363,9 @@ int CIntegerParameterType::toPlainInteger(int iSizeOptimizedData) const
 }
 
 // Convert value provided by the user as a string into an int64
-bool CIntegerParameterType::convertValueFromString(const string& strValue, int64_t& iData, CParameterAccessContext& parameterAccessContext) const {
+bool CIntegerParameterType::convertValueFromString(
+    const string &strValue, int64_t &iData, CParameterAccessContext &parameterAccessContext) const
+{
 
     // Reset errno to check if it is updated during the conversion (strtol/strtoul)
     errno = 0;
@@ -367,11 +380,12 @@ bool CIntegerParameterType::convertValueFromString(const string& strValue, int64
         iData = strtoull(strValue.c_str(), &pcStrEnd, 0);
     }
 
-    // Conversion error when the input string does not contain only digits or the number is out of range (int32_t type)
+    // Conversion error when the input string does not contain only digits or the number is out of
+    // range (int32_t type)
     if (errno || (*pcStrEnd != '\0')) {
 
         string strError;
-        strError =  "Impossible to convert value " + strValue + " for " + getKind();
+        strError = "Impossible to convert value " + strValue + " for " + getKind();
 
         parameterAccessContext.setError(strError);
 
@@ -382,7 +396,11 @@ bool CIntegerParameterType::convertValueFromString(const string& strValue, int64
 }
 
 // Range checking
-template <typename type> bool CIntegerParameterType::checkValueAgainstRange(const string& strValue, type value, type minValue, type maxValue, CParameterAccessContext& parameterAccessContext, bool bHexaValue) const
+template <typename type>
+bool CIntegerParameterType::checkValueAgainstRange(const string &strValue, type value,
+                                                   type minValue, type maxValue,
+                                                   CParameterAccessContext &parameterAccessContext,
+                                                   bool bHexaValue) const
 {
     if (value < minValue || value > maxValue) {
 
@@ -392,8 +410,8 @@ template <typename type> bool CIntegerParameterType::checkValueAgainstRange(cons
 
         if (bHexaValue) {
 
-            stream << "0x" << std::hex << std::uppercase <<
-                   std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0');
+            stream << "0x" << std::hex << std::uppercase
+                   << std::setw(static_cast<int>(getSize() * 2)) << std::setfill('0');
             // Format Min
             stream << minValue;
             // Format Max
@@ -401,7 +419,7 @@ template <typename type> bool CIntegerParameterType::checkValueAgainstRange(cons
 
         } else {
 
-            stream << minValue << ", " <<  maxValue;
+            stream << minValue << ", " << maxValue;
         }
 
         stream << "] for " << getKind();
@@ -414,13 +432,14 @@ template <typename type> bool CIntegerParameterType::checkValueAgainstRange(cons
 }
 
 // Adaptation element retrieval
-const CParameterAdaptation* CIntegerParameterType::getParameterAdaptation() const
+const CParameterAdaptation *CIntegerParameterType::getParameterAdaptation() const
 {
-    return static_cast<const CParameterAdaptation*>(findChildOfKind("Adaptation"));
+    return static_cast<const CParameterAdaptation *>(findChildOfKind("Adaptation"));
 }
 
 // From IXmlSource
-void CIntegerParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CIntegerParameterType::toXml(CXmlElement &xmlElement,
+                                  CXmlSerializingContext &serializingContext) const
 {
     // Sign
     xmlElement.setAttribute("Signed", _bSigned);
@@ -446,5 +465,4 @@ void CIntegerParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContex
     xmlElement.setAttribute("Size", getSize() * 8);
 
     base::toXml(xmlElement, serializingContext);
-
 }

--- a/parameter/IntegerParameterType.h
+++ b/parameter/IntegerParameterType.h
@@ -39,33 +39,41 @@ class CParameterAdaptation;
 class CIntegerParameterType : public CParameterType
 {
 public:
-    CIntegerParameterType(const std::string& strName);
+    CIntegerParameterType(const std::string &strName);
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     /// Conversion
     // String
-    virtual bool toBlackboard(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(std::string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(const std::string &strValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(std::string &strValue, const uint32_t &uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Integer
-    virtual bool toBlackboard(uint32_t uiUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(uint32_t& uiUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(uint32_t uiUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(uint32_t &uiUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Signed Integer
-    virtual bool toBlackboard(int32_t iUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(int32_t& iUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(int32_t iUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(int32_t &iUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Double
-    virtual bool toBlackboard(double dUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(double& dUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(double dUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(double &dUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
 
     // Default value handling (simulation only)
     virtual uint32_t getDefaultValue() const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // Integer conversion
     virtual int toPlainInteger(int iSizeOptimizedData) const;
@@ -78,13 +86,17 @@ private:
     virtual bool childrenAreDynamic() const;
 
     // Conversion from std::string
-    bool convertValueFromString(const std::string& strValue, int64_t& iData, CParameterAccessContext& parameterAccessContext) const;
+    bool convertValueFromString(const std::string &strValue, int64_t &iData,
+                                CParameterAccessContext &parameterAccessContext) const;
 
     // Range checking
-    template <typename type> bool checkValueAgainstRange(const std::string& strValue, type value, type minValue, type maxValue, CParameterAccessContext& parameterAccessContext, bool bHexaValue) const;
+    template <typename type>
+    bool checkValueAgainstRange(const std::string &strValue, type value, type minValue,
+                                type maxValue, CParameterAccessContext &parameterAccessContext,
+                                bool bHexaValue) const;
 
     // Adaptation element retrieval
-    const CParameterAdaptation* getParameterAdaptation() const;
+    const CParameterAdaptation *getParameterAdaptation() const;
 
     // Signing
     bool _bSigned{false};

--- a/parameter/KindElement.h
+++ b/parameter/KindElement.h
@@ -36,15 +36,12 @@
 class CKindElement : public CElement
 {
 public:
-    CKindElement(const std::string& strName, const std::string& strKind) : CElement(strName), _strKind(strKind)
+    CKindElement(const std::string &strName, const std::string &strKind)
+        : CElement(strName), _strKind(strKind)
     {
     }
 
-    virtual std::string getKind() const
-    {
-        return _strKind;
-    }
+    virtual std::string getKind() const { return _strKind; }
 private:
-
     std::string _strKind;
 };

--- a/parameter/KindElementBuilderTemplate.h
+++ b/parameter/KindElementBuilderTemplate.h
@@ -37,7 +37,7 @@ class TKindElementBuilderTemplate : public CElementBuilder
 public:
     TKindElementBuilderTemplate() : CElementBuilder() {}
 
-    virtual CElement* createElement(const CXmlElement& xmlElement) const
+    virtual CElement *createElement(const CXmlElement &xmlElement) const
     {
         return new ElementType(xmlElement.getNameAttribute(), xmlElement.getType());
     }

--- a/parameter/LinearParameterAdaptation.cpp
+++ b/parameter/LinearParameterAdaptation.cpp
@@ -37,13 +37,12 @@ CLinearParameterAdaptation::CLinearParameterAdaptation() : base("Linear")
 {
 }
 
-CLinearParameterAdaptation::CLinearParameterAdaptation(const string& strType) :
-    base(strType)
+CLinearParameterAdaptation::CLinearParameterAdaptation(const string &strType) : base(strType)
 {
 }
 
 // Element properties
-void CLinearParameterAdaptation::showProperties(string& strResult) const
+void CLinearParameterAdaptation::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -59,17 +58,19 @@ void CLinearParameterAdaptation::showProperties(string& strResult) const
 }
 
 // From IXmlSink
-bool CLinearParameterAdaptation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CLinearParameterAdaptation::fromXml(const CXmlElement &xmlElement,
+                                         CXmlSerializingContext &serializingContext)
 {
     // Get SlopeNumerator
     xmlElement.getAttribute("SlopeNumerator", _dSlopeNumerator);
 
     // Get SlopeDenominator
-    if (xmlElement.getAttribute("SlopeDenominator", _dSlopeDenominator)
-        && (_dSlopeDenominator == 0)) {
+    if (xmlElement.getAttribute("SlopeDenominator", _dSlopeDenominator) &&
+        (_dSlopeDenominator == 0)) {
 
         // Avoid by 0 division errors
-        serializingContext.setError("SlopeDenominator attribute can't be 0 on element" + xmlElement.getPath());
+        serializingContext.setError("SlopeDenominator attribute can't be 0 on element" +
+                                    xmlElement.getPath());
         return false;
     }
 

--- a/parameter/LinearParameterAdaptation.h
+++ b/parameter/LinearParameterAdaptation.h
@@ -37,17 +37,18 @@ class CLinearParameterAdaptation : public CParameterAdaptation
 {
 public:
     CLinearParameterAdaptation();
-    CLinearParameterAdaptation(const std::string& strType);
+    CLinearParameterAdaptation(const std::string &strType);
 
     // Conversions
     virtual int64_t fromUserValue(double dValue) const;
     virtual double toUserValue(int64_t iValue) const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
+
 private:
     // Slope attributes
     double _dSlopeNumerator{1};

--- a/parameter/LogarithmicParameterAdaptation.cpp
+++ b/parameter/LogarithmicParameterAdaptation.cpp
@@ -38,12 +38,12 @@
 CLogarithmicParameterAdaptation::CLogarithmicParameterAdaptation() : base("Logarithmic")
 {
     static_assert(std::numeric_limits<double>::is_iec559,
-            "Only double-precision floating points that are compliant with"
-            " IEC 559 (aka IEEE 754) are supported");
+                  "Only double-precision floating points that are compliant with"
+                  " IEC 559 (aka IEEE 754) are supported");
 }
 
 // Element properties
-void CLogarithmicParameterAdaptation::showProperties(std::string& strResult) const
+void CLogarithmicParameterAdaptation::showProperties(std::string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -55,14 +55,14 @@ void CLogarithmicParameterAdaptation::showProperties(std::string& strResult) con
     strResult += "\n";
 }
 
-bool CLogarithmicParameterAdaptation::fromXml(const CXmlElement& xmlElement,
-                                            CXmlSerializingContext& serializingContext)
+bool CLogarithmicParameterAdaptation::fromXml(const CXmlElement &xmlElement,
+                                              CXmlSerializingContext &serializingContext)
 {
-    if (xmlElement.getAttribute("LogarithmBase", _dLogarithmBase)
-        && (_dLogarithmBase <= 0 || _dLogarithmBase == 1)) {
+    if (xmlElement.getAttribute("LogarithmBase", _dLogarithmBase) &&
+        (_dLogarithmBase <= 0 || _dLogarithmBase == 1)) {
         // Avoid negative and 1 values
-        serializingContext.setError("LogarithmBase attribute cannot be negative or 1 on element"
-                                    + xmlElement.getPath());
+        serializingContext.setError("LogarithmBase attribute cannot be negative or 1 on element" +
+                                    xmlElement.getPath());
 
         return false;
     }
@@ -73,11 +73,10 @@ bool CLogarithmicParameterAdaptation::fromXml(const CXmlElement& xmlElement,
     return base::fromXml(xmlElement, serializingContext);
 }
 
-
 int64_t CLogarithmicParameterAdaptation::fromUserValue(double value) const
 {
     return std::max(base::fromUserValue(log(value) / log(_dLogarithmBase)),
-                        static_cast<int64_t>(_dFloorValue));
+                    static_cast<int64_t>(_dFloorValue));
 }
 
 double CLogarithmicParameterAdaptation::toUserValue(int64_t iValue) const

--- a/parameter/LogarithmicParameterAdaptation.h
+++ b/parameter/LogarithmicParameterAdaptation.h
@@ -56,9 +56,10 @@ public:
     virtual int64_t fromUserValue(double dValue) const;
     virtual double toUserValue(int64_t iValue) const;
 
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
+
 private:
     /**
      * _dLogarithmBase characterizes the new logarithm logB(x) with

--- a/parameter/LoggingElementBuilderTemplate.cpp
+++ b/parameter/LoggingElementBuilderTemplate.cpp
@@ -33,8 +33,8 @@
 
 namespace detail
 {
-    std::string getName(const CXmlElement& xmlElement)
-    {
-        return xmlElement.getNameAttribute();
-    }
+std::string getName(const CXmlElement &xmlElement)
+{
+    return xmlElement.getNameAttribute();
+}
 }

--- a/parameter/LoggingElementBuilderTemplate.h
+++ b/parameter/LoggingElementBuilderTemplate.h
@@ -57,7 +57,7 @@ namespace detail
  * empty string if attribute is not present
  *
  */
-std::string PARAMETER_EXPORT getName(const CXmlElement& xmlElement);
+std::string PARAMETER_EXPORT getName(const CXmlElement &xmlElement);
 }
 
 /**
@@ -69,14 +69,12 @@ template <class ElementType>
 class TLoggingElementBuilderTemplate : public CElementBuilder
 {
 public:
-
     /**
      * Class Constructor
      *
      * @param[in] logger the logger provided by the client
      */
-    TLoggingElementBuilderTemplate(core::log::Logger& logger)
-        : CElementBuilder(), mLogger(logger)
+    TLoggingElementBuilderTemplate(core::log::Logger &logger) : CElementBuilder(), mLogger(logger)
     {
     }
 
@@ -87,12 +85,12 @@ public:
      *
      * @return pointer to the generated element
      */
-    virtual CElement* createElement(const CXmlElement& xmlElement) const
+    virtual CElement *createElement(const CXmlElement &xmlElement) const
     {
         return new ElementType(detail::getName(xmlElement), mLogger);
     }
-private:
 
+private:
     /** Application Logger */
-    core::log::Logger& mLogger;
+    core::log::Logger &mLogger;
 };

--- a/parameter/Mapper.h
+++ b/parameter/Mapper.h
@@ -36,7 +36,8 @@ class CInstanceConfigurableElement;
 class IMapper
 {
 public:
-    virtual bool mapBegin(CInstanceConfigurableElement* pInstanceConfigurableElement, bool& bKeepDiving, std::string& strError) = 0;
+    virtual bool mapBegin(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                          bool &bKeepDiving, std::string &strError) = 0;
     virtual void mapEnd() = 0;
 
 protected:

--- a/parameter/MappingContext.cpp
+++ b/parameter/MappingContext.cpp
@@ -35,7 +35,7 @@
 using std::string;
 
 // Item access
-bool CMappingContext::setItem(size_t itemType, const string* pStrKey, const string* pStrItem)
+bool CMappingContext::setItem(size_t itemType, const string *pStrKey, const string *pStrItem)
 {
     if (iSet(itemType)) {
         // Already set!
@@ -51,7 +51,7 @@ bool CMappingContext::setItem(size_t itemType, const string* pStrKey, const stri
     return true;
 }
 
-const string&  CMappingContext::getItem(size_t itemType) const
+const string &CMappingContext::getItem(size_t itemType) const
 {
     return *mItems[itemType].strItem;
 }
@@ -66,7 +66,7 @@ size_t CMappingContext::getItemAsInteger(size_t itemType) const
     return strtoul(mItems[itemType].strItem->c_str(), NULL, 0);
 }
 
-const string* CMappingContext::getItem(const string& strKey) const
+const string *CMappingContext::getItem(const string &strKey) const
 {
     auto itemFound = find_if(begin(mItems), end(mItems), [&](const SItem &item) {
         return item.strKey != NULL && strKey == *item.strKey;

--- a/parameter/MappingContext.h
+++ b/parameter/MappingContext.h
@@ -31,7 +31,6 @@
 
 #include "parameter_export.h"
 
-
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -40,9 +39,10 @@ class PARAMETER_EXPORT CMappingContext
 {
 private:
     // Item structure
-    struct SItem {
-        const std::string* strKey{nullptr};
-        const std::string* strItem{nullptr};
+    struct SItem
+    {
+        const std::string *strKey{nullptr};
+        const std::string *strItem{nullptr};
     };
 
 public:
@@ -58,8 +58,8 @@ public:
      *
      * @return False if already set, true else.
      */
-    bool setItem(size_t itemType, const std::string* pStrKey, const std::string* pStrItem);
-    const std::string& getItem(size_t itemType) const;
+    bool setItem(size_t itemType, const std::string *pStrKey, const std::string *pStrItem);
+    const std::string &getItem(size_t itemType) const;
     size_t getItemAsInteger(size_t itemType) const;
     /**
      * Get mapping item value from its key name.
@@ -68,7 +68,7 @@ public:
      *
      * @return Mapping item value pointer if found, NULL else.
      */
-    const std::string* getItem(const std::string& strKey) const;
+    const std::string *getItem(const std::string &strKey) const;
     bool iSet(size_t itemType) const;
 
 private:
@@ -77,4 +77,3 @@ private:
     using Items = std::vector<SItem>;
     Items mItems;
 };
-

--- a/parameter/MappingData.cpp
+++ b/parameter/MappingData.cpp
@@ -58,7 +58,6 @@ bool CMappingData::init(const std::string &rawMapping, std::string &error)
 
             // Get mapping value
             strValue = strMappingElement.substr(iFistDelimiterOccurrence + 1);
-
         }
 
         if (!addValue(strKey, strValue)) {
@@ -72,7 +71,7 @@ bool CMappingData::init(const std::string &rawMapping, std::string &error)
     return true;
 }
 
-bool CMappingData::getValue(const std::string& strkey, const std::string*& pStrValue) const
+bool CMappingData::getValue(const std::string &strkey, const std::string *&pStrValue) const
 {
     KeyToValueMapConstIterator it = _keyToValueMap.find(strkey);
 
@@ -90,7 +89,7 @@ std::string CMappingData::asString() const
     return utility::asString(_keyToValueMap, ", ", ":");
 }
 
-bool CMappingData::addValue(const std::string& strkey, const std::string& strValue)
+bool CMappingData::addValue(const std::string &strkey, const std::string &strValue)
 {
     if (_keyToValueMap.find(strkey) != _keyToValueMap.end()) {
 
@@ -100,4 +99,3 @@ bool CMappingData::addValue(const std::string& strkey, const std::string& strVal
 
     return true;
 }
-

--- a/parameter/MappingData.h
+++ b/parameter/MappingData.h
@@ -35,6 +35,7 @@
 class CMappingData
 {
     typedef std::map<std::string, std::string>::const_iterator KeyToValueMapConstIterator;
+
 public:
     /** Initialize mapping data through a raw value
      *
@@ -46,7 +47,7 @@ public:
     bool init(const std::string &rawMapping, std::string &error);
 
     // Query
-    bool getValue(const std::string& strkey, const std::string*& pStrValue) const;
+    bool getValue(const std::string &strkey, const std::string *&pStrValue) const;
 
     /**
      * Formats the mapping as a list of comma-space separated key:value pairs
@@ -56,7 +57,7 @@ public:
     std::string asString() const;
 
 private:
-    bool addValue(const std::string& strkey, const std::string& strValue);
+    bool addValue(const std::string &strkey, const std::string &strValue);
 
     std::map<std::string, std::string> _keyToValueMap;
 };

--- a/parameter/NamedElementBuilderTemplate.h
+++ b/parameter/NamedElementBuilderTemplate.h
@@ -35,7 +35,7 @@ template <class ElementType>
 class TNamedElementBuilderTemplate : public CElementBuilder
 {
 public:
-    virtual CElement* createElement(const CXmlElement& xmlElement) const
+    virtual CElement *createElement(const CXmlElement &xmlElement) const
     {
         return new ElementType(xmlElement.getNameAttribute());
     }

--- a/parameter/Parameter.cpp
+++ b/parameter/Parameter.cpp
@@ -37,7 +37,8 @@
 
 using std::string;
 
-CParameter::CParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
+CParameter::CParameter(const string &strName, const CTypeElement *pTypeElement)
+    : base(strName, pTypeElement)
 {
 }
 
@@ -47,20 +48,26 @@ CInstanceConfigurableElement::Type CParameter::getType() const
 }
 
 // XML configuration settings parsing/composing
-bool CParameter::serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const
+bool CParameter::serializeXmlSettings(CXmlElement &xmlConfigurationSettingsElementContent,
+                                      CConfigurationAccessContext &configurationAccessContext) const
 {
     // Check for value space
     handleValueSpaceAttribute(xmlConfigurationSettingsElementContent, configurationAccessContext);
 
     // Base
-    return base::serializeXmlSettings(xmlConfigurationSettingsElementContent, configurationAccessContext);
+    return base::serializeXmlSettings(xmlConfigurationSettingsElementContent,
+                                      configurationAccessContext);
 }
 
 // Value space handling for configuration import
-void CParameter::handleValueSpaceAttribute(CXmlElement& xmlConfigurableElementSettingsElement, CConfigurationAccessContext& configurationAccessContext) const
+void CParameter::handleValueSpaceAttribute(
+    CXmlElement &xmlConfigurableElementSettingsElement,
+    CConfigurationAccessContext &configurationAccessContext) const
 {
     // Delegate to type
-    static_cast<const CParameterType*>(getTypeElement())->handleValueSpaceAttribute(xmlConfigurableElementSettingsElement, configurationAccessContext);
+    static_cast<const CParameterType *>(getTypeElement())
+        ->handleValueSpaceAttribute(xmlConfigurableElementSettingsElement,
+                                    configurationAccessContext);
 }
 
 size_t CParameter::getFootPrint() const
@@ -70,62 +77,70 @@ size_t CParameter::getFootPrint() const
 
 size_t CParameter::getSize() const
 {
-    return static_cast<const CParameterType*>(getTypeElement())->getSize();
+    return static_cast<const CParameterType *>(getTypeElement())->getSize();
 }
 
 // Used for simulation and virtual subsystems
-void CParameter::setDefaultValues(CParameterAccessContext& parameterAccessContext) const
+void CParameter::setDefaultValues(CParameterAccessContext &parameterAccessContext) const
 {
     // Get default value from type
-    uint32_t uiDefaultValue = static_cast<const CParameterType*>(getTypeElement())->getDefaultValue();
+    uint32_t uiDefaultValue =
+        static_cast<const CParameterType *>(getTypeElement())->getDefaultValue();
 
     // Write blackboard
-    CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Beware this code works on little endian architectures only!
-    pBlackboard->writeInteger(&uiDefaultValue, getSize(), getOffset() - parameterAccessContext.getBaseOffset());
+    pBlackboard->writeInteger(&uiDefaultValue, getSize(),
+                              getOffset() - parameterAccessContext.getBaseOffset());
 }
 
 /// Actual parameter access
 // String access
-bool CParameter::doSetValue(const string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const
+bool CParameter::doSetValue(const string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     return doSet(strValue, offset, parameterAccessContext);
 }
 
-void CParameter::doGetValue(string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const
+void CParameter::doGetValue(string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const
 {
     doGet(strValue, offset, parameterAccessContext);
 }
 
 // Boolean access
-bool CParameter::access(bool& bValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CParameter::access(bool &bValue, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const
 {
     return doAccess(bValue, bSet, parameterAccessContext);
 }
 
 // Integer Access
-bool CParameter::access(uint32_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CParameter::access(uint32_t &uiValue, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const
 {
     return doAccess(uiValue, bSet, parameterAccessContext);
 }
 
 // Signed Integer Access
-bool CParameter::access(int32_t& iValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CParameter::access(int32_t &iValue, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const
 {
     return doAccess(iValue, bSet, parameterAccessContext);
 }
 
 // Double Access
-bool CParameter::access(double& dValue, bool bSet, CParameterAccessContext& parameterAccessContext) const
+bool CParameter::access(double &dValue, bool bSet,
+                        CParameterAccessContext &parameterAccessContext) const
 {
     return doAccess(dValue, bSet, parameterAccessContext);
 }
 
 // Generic Access
 template <typename type>
-bool CParameter::doAccess(type& value, bool bSet,
-                          CParameterAccessContext& parameterAccessContext) const
+bool CParameter::doAccess(type &value, bool bSet,
+                          CParameterAccessContext &parameterAccessContext) const
 {
     if (bSet) {
         // set value
@@ -134,10 +149,9 @@ bool CParameter::doAccess(type& value, bool bSet,
 
             appendParameterPathToError(parameterAccessContext);
             return false;
-
         }
         // Synchronize
-        if (!sync(parameterAccessContext)){
+        if (!sync(parameterAccessContext)) {
 
             appendParameterPathToError(parameterAccessContext);
             return false;
@@ -155,16 +169,18 @@ bool CParameter::doAccess(type& value, bool bSet,
 }
 
 template <typename type>
-bool CParameter::doSet(type value, size_t offset, CParameterAccessContext& parameterAccessContext) const
+bool CParameter::doSet(type value, size_t offset,
+                       CParameterAccessContext &parameterAccessContext) const
 {
     uint32_t uiData;
 
-    if (!static_cast<const CParameterType*>(getTypeElement())->toBlackboard(value, uiData, parameterAccessContext)) {
+    if (!static_cast<const CParameterType *>(getTypeElement())
+             ->toBlackboard(value, uiData, parameterAccessContext)) {
 
         return false;
     }
     // Write blackboard
-    CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Beware this code works on little endian architectures only!
     pBlackboard->writeInteger(&uiData, getSize(), offset);
@@ -173,15 +189,17 @@ bool CParameter::doSet(type value, size_t offset, CParameterAccessContext& param
 }
 
 template <typename type>
-bool CParameter::doGet(type& value, size_t offset, CParameterAccessContext& parameterAccessContext) const
+bool CParameter::doGet(type &value, size_t offset,
+                       CParameterAccessContext &parameterAccessContext) const
 {
     uint32_t uiData = 0;
 
     // Read blackboard
-    const CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    const CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     // Beware this code works on little endian architectures only!
     pBlackboard->readInteger(&uiData, getSize(), offset);
 
-    return static_cast<const CParameterType*>(getTypeElement())->fromBlackboard(value, uiData, parameterAccessContext);
+    return static_cast<const CParameterType *>(getTypeElement())
+        ->fromBlackboard(value, uiData, parameterAccessContext);
 }

--- a/parameter/Parameter.h
+++ b/parameter/Parameter.h
@@ -38,7 +38,7 @@
 class CParameter : public CBaseParameter
 {
 public:
-    CParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    CParameter(const std::string &strName, const CTypeElement *pTypeElement);
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;
@@ -47,39 +47,49 @@ public:
     virtual Type getType() const;
 
     // XML configuration settings parsing/composing
-    virtual bool serializeXmlSettings(CXmlElement& xmlConfigurationSettingsElementContent, CConfigurationAccessContext& configurationAccessContext) const;
+    virtual bool serializeXmlSettings(
+        CXmlElement &xmlConfigurationSettingsElementContent,
+        CConfigurationAccessContext &configurationAccessContext) const;
 
     // Boolean access
-    bool access(bool& bValue, bool bSet, CParameterAccessContext& parameterAccessContext) const override;
+    bool access(bool &bValue, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override;
 
     // Integer Access
-    bool access(uint32_t& uiValue, bool bSet, CParameterAccessContext& parameterAccessContext) const override;
+    bool access(uint32_t &uiValue, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override;
 
     // Signed Integer Access
-    bool access(int32_t& iValue, bool bSet, CParameterAccessContext& parameterAccessContext) const override;
+    bool access(int32_t &iValue, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override;
 
     // Double Access
-    bool access(double& dValue, bool bSet, CParameterAccessContext& parameterAccessContext) const override;
+    bool access(double &dValue, bool bSet,
+                CParameterAccessContext &parameterAccessContext) const override;
 
 protected:
     // Used for simulation and virtual subsystems
-    virtual void setDefaultValues(CParameterAccessContext& parameterAccessContext) const;
+    virtual void setDefaultValues(CParameterAccessContext &parameterAccessContext) const;
 
     // Actual value access
-    virtual bool doSetValue(const std::string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const;
-    virtual void doGetValue(std::string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool doSetValue(const std::string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const;
+    virtual void doGetValue(std::string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const;
 
     // Value space handling for configuration import
-    void handleValueSpaceAttribute(CXmlElement& xmlConfigurableElementSettingsElement, CConfigurationAccessContext& configurationAccessContext) const;
+    void handleValueSpaceAttribute(CXmlElement &xmlConfigurableElementSettingsElement,
+                                   CConfigurationAccessContext &configurationAccessContext) const;
 
     // Size
     size_t getSize() const;
+
 private:
     // Generic Access
     template <typename type>
-    bool doAccess(type& value, bool bSet, CParameterAccessContext& parameterAccessContext) const;
+    bool doAccess(type &value, bool bSet, CParameterAccessContext &parameterAccessContext) const;
     template <typename type>
-    bool doSet(type value, size_t offset, CParameterAccessContext& parameterAccessContext) const;
+    bool doSet(type value, size_t offset, CParameterAccessContext &parameterAccessContext) const;
     template <typename type>
-    bool doGet(type& value, size_t offset, CParameterAccessContext& parameterAccessContext) const;
+    bool doGet(type &value, size_t offset, CParameterAccessContext &parameterAccessContext) const;
 };

--- a/parameter/ParameterAccessContext.cpp
+++ b/parameter/ParameterAccessContext.cpp
@@ -31,36 +31,34 @@
 
 #define base utility::ErrorContext
 
-CParameterAccessContext::CParameterAccessContext(std::string& strError,
-                                                 CParameterBlackboard* pParameterBlackboard,
-                                                 bool bValueSpaceIsRaw,
-                                                 bool bOutputRawFormatIsHex,
+CParameterAccessContext::CParameterAccessContext(std::string &strError,
+                                                 CParameterBlackboard *pParameterBlackboard,
+                                                 bool bValueSpaceIsRaw, bool bOutputRawFormatIsHex,
                                                  size_t baseOffset)
     : base(strError), _pParameterBlackboard(pParameterBlackboard),
-    _bValueSpaceIsRaw(bValueSpaceIsRaw), _bOutputRawFormatIsHex(bOutputRawFormatIsHex),
-    _uiBaseOffset(baseOffset)
+      _bValueSpaceIsRaw(bValueSpaceIsRaw), _bOutputRawFormatIsHex(bOutputRawFormatIsHex),
+      _uiBaseOffset(baseOffset)
 {
 }
 
-CParameterAccessContext::CParameterAccessContext(std::string& strError,
-                                                 CParameterBlackboard* pParameterBlackboard,
+CParameterAccessContext::CParameterAccessContext(std::string &strError,
+                                                 CParameterBlackboard *pParameterBlackboard,
                                                  size_t baseOffset)
     : base(strError), _pParameterBlackboard(pParameterBlackboard), _uiBaseOffset(baseOffset)
 {
 }
 
-CParameterAccessContext::CParameterAccessContext(std::string& strError)
-    : base(strError)
+CParameterAccessContext::CParameterAccessContext(std::string &strError) : base(strError)
 {
 }
 
 // ParameterBlackboard
-CParameterBlackboard* CParameterAccessContext::getParameterBlackboard()
+CParameterBlackboard *CParameterAccessContext::getParameterBlackboard()
 {
     return _pParameterBlackboard;
 }
 
-void CParameterAccessContext::setParameterBlackboard(CParameterBlackboard* pBlackboard)
+void CParameterAccessContext::setParameterBlackboard(CParameterBlackboard *pBlackboard)
 {
     _pParameterBlackboard = pBlackboard;
     _uiBaseOffset = 0;

--- a/parameter/ParameterAccessContext.h
+++ b/parameter/ParameterAccessContext.h
@@ -38,19 +38,16 @@ class CParameterBlackboard;
 class CParameterAccessContext : public utility::ErrorContext
 {
 public:
-    CParameterAccessContext(std::string& strError,
-                            CParameterBlackboard* pParameterBlackboard,
-                            bool bValueSpaceIsRaw,
-                            bool bOutputRawFormatIsHex,
+    CParameterAccessContext(std::string &strError, CParameterBlackboard *pParameterBlackboard,
+                            bool bValueSpaceIsRaw, bool bOutputRawFormatIsHex,
                             size_t offsetBase = 0);
-    CParameterAccessContext(std::string& strError,
-                            CParameterBlackboard* pParameterBlackboard,
+    CParameterAccessContext(std::string &strError, CParameterBlackboard *pParameterBlackboard,
                             size_t offsetBase = 0);
-    CParameterAccessContext(std::string& strError);
+    CParameterAccessContext(std::string &strError);
 
     // ParameterBlackboard
-    CParameterBlackboard* getParameterBlackboard();
-    void setParameterBlackboard(CParameterBlackboard* pBlackboard);
+    CParameterBlackboard *getParameterBlackboard();
+    void setParameterBlackboard(CParameterBlackboard *pBlackboard);
 
     // Value interpretation as Real or Raw
     void setValueSpaceRaw(bool bIsRaw);
@@ -86,7 +83,7 @@ public:
 
 private:
     // Blackboard
-    CParameterBlackboard* _pParameterBlackboard{nullptr};
+    CParameterBlackboard *_pParameterBlackboard{nullptr};
     // Value space
     bool _bValueSpaceIsRaw{false};
     // Output Raw Format
@@ -96,4 +93,3 @@ private:
     // Base offset where parameters are stored in configuration blackboards
     size_t _uiBaseOffset{0};
 };
-

--- a/parameter/ParameterAdaptation.cpp
+++ b/parameter/ParameterAdaptation.cpp
@@ -33,7 +33,7 @@
 
 using std::string;
 
-CParameterAdaptation::CParameterAdaptation(const string& strType) : base(strType)
+CParameterAdaptation::CParameterAdaptation(const string &strType) : base(strType)
 {
 }
 // CElement
@@ -49,7 +49,7 @@ int32_t CParameterAdaptation::getOffset() const
 }
 
 // Element properties
-void CParameterAdaptation::showProperties(string& strResult) const
+void CParameterAdaptation::showProperties(string &strResult) const
 {
     // Adaptation type
     strResult += " - Type: ";
@@ -63,7 +63,8 @@ void CParameterAdaptation::showProperties(string& strResult) const
 }
 
 // From IXmlSink
-bool CParameterAdaptation::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CParameterAdaptation::fromXml(const CXmlElement &xmlElement,
+                                   CXmlSerializingContext &serializingContext)
 {
     xmlElement.getAttribute("Offset", _iOffset);
 

--- a/parameter/ParameterAdaptation.h
+++ b/parameter/ParameterAdaptation.h
@@ -36,13 +36,13 @@
 class CParameterAdaptation : public CElement
 {
 public:
-    CParameterAdaptation(const std::string& strType);
+    CParameterAdaptation(const std::string &strType);
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // Conversions
     virtual int64_t fromUserValue(double dValue) const;
@@ -50,6 +50,7 @@ public:
 
     // CElement
     virtual std::string getKind() const;
+
 protected:
     // Attributes
     int32_t getOffset() const;
@@ -58,4 +59,3 @@ private:
     // Offset
     int32_t _iOffset{0};
 };
-

--- a/parameter/ParameterBlackboard.cpp
+++ b/parameter/ParameterBlackboard.cpp
@@ -44,7 +44,7 @@ size_t CParameterBlackboard::getSize() const
 }
 
 // Single parameter access
-void CParameterBlackboard::writeInteger(const void* pvSrcData, size_t size, size_t offset)
+void CParameterBlackboard::writeInteger(const void *pvSrcData, size_t size, size_t offset)
 {
     assertValidAccess(offset, size);
 
@@ -55,7 +55,7 @@ void CParameterBlackboard::writeInteger(const void* pvSrcData, size_t size, size
     std::copy(first, last, dest_first);
 }
 
-void CParameterBlackboard::readInteger(void* pvDstData, size_t size, size_t offset) const
+void CParameterBlackboard::readInteger(void *pvDstData, size_t size, size_t offset) const
 {
     assertValidAccess(offset, size);
 
@@ -85,24 +85,24 @@ void CParameterBlackboard::readString(std::string &output, size_t offset) const
     output = reinterpret_cast<const char *>(first);
 }
 
-void CParameterBlackboard::writeBuffer(const void* pvSrcData, size_t size, size_t offset)
+void CParameterBlackboard::writeBuffer(const void *pvSrcData, size_t size, size_t offset)
 {
     writeInteger(pvSrcData, size, offset);
 }
-void CParameterBlackboard::readBuffer(void* pvDstData, size_t size, size_t offset) const
+void CParameterBlackboard::readBuffer(void *pvDstData, size_t size, size_t offset) const
 {
     readInteger(pvDstData, size, offset);
 }
 
 // Element access
-void CParameterBlackboard::writeBytes(const std::vector<uint8_t>& bytes, size_t offset)
+void CParameterBlackboard::writeBytes(const std::vector<uint8_t> &bytes, size_t offset)
 {
     assertValidAccess(offset, bytes.size());
 
     std::copy(begin(bytes), end(bytes), atOffset(offset));
 }
 
-void CParameterBlackboard::readBytes(std::vector<uint8_t>& bytes, size_t offset) const
+void CParameterBlackboard::readBytes(std::vector<uint8_t> &bytes, size_t offset) const
 {
     assertValidAccess(offset, bytes.size());
 
@@ -110,21 +110,21 @@ void CParameterBlackboard::readBytes(std::vector<uint8_t>& bytes, size_t offset)
 }
 
 // Access from/to subsystems
-uint8_t* CParameterBlackboard::getLocation(size_t offset)
+uint8_t *CParameterBlackboard::getLocation(size_t offset)
 {
     assertValidAccess(offset, 1);
     return &mBlackboard[offset];
 }
 
 // Configuration handling
-void CParameterBlackboard::restoreFrom(const CParameterBlackboard* pFromBlackboard, size_t offset)
+void CParameterBlackboard::restoreFrom(const CParameterBlackboard *pFromBlackboard, size_t offset)
 {
     const auto &fromBB = pFromBlackboard->mBlackboard;
     assertValidAccess(offset, fromBB.size());
     std::copy(begin(fromBB), end(fromBB), atOffset(offset));
 }
 
-void CParameterBlackboard::saveTo(CParameterBlackboard* pToBlackboard, size_t offset) const
+void CParameterBlackboard::saveTo(CParameterBlackboard *pToBlackboard, size_t offset) const
 {
     auto &toBB = pToBlackboard->mBlackboard;
     assertValidAccess(offset, toBB.size());
@@ -133,7 +133,7 @@ void CParameterBlackboard::saveTo(CParameterBlackboard* pToBlackboard, size_t of
 
 void CParameterBlackboard::assertValidAccess(size_t offset, size_t size) const
 {
-    ALWAYS_ASSERT(offset + size <= getSize(), "Invalid data size access: offset=" << offset
-            << " size=" << size
-            << "reference size=" << getSize());
+    ALWAYS_ASSERT(offset + size <= getSize(),
+                  "Invalid data size access: offset=" << offset << " size=" << size
+                                                      << "reference size=" << getSize());
 }

--- a/parameter/ParameterBlackboard.h
+++ b/parameter/ParameterBlackboard.h
@@ -43,14 +43,14 @@ public:
     size_t getSize() const;
 
     // Single parameter access
-    void writeInteger(const void* pvSrcData, size_t size, size_t offset);
-    void readInteger(void* pvDstData, size_t size, size_t offset) const;
+    void writeInteger(const void *pvSrcData, size_t size, size_t offset);
+    void readInteger(void *pvDstData, size_t size, size_t offset) const;
 
     void writeString(const std::string &input, size_t offset);
     void readString(std::string &output, size_t offset) const;
 
-    void writeBuffer(const void* pvSrcData, size_t size, size_t offset);
-    void readBuffer(void* pvDstData, size_t size, size_t offset) const;
+    void writeBuffer(const void *pvSrcData, size_t size, size_t offset);
+    void readBuffer(void *pvDstData, size_t size, size_t offset) const;
 
     /**
      * Raw write the blackboard memory.
@@ -64,7 +64,7 @@ public:
      *    - This function asserts that the input vector's size + the offset
      *      does not exceed the size of the blackboard istelf.
      */
-    void writeBytes(const std::vector<uint8_t>& bytes, size_t offset);
+    void writeBytes(const std::vector<uint8_t> &bytes, size_t offset);
 
     /**
      * Raw read the blackboard memory.
@@ -80,14 +80,14 @@ public:
      *    - The user MUST resize the output vector to exactly the number of
      *      elements to be read
      */
-    void readBytes(std::vector<uint8_t>& bytes, size_t offset) const;
+    void readBytes(std::vector<uint8_t> &bytes, size_t offset) const;
 
     // Access from/to subsystems
-    uint8_t* getLocation(size_t offset);
+    uint8_t *getLocation(size_t offset);
 
     // Configuration handling
-    void restoreFrom(const CParameterBlackboard* pFromBlackboard, size_t offset);
-    void saveTo(CParameterBlackboard* pToBlackboard, size_t offset) const;
+    void restoreFrom(const CParameterBlackboard *pFromBlackboard, size_t offset);
+    void saveTo(CParameterBlackboard *pToBlackboard, size_t offset) const;
 
 private:
     void assertValidAccess(size_t offset, size_t size) const;
@@ -98,4 +98,3 @@ private:
     Blackboard::iterator atOffset(size_t offset) { return begin(mBlackboard) + offset; }
     Blackboard::const_iterator atOffset(size_t offset) const { return begin(mBlackboard) + offset; }
 };
-

--- a/parameter/ParameterBlock.h
+++ b/parameter/ParameterBlock.h
@@ -36,15 +36,11 @@
 class CParameterBlock : public CInstanceConfigurableElement
 {
 public:
-    CParameterBlock(const std::string& strName, const CTypeElement* pTypeElement)
+    CParameterBlock(const std::string &strName, const CTypeElement *pTypeElement)
         : CInstanceConfigurableElement(strName, pTypeElement)
     {
     }
 
     // Type
-    virtual Type getType() const
-    {
-        return EParameterBlock;
-    }
+    virtual Type getType() const { return EParameterBlock; }
 };
-

--- a/parameter/ParameterBlockType.cpp
+++ b/parameter/ParameterBlockType.cpp
@@ -33,7 +33,7 @@
 
 #define base CTypeElement
 
-CParameterBlockType::CParameterBlockType(const std::string& strName) : base(strName)
+CParameterBlockType::CParameterBlockType(const std::string &strName) : base(strName)
 {
 }
 
@@ -47,12 +47,12 @@ bool CParameterBlockType::childrenAreDynamic() const
     return true;
 }
 
-CInstanceConfigurableElement* CParameterBlockType::doInstantiate() const
+CInstanceConfigurableElement *CParameterBlockType::doInstantiate() const
 {
     return new CParameterBlock(getName(), this);
 }
 
-void CParameterBlockType::populate(CElement* pElement) const
+void CParameterBlockType::populate(CElement *pElement) const
 {
     size_t arrayLength = getArrayLength();
 
@@ -61,8 +61,8 @@ void CParameterBlockType::populate(CElement* pElement) const
         // Create child elements
         for (size_t child = 0; child < arrayLength; child++) {
 
-            CParameterBlock* pChildParameterBlock = new CParameterBlock(std::to_string(child),
-                                                                        this);
+            CParameterBlock *pChildParameterBlock =
+                new CParameterBlock(std::to_string(child), this);
 
             pElement->addChild(pChildParameterBlock);
 

--- a/parameter/ParameterBlockType.h
+++ b/parameter/ParameterBlockType.h
@@ -36,15 +36,15 @@
 class CParameterBlockType : public CTypeElement
 {
 public:
-    CParameterBlockType(const std::string& strName);
+    CParameterBlockType(const std::string &strName);
 
     // CElement
     virtual std::string getKind() const;
+
 private:
     virtual bool childrenAreDynamic() const;
     // Instantiation
-    virtual CInstanceConfigurableElement* doInstantiate() const;
+    virtual CInstanceConfigurableElement *doInstantiate() const;
     // Population
-    virtual void populate(CElement* pElement) const;
+    virtual void populate(CElement *pElement) const;
 };
-

--- a/parameter/ParameterFrameworkConfiguration.cpp
+++ b/parameter/ParameterFrameworkConfiguration.cpp
@@ -42,7 +42,7 @@ bool CParameterFrameworkConfiguration::childrenAreDynamic() const
 }
 
 // System class name
-const std::string& CParameterFrameworkConfiguration::getSystemClassName() const
+const std::string &CParameterFrameworkConfiguration::getSystemClassName() const
 {
     return _strSystemClassName;
 }
@@ -60,7 +60,8 @@ uint16_t CParameterFrameworkConfiguration::getServerPort() const
 }
 
 // From IXmlSink
-bool CParameterFrameworkConfiguration::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CParameterFrameworkConfiguration::fromXml(const CXmlElement &xmlElement,
+                                               CXmlSerializingContext &serializingContext)
 {
     // System class name
     xmlElement.getAttribute("SystemClassName", _strSystemClassName);

--- a/parameter/ParameterFrameworkConfiguration.h
+++ b/parameter/ParameterFrameworkConfiguration.h
@@ -37,7 +37,7 @@ class CParameterFrameworkConfiguration : public CElement
 {
 public:
     // System class name
-    const std::string& getSystemClassName() const;
+    const std::string &getSystemClassName() const;
 
     // Tuning allowed
     bool isTuningAllowed() const;
@@ -46,7 +46,8 @@ public:
     uint16_t getServerPort() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
+
 private:
     virtual std::string getKind() const;
     virtual bool childrenAreDynamic() const;

--- a/parameter/ParameterMgr.h
+++ b/parameter/ParameterMgr.h
@@ -65,13 +65,15 @@ class CConfigurableElement;
 
 class CParameterMgr : private CElement
 {
-    enum ChildElement {
+    enum ChildElement
+    {
         EFrameworkConfiguration,
         ESelectionCriteria,
         ESystemClass,
         EConfigurableDomains
     };
-    enum ElementLibrary {
+    enum ElementLibrary
+    {
         EFrameworkConfigurationLibrary,
         EParameterCreationLibrary,
         EParameterConfigurationLibrary
@@ -80,16 +82,17 @@ class CParameterMgr : private CElement
     // Remote command parsers
     typedef TRemoteCommandHandlerTemplate<CParameterMgr> CCommandHandler;
 
-    typedef CCommandHandler::CommandStatus (CParameterMgr::*RemoteCommandParser)(const IRemoteCommand& remoteCommand, std::string& strResult);
+    typedef CCommandHandler::CommandStatus (CParameterMgr::*RemoteCommandParser)(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
 
     // Parser descriptions
     struct SRemoteCommandParserItem
     {
-        const char* _pcCommandName;
+        const char *_pcCommandName;
         CParameterMgr::RemoteCommandParser _pfnParser;
         size_t _minArgumentCount;
-        const char* _pcHelp;
-        const char* _pcDescription;
+        const char *_pcHelp;
+        const char *_pcDescription;
     };
     // Version
     static const uint32_t guiEditionMajor = 3;
@@ -98,10 +101,10 @@ class CParameterMgr : private CElement
 
     // Parameter handle friendship
     friend class ElementHandle;
-public:
 
+public:
     // Construction
-    CParameterMgr(const std::string& strConfigurationFilePath, core::log::ILogger& logger);
+    CParameterMgr(const std::string &strConfigurationFilePath, core::log::ILogger &logger);
     virtual ~CParameterMgr();
 
     /** Load plugins, structures and settings from the config file given.
@@ -111,20 +114,21 @@ public:
       *
       * @return true if no error occurred, false otherwise.
       */
-    bool load(std::string& strError);
+    bool load(std::string &strError);
 
     // Selection Criteria
-    CSelectionCriterionType* createSelectionCriterionType(bool bIsInclusive);
-    CSelectionCriterion* createSelectionCriterion(const std::string& strName, const CSelectionCriterionType* pSelectionCriterionType);
+    CSelectionCriterionType *createSelectionCriterionType(bool bIsInclusive);
+    CSelectionCriterion *createSelectionCriterion(
+        const std::string &strName, const CSelectionCriterionType *pSelectionCriterionType);
     // Selection criterion retrieval
-    CSelectionCriterion* getSelectionCriterion(const std::string& strName);
+    CSelectionCriterion *getSelectionCriterion(const std::string &strName);
 
     // Configuration application
     void applyConfigurations();
 
     /** const version of getConfigurableElement */
-    const CConfigurableElement* getConfigurableElement(const std::string& strPath,
-                                                       std::string& strError) const;
+    const CConfigurableElement *getConfigurableElement(const std::string &strPath,
+                                                       std::string &strError) const;
 
     /** Returns the CConfigurableElement corresponding to the path given in argument.
      *
@@ -134,10 +138,9 @@ public:
      * @return A const pointer to the corresponding CConfigurableElement.
      * On error, NULL is returned and the error is explained in strError.
      */
-    CConfigurableElement* getConfigurableElement(const std::string& strPath,
-                                                 std::string& strError);
+    CConfigurableElement *getConfigurableElement(const std::string &strPath, std::string &strError);
     // Dynamic parameter handling
-    CParameterHandle* createParameterHandle(const std::string& strPath, std::string& strError);
+    CParameterHandle *createParameterHandle(const std::string &strPath, std::string &strError);
 
     /** Creates a handle to a configurable element.
      *
@@ -151,8 +154,6 @@ public:
      *         nullptr on error
      */
     ElementHandle *createElementHandle(const std::string &path, std::string &error);
-
-
 
     /** Is the remote interface forcefully disabled ?
      */
@@ -194,13 +195,13 @@ public:
      *
      * @returns the XML Schemas URI
      */
-    const std::string& getSchemaUri() const;
+    const std::string &getSchemaUri() const;
 
     /** Override the XML Schemas URI
      *
      * @param[in] schemaUri XML Schemas URI
      */
-    void setSchemaUri(const std::string& schemaUri);
+    void setSchemaUri(const std::string &schemaUri);
 
     /** Should .xml files be validated on start ?
      *
@@ -230,7 +231,7 @@ public:
      *         requested or in case of error.
      *         If false, strError is set with the associated human readable error.
      */
-    bool setTuningMode(bool bOn, std::string& strError);
+    bool setTuningMode(bool bOn, std::string &strError);
     bool tuningModeOn() const;
 
     // Current value space for user set/get value interpretation
@@ -242,12 +243,13 @@ public:
     bool outputRawFormatIsHex();
 
     // Automatic hardware synchronization control (during tuning session)
-    bool setAutoSync(bool bAutoSyncOn, std::string& strError);
+    bool setAutoSync(bool bAutoSyncOn, std::string &strError);
     bool autoSyncOn() const;
-    bool sync(std::string& strError);
+    bool sync(std::string &strError);
 
     // User set/get parameters
-    bool accessParameterValue(const std::string& strPath, std::string& strValue, bool bSet, std::string& strError);
+    bool accessParameterValue(const std::string &strPath, std::string &strValue, bool bSet,
+                              std::string &strError);
     /**
      * Returns the element mapping corresponding to the path given in parameter.
      *
@@ -256,23 +258,28 @@ public:
      *
      * @return true if a mapping was found for this element
      */
-    bool getParameterMapping(const std::string& strPath, std::string& strValue) const;
-    bool accessConfigurationValue(const std::string &strDomain, const std::string &stConfiguration, const std::string& strPath, std::string& strValue, bool bSet, std::string& strError);
+    bool getParameterMapping(const std::string &strPath, std::string &strValue) const;
+    bool accessConfigurationValue(const std::string &strDomain, const std::string &stConfiguration,
+                                  const std::string &strPath, std::string &strValue, bool bSet,
+                                  std::string &strError);
 
     ////////// Configuration/Domains handling //////////////
     // Creation/Deletion
-    bool createDomain(const std::string& strName, std::string& strError);
-    bool renameDomain(const std::string& strName, const std::string& strNewName,
-                      std::string& strError);
-    bool deleteDomain(const std::string& strName, std::string& strError);
-    bool deleteAllDomains(std::string& strError);
-    bool setSequenceAwareness(const std::string& strName, bool bSequenceAware,
-                              std::string& strResult);
-    bool getSequenceAwareness(const std::string& strName, bool& bSequenceAware,
-                              std::string& strResult);
-    bool createConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
-    bool deleteConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
-    bool renameConfiguration(const std::string& strDomain, const std::string& strConfiguration, const std::string& strNewConfiguration, std::string& strError);
+    bool createDomain(const std::string &strName, std::string &strError);
+    bool renameDomain(const std::string &strName, const std::string &strNewName,
+                      std::string &strError);
+    bool deleteDomain(const std::string &strName, std::string &strError);
+    bool deleteAllDomains(std::string &strError);
+    bool setSequenceAwareness(const std::string &strName, bool bSequenceAware,
+                              std::string &strResult);
+    bool getSequenceAwareness(const std::string &strName, bool &bSequenceAware,
+                              std::string &strResult);
+    bool createConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                             std::string &strError);
+    bool deleteConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                             std::string &strError);
+    bool renameConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                             const std::string &strNewConfiguration, std::string &strError);
 
     /** Restore a configuration
      *
@@ -281,26 +288,31 @@ public:
      * @param[out] errors errors encountered during restoration
      * @return true if success false otherwise
      */
-    bool restoreConfiguration(const std::string& strDomain,
-                              const std::string& strConfiguration,
-                              core::Results& errors);
+    bool restoreConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                              core::Results &errors);
 
-    bool saveConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
+    bool saveConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                           std::string &strError);
 
     // Configurable element - domain association
-    bool addConfigurableElementToDomain(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
-    bool removeConfigurableElementFromDomain(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
-    bool split(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
-    bool setElementSequence(const std::string& strDomain, const std::string& strConfiguration,
-                            const std::vector<std::string>& astrNewElementSequence,
-                            std::string& strError);
+    bool addConfigurableElementToDomain(const std::string &strDomain,
+                                        const std::string &strConfigurableElementPath,
+                                        std::string &strError);
+    bool removeConfigurableElementFromDomain(const std::string &strDomain,
+                                             const std::string &strConfigurableElementPath,
+                                             std::string &strError);
+    bool split(const std::string &strDomain, const std::string &strConfigurableElementPath,
+               std::string &strError);
+    bool setElementSequence(const std::string &strDomain, const std::string &strConfiguration,
+                            const std::vector<std::string> &astrNewElementSequence,
+                            std::string &strError);
 
-    bool getApplicationRule(const std::string& strDomain, const std::string& strConfiguration,
-                            std::string& strResult);
-    bool setApplicationRule(const std::string& strDomain, const std::string& strConfiguration,
-                            const std::string& strApplicationRule, std::string& strError);
-    bool clearApplicationRule(const std::string& strDomain, const std::string& strConfiguration,
-                              std::string& strError);
+    bool getApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                            std::string &strResult);
+    bool setApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                            const std::string &strApplicationRule, std::string &strError);
+    bool clearApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                              std::string &strError);
 
     /**
       * Method that imports Configurable Domains from an Xml source.
@@ -314,8 +326,8 @@ public:
       *
       * @return false if any error occures
       */
-    bool importDomainsXml(const std::string& xmlSource, bool withSettings, bool fromFile,
-                          std::string& errorMsg);
+    bool importDomainsXml(const std::string &xmlSource, bool withSettings, bool fromFile,
+                          std::string &errorMsg);
 
     /**
       * Method that imports a single Configurable Domain from an Xml source.
@@ -331,8 +343,8 @@ public:
       *
       * @return false if any error occurs
       */
-    bool importSingleDomainXml(const std::string& xmlSource, bool overwrite, bool withSettings,
-                               bool fromFile, std::string& errorMsg);
+    bool importSingleDomainXml(const std::string &xmlSource, bool overwrite, bool withSettings,
+                               bool fromFile, std::string &errorMsg);
 
     /**
       * Method that exports Configurable Domains to an Xml destination.
@@ -346,8 +358,8 @@ public:
       *
       * @return false if any error occurs, true otherwise.
       */
-    bool exportDomainsXml(std::string& xmlDest, bool withSettings, bool toFile,
-                          std::string& errorMsg) const;
+    bool exportDomainsXml(std::string &xmlDest, bool withSettings, bool toFile,
+                          std::string &errorMsg) const;
 
     /**
       * Method that exports a given Configurable Domain to an Xml destination.
@@ -362,8 +374,8 @@ public:
       *
       * @return false if any error occurs, true otherwise.
       */
-    bool exportSingleDomainXml(std::string& xmlDest, const std::string& domainName,
-                               bool withSettings, bool toFile, std::string& errorMsg) const;
+    bool exportSingleDomainXml(std::string &xmlDest, const std::string &domainName,
+                               bool withSettings, bool toFile, std::string &errorMsg) const;
 
     /**
       * Method that exports an Xml description of the passed element into a string
@@ -375,101 +387,161 @@ public:
       *                                  call to set the error.
       *                                  Additionally, using it for an other serialization would
       *                                  override the error.
-      * @param[out] strResult contains the xml description or the error description in case false is returned
+      * @param[out] strResult contains the xml description or the error description in case false is
+     * returned
       *
-      * @return true for success, false if any error occurs during the creation of the xml description (validation or encoding)
+      * @return true for success, false if any error occurs during the creation of the xml
+     * description (validation or encoding)
       */
-    bool exportElementToXMLString(const IXmlSource* pXmlSource,
-                                  const std::string& strRootElementType,
+    bool exportElementToXMLString(const IXmlSource *pXmlSource,
+                                  const std::string &strRootElementType,
                                   CXmlSerializingContext &&xmlSerializingContext,
-                                  std::string& strResult) const;
+                                  std::string &strResult) const;
 
     // CElement
     virtual std::string getKind() const;
 
 private:
-    CParameterMgr(const CParameterMgr&);
-    CParameterMgr& operator=(const CParameterMgr&);
+    CParameterMgr(const CParameterMgr &);
+    CParameterMgr &operator=(const CParameterMgr &);
 
     // Init
-    virtual bool init(std::string& strError);
+    virtual bool init(std::string &strError);
 
     // Version
     std::string getVersion() const;
 
     ////////////////:: Remote command parsers
     /// Version
-    CCommandHandler::CommandStatus versionCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus versionCommandProcess(const IRemoteCommand &remoteCommand,
+                                                         std::string &strResult);
     /// Status
-    CCommandHandler::CommandStatus statusCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus statusCommandProcess(const IRemoteCommand &remoteCommand,
+                                                        std::string &strResult);
     /// Tuning Mode
-    CCommandHandler::CommandStatus setTuningModeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getTuningModeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus setTuningModeCommandProcess(const IRemoteCommand &remoteCommand,
+                                                               std::string &strResult);
+    CCommandHandler::CommandStatus getTuningModeCommandProcess(const IRemoteCommand &remoteCommand,
+                                                               std::string &strResult);
     /// Value Space
-    CCommandHandler::CommandStatus setValueSpaceCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getValueSpaceCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus setValueSpaceCommandProcess(const IRemoteCommand &remoteCommand,
+                                                               std::string &strResult);
+    CCommandHandler::CommandStatus getValueSpaceCommandProcess(const IRemoteCommand &remoteCommand,
+                                                               std::string &strResult);
     /// Output Raw Format
-    CCommandHandler::CommandStatus setOutputRawFormatCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getOutputRawFormatCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus setOutputRawFormatCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus getOutputRawFormatCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
     /// Sync
-    CCommandHandler::CommandStatus setAutoSyncCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getAutoSyncCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus syncCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus setAutoSyncCommandProcess(const IRemoteCommand &remoteCommand,
+                                                             std::string &strResult);
+    CCommandHandler::CommandStatus getAutoSyncCommandProcess(const IRemoteCommand &remoteCommand,
+                                                             std::string &strResult);
+    CCommandHandler::CommandStatus syncCommandProcess(const IRemoteCommand &remoteCommand,
+                                                      std::string &strResult);
     /// Criteria
-    CCommandHandler::CommandStatus listCriteriaCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus listCriteriaCommandProcess(const IRemoteCommand &remoteCommand,
+                                                              std::string &strResult);
     /// Domains
-    CCommandHandler::CommandStatus listDomainsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus createDomainCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus deleteDomainCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus deleteAllDomainsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus renameDomainCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus setSequenceAwarenessCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getSequenceAwarenessCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus listDomainElementsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus addElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus removeElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus splitDomainCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus listDomainsCommandProcess(const IRemoteCommand &remoteCommand,
+                                                             std::string &strResult);
+    CCommandHandler::CommandStatus createDomainCommandProcess(const IRemoteCommand &remoteCommand,
+                                                              std::string &strResult);
+    CCommandHandler::CommandStatus deleteDomainCommandProcess(const IRemoteCommand &remoteCommand,
+                                                              std::string &strResult);
+    CCommandHandler::CommandStatus deleteAllDomainsCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus renameDomainCommandProcess(const IRemoteCommand &remoteCommand,
+                                                              std::string &strResult);
+    CCommandHandler::CommandStatus setSequenceAwarenessCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus getSequenceAwarenessCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus listDomainElementsCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus addElementCommandProcess(const IRemoteCommand &remoteCommand,
+                                                            std::string &strResult);
+    CCommandHandler::CommandStatus removeElementCommandProcess(const IRemoteCommand &remoteCommand,
+                                                               std::string &strResult);
+    CCommandHandler::CommandStatus splitDomainCommandProcess(const IRemoteCommand &remoteCommand,
+                                                             std::string &strResult);
     /// Configurations
-    CCommandHandler::CommandStatus listConfigurationsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus dumpDomainsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus createConfigurationCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus deleteConfigurationCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus renameConfigurationCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus saveConfigurationCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus restoreConfigurationCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus setElementSequenceCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getElementSequenceCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus setRuleCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus clearRuleCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getRuleCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus listConfigurationsCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus dumpDomainsCommandProcess(const IRemoteCommand &remoteCommand,
+                                                             std::string &strResult);
+    CCommandHandler::CommandStatus createConfigurationCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus deleteConfigurationCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus renameConfigurationCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus saveConfigurationCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus restoreConfigurationCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus setElementSequenceCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus getElementSequenceCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus setRuleCommandProcess(const IRemoteCommand &remoteCommand,
+                                                         std::string &strResult);
+    CCommandHandler::CommandStatus clearRuleCommandProcess(const IRemoteCommand &remoteCommand,
+                                                           std::string &strResult);
+    CCommandHandler::CommandStatus getRuleCommandProcess(const IRemoteCommand &remoteCommand,
+                                                         std::string &strResult);
     /// Elements/Parameters
-    CCommandHandler::CommandStatus listElementsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus listParametersCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getElementStructureXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus setElementBytesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getElementXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus setElementXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus dumpElementCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getElementSizeCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus showPropertiesCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getParameterCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus setParameterCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus getConfigurationParameterCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus setConfigurationParameterCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus listBelongingDomainsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus listAssociatedDomainsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus showMappingCommandProcess(const IRemoteCommand& remoteCommand,
-                                                              std::string& strResult);
+    CCommandHandler::CommandStatus listElementsCommandProcess(const IRemoteCommand &remoteCommand,
+                                                              std::string &strResult);
+    CCommandHandler::CommandStatus listParametersCommandProcess(const IRemoteCommand &remoteCommand,
+                                                                std::string &strResult);
+    CCommandHandler::CommandStatus getElementStructureXMLCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus getElementBytesCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus setElementBytesCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus getElementXMLCommandProcess(const IRemoteCommand &remoteCommand,
+                                                               std::string &strResult);
+    CCommandHandler::CommandStatus setElementXMLCommandProcess(const IRemoteCommand &remoteCommand,
+                                                               std::string &strResult);
+    CCommandHandler::CommandStatus dumpElementCommandProcess(const IRemoteCommand &remoteCommand,
+                                                             std::string &strResult);
+    CCommandHandler::CommandStatus getElementSizeCommandProcess(const IRemoteCommand &remoteCommand,
+                                                                std::string &strResult);
+    CCommandHandler::CommandStatus showPropertiesCommandProcess(const IRemoteCommand &remoteCommand,
+                                                                std::string &strResult);
+    CCommandHandler::CommandStatus getParameterCommandProcess(const IRemoteCommand &remoteCommand,
+                                                              std::string &strResult);
+    CCommandHandler::CommandStatus setParameterCommandProcess(const IRemoteCommand &remoteCommand,
+                                                              std::string &strResult);
+    CCommandHandler::CommandStatus getConfigurationParameterCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus setConfigurationParameterCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus listBelongingDomainsCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus listAssociatedDomainsCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus showMappingCommandProcess(const IRemoteCommand &remoteCommand,
+                                                             std::string &strResult);
     /// Browse
-    CCommandHandler::CommandStatus listAssociatedElementsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus listConflictingElementsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus listRogueElementsCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus listAssociatedElementsCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus listConflictingElementsCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus listRogueElementsCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
     /// Settings Import/Export
-    CCommandHandler::CommandStatus exportDomainsXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus importDomainsXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus exportDomainsWithSettingsXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
-    CCommandHandler::CommandStatus importDomainsWithSettingsXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus exportDomainsXMLCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus importDomainsXMLCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus exportDomainsWithSettingsXMLCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
+    CCommandHandler::CommandStatus importDomainsWithSettingsXMLCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
     /**
       * Command handler method for exportDomainWithSettingsXML command.
       *
@@ -479,8 +551,10 @@ private:
       * @return CCommandHandler::ESucceeded if command succeeded or CCommandHandler::EFailed
       * in the other case
       */
-    CCommandHandler::CommandStatus exportDomainWithSettingsXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& result);
-    CCommandHandler::CommandStatus importDomainWithSettingsXMLCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CCommandHandler::CommandStatus exportDomainWithSettingsXMLCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &result);
+    CCommandHandler::CommandStatus importDomainWithSettingsXMLCommandProcess(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /**
       * Command handler method for getDomainsWithSettings command.
@@ -492,7 +566,7 @@ private:
       * in the other case
       */
     CCommandHandler::CommandStatus getDomainsWithSettingsXMLCommandProcess(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+        const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /**
       * Command handler method for getDomainWithSettings command.
@@ -504,7 +578,7 @@ private:
       * in the other case
       */
     CCommandHandler::CommandStatus getDomainWithSettingsXMLCommandProcess(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+        const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /**
       * Command handler method for setDomainsWithSettings command.
@@ -516,7 +590,7 @@ private:
       * in the other case
       */
     CCommandHandler::CommandStatus setDomainsWithSettingsXMLCommandProcess(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+        const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /**
       * Command handler method for setDomainWithSettings command.
@@ -528,7 +602,7 @@ private:
       * in the other case
       */
     CCommandHandler::CommandStatus setDomainWithSettingsXMLCommandProcess(
-            const IRemoteCommand& remoteCommand, std::string& result);
+        const IRemoteCommand &remoteCommand, std::string &result);
 
     /**
       * Command handler method for getSystemClass command.
@@ -540,41 +614,44 @@ private:
       * in the other case
       */
     CCommandHandler::CommandStatus getSystemClassXMLCommandProcess(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+        const IRemoteCommand &remoteCommand, std::string &strResult);
 
     // Max command usage length, use for formatting
     void setMaxCommandUsageLength();
 
     // For tuning, check we're in tuning mode
-    bool checkTuningModeOn(std::string& strError) const;
+    bool checkTuningModeOn(std::string &strError) const;
 
     // Blackboard (dynamic parameter handling)
     std::mutex &getBlackboardMutex();
 
     // Blackboard reference (dynamic parameter handling)
-    CParameterBlackboard* getParameterBlackboard();
+    CParameterBlackboard *getParameterBlackboard();
 
     // Parameter access
-    bool accessValue(CParameterAccessContext& parameterAccessContext, const std::string& strPath, std::string& strValue, bool bSet, std::string& strError);
-    bool doSetValue(const std::string& strPath, const std::string& strValue, bool bRawValueSpace, bool bDynamicAccess, std::string& strError) const;
-    bool doGetValue(const std::string& strPath, std::string& strValue, bool bRawValueSpace, bool bHexOutputRawFormat, bool bDynamicAccess, std::string& strError) const;
+    bool accessValue(CParameterAccessContext &parameterAccessContext, const std::string &strPath,
+                     std::string &strValue, bool bSet, std::string &strError);
+    bool doSetValue(const std::string &strPath, const std::string &strValue, bool bRawValueSpace,
+                    bool bDynamicAccess, std::string &strError) const;
+    bool doGetValue(const std::string &strPath, std::string &strValue, bool bRawValueSpace,
+                    bool bHexOutputRawFormat, bool bDynamicAccess, std::string &strError) const;
 
     // Framework global configuration loading
-    bool loadFrameworkConfiguration(std::string& strError);
+    bool loadFrameworkConfiguration(std::string &strError);
 
     /** Load required subsystems
      *
      * @param[out] error error description if there is one
      * @return true if succeed false otherwise
      */
-    bool loadSubsystems(std::string& error);
+    bool loadSubsystems(std::string &error);
 
     // System class Structure loading
-    bool loadStructure(std::string& strError);
+    bool loadStructure(std::string &strError);
 
     // System class Structure loading
-    bool loadSettings(std::string& strError);
-    bool loadSettingsFromConfigFile(std::string& strError);
+    bool loadSettings(std::string &strError);
+    bool loadSettingsFromConfigFile(std::string &strError);
 
     /** Get settings from a configurable element in binary format.
      *
@@ -592,7 +669,8 @@ private:
      * @param[in] settings the settings as byte array (binary).
      * @param[out] error error message filled in case of error
      *
-     * @return true in case of success, false oherwise, in which case error is filled with error message.
+     * @return true in case of success, false oherwise, in which case error is filled with error
+     * message.
      */
     bool setSettingsAsBytes(const CConfigurableElement &element,
                             const std::vector<uint8_t> &settings, std::string &error);
@@ -631,10 +709,9 @@ private:
      *
      * @returns true if parsing succeeded, false otherwise
      */
-    bool xmlParse(CXmlElementSerializingContext& elementSerializingContext, CElement* pRootElement,
-                  _xmlDoc* doc, const std::string& baseUri,
-                  ElementLibrary eElementLibrary, bool replace = true,
-                  const std::string& strNameAttributeName = "Name");
+    bool xmlParse(CXmlElementSerializingContext &elementSerializingContext, CElement *pRootElement,
+                  _xmlDoc *doc, const std::string &baseUri, ElementLibrary eElementLibrary,
+                  bool replace = true, const std::string &strNameAttributeName = "Name");
 
     /** Wrapper for converting public APIs semantics to internal API
      *
@@ -661,9 +738,9 @@ private:
      *
      * @returns true if the import succeeded, false otherwise
      */
-    bool wrapLegacyXmlImport(const std::string& xmlSource, bool fromFile, bool withSettings,
-                             CElement& element, const std::string& nameAttributeName,
-                             std::string& errorMsg);
+    bool wrapLegacyXmlImport(const std::string &xmlSource, bool fromFile, bool withSettings,
+                             CElement &element, const std::string &nameAttributeName,
+                             std::string &errorMsg);
 
     /**
      * Export an element object to an Xml destination.
@@ -675,8 +752,8 @@ private:
      *
      * @return false if any error occurs, true otherwise.
      */
-    bool serializeElement(std::ostream& output, CXmlSerializingContext& xmlSerializingContext,
-                          const CElement& element) const;
+    bool serializeElement(std::ostream &output, CXmlSerializingContext &xmlSerializingContext,
+                          const CElement &element) const;
 
     /** Wrapper for converting public APIs semantics to internal API
      *
@@ -701,42 +778,39 @@ private:
      *
      * @returns true if the export succeeded, false otherwise
      */
-    bool wrapLegacyXmlExport(std::string& xmlDest, bool toFile, bool withSettings,
-                             const CElement& element, std::string& errorMsg) const;
+    bool wrapLegacyXmlExport(std::string &xmlDest, bool toFile, bool withSettings,
+                             const CElement &element, std::string &errorMsg) const;
 
     /** Wrapper for converting public APIs semantics to internal API
      *
      * @see wrapLegacyXmlExport
      */
-    bool wrapLegacyXmlExportToFile(std::string& xmlDest,
-                                   const CElement& element,
+    bool wrapLegacyXmlExportToFile(std::string &xmlDest, const CElement &element,
                                    CXmlDomainExportContext &context) const;
 
     /** Wrapper for converting public APIs semantics to internal API
      *
      * @see wrapLegacyXmlExport
      */
-    bool wrapLegacyXmlExportToString(std::string& xmlDest,
-                                     const CElement& element,
+    bool wrapLegacyXmlExportToString(std::string &xmlDest, const CElement &element,
                                      CXmlDomainExportContext &context) const;
 
-
     // Framework Configuration
-    CParameterFrameworkConfiguration* getFrameworkConfiguration();
-    const CParameterFrameworkConfiguration* getConstFrameworkConfiguration();
+    CParameterFrameworkConfiguration *getFrameworkConfiguration();
+    const CParameterFrameworkConfiguration *getConstFrameworkConfiguration();
 
     // Selection Criteria
-    CSelectionCriteria* getSelectionCriteria();
-    const CSelectionCriteria* getConstSelectionCriteria();
+    CSelectionCriteria *getSelectionCriteria();
+    const CSelectionCriteria *getConstSelectionCriteria();
 
     // System Class
-    CSystemClass* getSystemClass();
-    const CSystemClass* getConstSystemClass() const;
+    CSystemClass *getSystemClass();
+    const CSystemClass *getConstSystemClass() const;
 
     // Configurable Domains
-    CConfigurableDomains* getConfigurableDomains();
-    const CConfigurableDomains* getConstConfigurableDomains();
-    const CConfigurableDomains* getConstConfigurableDomains() const;
+    CConfigurableDomains *getConfigurableDomains();
+    const CConfigurableDomains *getConstConfigurableDomains();
+    const CConfigurableDomains *getConstConfigurableDomains() const;
 
     // Apply configurations
     void doApplyConfigurations(bool bForce);
@@ -745,7 +819,7 @@ private:
     void feedElementLibraries();
 
     // Remote Processor Server connection handling
-    bool handleRemoteProcessingInterface(std::string& strError);
+    bool handleRemoteProcessingInterface(std::string &strError);
 
     /** Log the result of a function
      *
@@ -753,7 +827,7 @@ private:
      * @param[in] result function provided result string
      * @return isSuccess parameter
      */
-    bool logResult(bool isSuccess, const std::string& result);
+    bool logResult(bool isSuccess, const std::string &result);
 
     /** Info logger call helper */
     inline core::log::details::Info info();
@@ -774,20 +848,20 @@ private:
     bool _bAutoSyncOn{true};
 
     // Current Parameter Settings
-    CParameterBlackboard* _pMainParameterBlackboard;
+    CParameterBlackboard *_pMainParameterBlackboard;
 
     // Dynamic object creation
-    CElementLibrarySet* _pElementLibrarySet;
+    CElementLibrarySet *_pElementLibrarySet;
 
     // XML parsing, object creation handling
     std::string _xmlConfigurationUri;
     std::string _schemaUri; // Place where schemas stand
 
     // Subsystem plugin location
-    const CSubsystemPlugins* _pSubsystemPlugins{nullptr};
+    const CSubsystemPlugins *_pSubsystemPlugins{nullptr};
 
     // Remote Processor Server
-    IRemoteProcessorServerInterface* _pRemoteProcessorServer{nullptr};
+    IRemoteProcessorServerInterface *_pRemoteProcessorServer{nullptr};
 
     // Parser description array
     static const SRemoteCommandParserItem gastRemoteCommandParserItems[];
@@ -824,4 +898,3 @@ private:
      */
     bool _bValidateSchemasOnStart{false};
 };
-

--- a/parameter/ParameterMgrFullConnector.cpp
+++ b/parameter/ParameterMgrFullConnector.cpp
@@ -35,8 +35,10 @@
 
 using std::string;
 
-CParameterMgrFullConnector::CParameterMgrFullConnector(const string& strConfigurationFilePath)
-    : CParameterMgrPlatformConnector(strConfigurationFilePath) {}
+CParameterMgrFullConnector::CParameterMgrFullConnector(const string &strConfigurationFilePath)
+    : CParameterMgrPlatformConnector(strConfigurationFilePath)
+{
+}
 
 void CParameterMgrFullConnector::setFailureOnMissingSubsystem(bool bFail)
 {
@@ -56,7 +58,7 @@ void CParameterMgrFullConnector::setValidateSchemasOnStart(bool bValidate)
     setValidateSchemasOnStart(bValidate, error);
 }
 
-bool CParameterMgrFullConnector::setTuningMode(bool bOn, string& strError)
+bool CParameterMgrFullConnector::setTuningMode(bool bOn, string &strError)
 {
     return _pParameterMgr->setTuningMode(bOn, strError);
 }
@@ -86,7 +88,7 @@ bool CParameterMgrFullConnector::isOutputRawFormatHex() const
     return _pParameterMgr->outputRawFormatIsHex();
 }
 
-bool CParameterMgrFullConnector::setAutoSync(bool bAutoSyncOn, string& strError)
+bool CParameterMgrFullConnector::setAutoSync(bool bAutoSyncOn, string &strError)
 {
     return _pParameterMgr->setAutoSync(bAutoSyncOn, strError);
 }
@@ -96,185 +98,182 @@ bool CParameterMgrFullConnector::isAutoSyncOn() const
     return _pParameterMgr->autoSyncOn();
 }
 
-bool CParameterMgrFullConnector::sync(string& strError)
+bool CParameterMgrFullConnector::sync(string &strError)
 {
     return _pParameterMgr->sync(strError);
 }
 
-bool CParameterMgrFullConnector::accessParameterValue(const string& strPath, string& strValue,
-                                                      bool bSet, string& strError)
+bool CParameterMgrFullConnector::accessParameterValue(const string &strPath, string &strValue,
+                                                      bool bSet, string &strError)
 {
     return _pParameterMgr->accessParameterValue(strPath, strValue, bSet, strError);
 }
 
 bool CParameterMgrFullConnector::accessConfigurationValue(const string &strDomain,
                                                           const string &strConfiguration,
-                                                          const string& strPath, string& strValue,
-                                                          bool bSet, string& strError)
+                                                          const string &strPath, string &strValue,
+                                                          bool bSet, string &strError)
 {
     return _pParameterMgr->accessConfigurationValue(strDomain, strConfiguration, strPath, strValue,
-            bSet, strError);
+                                                    bSet, strError);
 }
 
-bool CParameterMgrFullConnector::getParameterMapping(const string& strPath, string& strValue) const
+bool CParameterMgrFullConnector::getParameterMapping(const string &strPath, string &strValue) const
 {
     return _pParameterMgr->getParameterMapping(strPath, strValue);
 }
 
-bool CParameterMgrFullConnector::createDomain(const string& strName, string& strError)
+bool CParameterMgrFullConnector::createDomain(const string &strName, string &strError)
 {
     return _pParameterMgr->createDomain(strName, strError);
 }
 
-bool CParameterMgrFullConnector::deleteDomain(const string& strName, string& strError)
+bool CParameterMgrFullConnector::deleteDomain(const string &strName, string &strError)
 {
     return _pParameterMgr->deleteDomain(strName, strError);
 }
 
-bool CParameterMgrFullConnector::renameDomain(const string& strName, const string& strNewName,
-                                              string& strError)
+bool CParameterMgrFullConnector::renameDomain(const string &strName, const string &strNewName,
+                                              string &strError)
 {
     return _pParameterMgr->renameDomain(strName, strNewName, strError);
 }
 
-bool CParameterMgrFullConnector::deleteAllDomains(string& strError)
+bool CParameterMgrFullConnector::deleteAllDomains(string &strError)
 {
     return _pParameterMgr->deleteAllDomains(strError);
 }
 
-bool CParameterMgrFullConnector::createConfiguration(const string& strDomain,
-                                                     const string& strConfiguration,
-                                                     string& strError)
+bool CParameterMgrFullConnector::createConfiguration(const string &strDomain,
+                                                     const string &strConfiguration,
+                                                     string &strError)
 {
     return _pParameterMgr->createConfiguration(strDomain, strConfiguration, strError);
 }
 
-bool CParameterMgrFullConnector::deleteConfiguration(const string& strDomain,
-                                                     const string& strConfiguration,
-                                                     string& strError)
+bool CParameterMgrFullConnector::deleteConfiguration(const string &strDomain,
+                                                     const string &strConfiguration,
+                                                     string &strError)
 {
     return _pParameterMgr->deleteConfiguration(strDomain, strConfiguration, strError);
 }
 
-bool CParameterMgrFullConnector::renameConfiguration(const string& strDomain,
-                                                     const string& strConfiguration,
-                                                     const string& strNewConfiguration,
-                                                     string& strError)
+bool CParameterMgrFullConnector::renameConfiguration(const string &strDomain,
+                                                     const string &strConfiguration,
+                                                     const string &strNewConfiguration,
+                                                     string &strError)
 {
     return _pParameterMgr->renameConfiguration(strDomain, strConfiguration, strNewConfiguration,
-            strError);
+                                               strError);
 }
 
-bool CParameterMgrFullConnector::saveConfiguration(const string& strDomain,
-                                                   const string& strConfiguration, string& strError)
+bool CParameterMgrFullConnector::saveConfiguration(const string &strDomain,
+                                                   const string &strConfiguration, string &strError)
 {
     return _pParameterMgr->saveConfiguration(strDomain, strConfiguration, strError);
 }
 
-bool CParameterMgrFullConnector::restoreConfiguration(const string& strDomain,
-                                                      const string& strConfiguration,
-                                                      Results& errors)
+bool CParameterMgrFullConnector::restoreConfiguration(const string &strDomain,
+                                                      const string &strConfiguration,
+                                                      Results &errors)
 {
     return _pParameterMgr->restoreConfiguration(strDomain, strConfiguration, errors);
 }
 
-bool CParameterMgrFullConnector::setSequenceAwareness(const string& strName, bool bSequenceAware,
-                                                      string& strResult)
+bool CParameterMgrFullConnector::setSequenceAwareness(const string &strName, bool bSequenceAware,
+                                                      string &strResult)
 {
     return _pParameterMgr->setSequenceAwareness(strName, bSequenceAware, strResult);
 }
 
-bool CParameterMgrFullConnector::getSequenceAwareness(const string& strName, bool& bSequenceAware,
-                                                      string& strResult)
+bool CParameterMgrFullConnector::getSequenceAwareness(const string &strName, bool &bSequenceAware,
+                                                      string &strResult)
 {
     return _pParameterMgr->getSequenceAwareness(strName, bSequenceAware, strResult);
 }
 
-bool CParameterMgrFullConnector::addConfigurableElementToDomain(const string& strDomain,
-        const string& strConfigurableElementPath, string& strError)
+bool CParameterMgrFullConnector::addConfigurableElementToDomain(
+    const string &strDomain, const string &strConfigurableElementPath, string &strError)
 {
     return _pParameterMgr->addConfigurableElementToDomain(strDomain, strConfigurableElementPath,
-            strError);
+                                                          strError);
 }
 
-bool CParameterMgrFullConnector::removeConfigurableElementFromDomain(const string& strDomain,
-        const string& strConfigurableElementPath, string& strError)
+bool CParameterMgrFullConnector::removeConfigurableElementFromDomain(
+    const string &strDomain, const string &strConfigurableElementPath, string &strError)
 {
-    return _pParameterMgr->removeConfigurableElementFromDomain(strDomain,
-            strConfigurableElementPath, strError);
+    return _pParameterMgr->removeConfigurableElementFromDomain(
+        strDomain, strConfigurableElementPath, strError);
 }
 
-bool CParameterMgrFullConnector::split(const string& strDomain, 
-                                       const string& strConfigurableElementPath, string& strError)
+bool CParameterMgrFullConnector::split(const string &strDomain,
+                                       const string &strConfigurableElementPath, string &strError)
 {
     return _pParameterMgr->split(strDomain, strConfigurableElementPath, strError);
 }
 
-bool CParameterMgrFullConnector::setElementSequence(const string& strDomain,
-        const string& strConfiguration,
-        const std::vector<string>& astrNewElementSequence,
-        string& strError)
+bool CParameterMgrFullConnector::setElementSequence(
+    const string &strDomain, const string &strConfiguration,
+    const std::vector<string> &astrNewElementSequence, string &strError)
 {
     return _pParameterMgr->setElementSequence(strDomain, strConfiguration, astrNewElementSequence,
-            strError);
+                                              strError);
 }
 
-bool CParameterMgrFullConnector::setApplicationRule(const string& strDomain,
-                                                    const string& strConfiguration,
-                                                    const string& strApplicationRule,
-                                                    string& strError)
+bool CParameterMgrFullConnector::setApplicationRule(const string &strDomain,
+                                                    const string &strConfiguration,
+                                                    const string &strApplicationRule,
+                                                    string &strError)
 {
     return _pParameterMgr->setApplicationRule(strDomain, strConfiguration, strApplicationRule,
-            strError);
+                                              strError);
 }
 
-
-bool CParameterMgrFullConnector::getApplicationRule(const string& strDomain,
-                                                    const string& strConfiguration,
-                                                    string& strResult)
+bool CParameterMgrFullConnector::getApplicationRule(const string &strDomain,
+                                                    const string &strConfiguration,
+                                                    string &strResult)
 {
     return _pParameterMgr->getApplicationRule(strDomain, strConfiguration, strResult);
 }
-bool CParameterMgrFullConnector::clearApplicationRule(const string& strDomain,
-                                                      const string& strConfiguration,
-                                                      string& strError)
+bool CParameterMgrFullConnector::clearApplicationRule(const string &strDomain,
+                                                      const string &strConfiguration,
+                                                      string &strError)
 {
     return _pParameterMgr->clearApplicationRule(strDomain, strConfiguration, strError);
 }
 
-
-bool CParameterMgrFullConnector::importDomainsXml(const string& strXmlSource, bool bWithSettings,
-                                                  bool bFromFile, string& strError)
+bool CParameterMgrFullConnector::importDomainsXml(const string &strXmlSource, bool bWithSettings,
+                                                  bool bFromFile, string &strError)
 {
     return _pParameterMgr->importDomainsXml(strXmlSource, bWithSettings, bFromFile, strError);
 }
 
-bool CParameterMgrFullConnector::exportDomainsXml(string& strXmlDest, bool bWithSettings,
-                                                  bool bToFile, string& strError) const
+bool CParameterMgrFullConnector::exportDomainsXml(string &strXmlDest, bool bWithSettings,
+                                                  bool bToFile, string &strError) const
 {
     return _pParameterMgr->exportDomainsXml(strXmlDest, bWithSettings, bToFile, strError);
 }
 
 // deprecated, use the other version of importSingleDomainXml instead
-bool CParameterMgrFullConnector::importSingleDomainXml(const string& strXmlSource, bool bOverwrite,
-                                                       string& strError)
+bool CParameterMgrFullConnector::importSingleDomainXml(const string &strXmlSource, bool bOverwrite,
+                                                       string &strError)
 {
     return importSingleDomainXml(strXmlSource, bOverwrite, true, false, strError);
 }
 
-bool CParameterMgrFullConnector::importSingleDomainXml(const string& xmlSource, bool overwrite,
+bool CParameterMgrFullConnector::importSingleDomainXml(const string &xmlSource, bool overwrite,
                                                        bool withSettings, bool fromFile,
-                                                       string& errorMsg)
+                                                       string &errorMsg)
 {
     return _pParameterMgr->importSingleDomainXml(xmlSource, overwrite, withSettings, fromFile,
                                                  errorMsg);
 }
 
-bool CParameterMgrFullConnector::exportSingleDomainXml(string& strXmlDest,
-                                                       const string& strDomainName,
+bool CParameterMgrFullConnector::exportSingleDomainXml(string &strXmlDest,
+                                                       const string &strDomainName,
                                                        bool bWithSettings, bool bToFile,
-                                                       string& strError) const
+                                                       string &strError) const
 {
     return _pParameterMgr->exportSingleDomainXml(strXmlDest, strDomainName, bWithSettings, bToFile,
-            strError);
+                                                 strError);
 }

--- a/parameter/ParameterMgrLogger.h
+++ b/parameter/ParameterMgrLogger.h
@@ -37,27 +37,17 @@
 
 /* Wrap a class to expose its logging [info, warning] capabilities
  * through ILogger. */
-template<class T>
+template <class T>
 class CParameterMgrLogger : public core::log::ILogger, private utility::NonCopyable
 {
 public:
-    CParameterMgrLogger(T& parameterMgrConnector) :
-        _parameterMgrConnector(parameterMgrConnector)
-    {
-    }
+    CParameterMgrLogger(T &parameterMgrConnector) : _parameterMgrConnector(parameterMgrConnector) {}
 
-    virtual void info(const std::string& log)
-    {
-        _parameterMgrConnector.info(log);
-    }
+    virtual void info(const std::string &log) { _parameterMgrConnector.info(log); }
 
-    virtual void warning(const std::string& log)
-    {
-        _parameterMgrConnector.warning(log);
-    }
+    virtual void warning(const std::string &log) { _parameterMgrConnector.warning(log); }
 
 private:
     // Log destination
-    T& _parameterMgrConnector;
+    T &_parameterMgrConnector;
 };
-

--- a/parameter/ParameterMgrPlatformConnector.cpp
+++ b/parameter/ParameterMgrPlatformConnector.cpp
@@ -36,10 +36,10 @@ using std::string;
 
 // Construction
 CParameterMgrPlatformConnector::CParameterMgrPlatformConnector(
-        const string& strConfigurationFilePath) :
-    _pParameterMgrLogger(new CParameterMgrLogger<CParameterMgrPlatformConnector>(*this)),
-    _pParameterMgr(new CParameterMgr(strConfigurationFilePath, *_pParameterMgrLogger)),
-    _bStarted(false), _pLogger(NULL)
+    const string &strConfigurationFilePath)
+    : _pParameterMgrLogger(new CParameterMgrLogger<CParameterMgrPlatformConnector>(*this)),
+      _pParameterMgr(new CParameterMgr(strConfigurationFilePath, *_pParameterMgrLogger)),
+      _bStarted(false), _pLogger(NULL)
 {
 }
 
@@ -50,22 +50,26 @@ CParameterMgrPlatformConnector::~CParameterMgrPlatformConnector()
 }
 
 // Selection Criteria interface. Beware returned objects are lent, clients shall not delete them!
-ISelectionCriterionTypeInterface* CParameterMgrPlatformConnector::createSelectionCriterionType(bool bIsInclusive)
+ISelectionCriterionTypeInterface *CParameterMgrPlatformConnector::createSelectionCriterionType(
+    bool bIsInclusive)
 {
     assert(!_bStarted);
 
     return _pParameterMgr->createSelectionCriterionType(bIsInclusive);
 }
 
-ISelectionCriterionInterface* CParameterMgrPlatformConnector::createSelectionCriterion(const string& strName, const ISelectionCriterionTypeInterface* pSelectionCriterionType)
+ISelectionCriterionInterface *CParameterMgrPlatformConnector::createSelectionCriterion(
+    const string &strName, const ISelectionCriterionTypeInterface *pSelectionCriterionType)
 {
     assert(!_bStarted);
 
-    return _pParameterMgr->createSelectionCriterion(strName, static_cast<const CSelectionCriterionType*>(pSelectionCriterionType));
+    return _pParameterMgr->createSelectionCriterion(
+        strName, static_cast<const CSelectionCriterionType *>(pSelectionCriterionType));
 }
 
 // Selection criterion retrieval
-ISelectionCriterionInterface* CParameterMgrPlatformConnector::getSelectionCriterion(const string& strName) const
+ISelectionCriterionInterface *CParameterMgrPlatformConnector::getSelectionCriterion(
+    const string &strName) const
 {
     return _pParameterMgr->getSelectionCriterion(strName);
 }
@@ -79,21 +83,22 @@ void CParameterMgrPlatformConnector::applyConfigurations()
 }
 
 // Dynamic parameter handling
-CParameterHandle* CParameterMgrPlatformConnector::createParameterHandle(const string& strPath, string& strError) const
+CParameterHandle *CParameterMgrPlatformConnector::createParameterHandle(const string &strPath,
+                                                                        string &strError) const
 {
     assert(_bStarted);
 
     return _pParameterMgr->createParameterHandle(strPath, strError);
 }
 
-ElementHandle* CParameterMgrPlatformConnector::createElementHandle(const string &strPath,
-                                                                   string& strError) const
+ElementHandle *CParameterMgrPlatformConnector::createElementHandle(const string &strPath,
+                                                                   string &strError) const
 {
     return _pParameterMgr->createElementHandle(strPath, strError);
 }
 
 // Logging
-void CParameterMgrPlatformConnector::setLogger(CParameterMgrPlatformConnector::ILogger* pLogger)
+void CParameterMgrPlatformConnector::setLogger(CParameterMgrPlatformConnector::ILogger *pLogger)
 {
     _pLogger = pLogger;
 }
@@ -125,8 +130,8 @@ bool CParameterMgrPlatformConnector::getFailureOnMissingSubsystem() const
     return _pParameterMgr->getFailureOnMissingSubsystem();
 }
 
-bool CParameterMgrPlatformConnector::setFailureOnFailedSettingsLoad(
-        bool bFail, std::string& strError)
+bool CParameterMgrPlatformConnector::setFailureOnFailedSettingsLoad(bool bFail,
+                                                                    std::string &strError)
 {
     if (_bStarted) {
 
@@ -143,18 +148,18 @@ bool CParameterMgrPlatformConnector::getFailureOnFailedSettingsLoad() const
     return _pParameterMgr->getFailureOnFailedSettingsLoad();
 }
 
-const string& CParameterMgrPlatformConnector::getSchemaUri() const
+const string &CParameterMgrPlatformConnector::getSchemaUri() const
 {
     return _pParameterMgr->getSchemaUri();
 }
 
-void CParameterMgrPlatformConnector::setSchemaUri(const string& schemaUri)
+void CParameterMgrPlatformConnector::setSchemaUri(const string &schemaUri)
 {
     _pParameterMgr->setSchemaUri(schemaUri);
 }
 
-bool CParameterMgrPlatformConnector::setValidateSchemasOnStart(
-    bool bValidate, std::string& strError)
+bool CParameterMgrPlatformConnector::setValidateSchemasOnStart(bool bValidate,
+                                                               std::string &strError)
 {
     if (_bStarted) {
 
@@ -172,7 +177,7 @@ bool CParameterMgrPlatformConnector::getValidateSchemasOnStart() const
 }
 
 // Start
-bool CParameterMgrPlatformConnector::start(string& strError)
+bool CParameterMgrPlatformConnector::start(string &strError)
 {
     // Create data structure
     if (!_pParameterMgr->load(strError)) {
@@ -192,7 +197,7 @@ bool CParameterMgrPlatformConnector::isStarted() const
 }
 
 // Private logging
-void CParameterMgrPlatformConnector::info(const string& log)
+void CParameterMgrPlatformConnector::info(const string &log)
 {
     if (_pLogger) {
 
@@ -200,7 +205,7 @@ void CParameterMgrPlatformConnector::info(const string& log)
     }
 }
 
-void CParameterMgrPlatformConnector::warning(const string& log)
+void CParameterMgrPlatformConnector::warning(const string &log)
 {
     if (_pLogger) {
 

--- a/parameter/ParameterType.cpp
+++ b/parameter/ParameterType.cpp
@@ -40,12 +40,12 @@ using std::string;
 
 const std::string CParameterType::gUnitPropertyName = "Unit";
 
-CParameterType::CParameterType(const string& strName) : base(strName)
+CParameterType::CParameterType(const string &strName) : base(strName)
 {
 }
 
 // Object creation
-void CParameterType::populate(CElement* /*elem*/) const
+void CParameterType::populate(CElement * /*elem*/) const
 {
     // Prevent further digging for instantiaton since we're leaf on the strcture tree
 }
@@ -67,28 +67,30 @@ string CParameterType::getUnit() const
     return _strUnit;
 }
 
-void CParameterType::setUnit(const std::string& strUnit)
+void CParameterType::setUnit(const std::string &strUnit)
 {
     _strUnit = strUnit;
 }
 
 // From IXmlSink
-bool CParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CParameterType::fromXml(const CXmlElement &xmlElement,
+                             CXmlSerializingContext &serializingContext)
 {
     xmlElement.getAttribute(gUnitPropertyName, _strUnit);
     return base::fromXml(xmlElement, serializingContext);
 }
 
 // From IXmlSource
-void CParameterType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CParameterType::toXml(CXmlElement &xmlElement,
+                           CXmlSerializingContext &serializingContext) const
 {
     base::toXml(xmlElement, serializingContext);
     setXmlUnitAttribute(xmlElement);
 }
 
-void CParameterType::setXmlUnitAttribute(CXmlElement& xmlElement) const
+void CParameterType::setXmlUnitAttribute(CXmlElement &xmlElement) const
 {
-    const string& unit = getUnit();
+    const string &unit = getUnit();
     if (!unit.empty()) {
         xmlElement.setAttribute(gUnitPropertyName, unit);
     }
@@ -96,14 +98,15 @@ void CParameterType::setXmlUnitAttribute(CXmlElement& xmlElement) const
 
 // XML Serialization value space handling
 // Value space handling for configuration import/export
-void CParameterType::handleValueSpaceAttribute(CXmlElement& /*xmlConfigurableElementSettingsElement*/,
-                                               CConfigurationAccessContext& /*ctx*/) const
+void CParameterType::handleValueSpaceAttribute(
+    CXmlElement & /*xmlConfigurableElementSettingsElement*/,
+    CConfigurationAccessContext & /*ctx*/) const
 {
     // Do nothing by default
 }
 
 // Element properties
-void CParameterType::showProperties(string& strResult) const
+void CParameterType::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -123,7 +126,7 @@ uint32_t CParameterType::getDefaultValue() const
 }
 
 // Parameter instantiation
-CInstanceConfigurableElement* CParameterType::doInstantiate() const
+CInstanceConfigurableElement *CParameterType::doInstantiate() const
 {
     if (isScalar()) {
         // Scalar parameter
@@ -134,19 +137,19 @@ CInstanceConfigurableElement* CParameterType::doInstantiate() const
     }
 }
 
-void CParameterType::signExtend(int32_t& iData) const
+void CParameterType::signExtend(int32_t &iData) const
 {
     doSignExtend(iData);
 }
 
-void CParameterType::signExtend(int64_t& iData) const
+void CParameterType::signExtend(int64_t &iData) const
 {
     doSignExtend(iData);
 }
 
 // Generic sign extension
 template <typename type>
-void CParameterType::doSignExtend(type& data) const
+void CParameterType::doSignExtend(type &data) const
 {
     size_t shift = CHAR_BIT * (sizeof(data) - getSize());
     // FIXME: If `data` has a signed type and nonnegative value,
@@ -208,40 +211,46 @@ uint32_t CParameterType::makeEncodable(uint32_t uiData) const
 // Conversions (dynamic access)
 // Value access
 // Boolean
-bool CParameterType::toBlackboard(bool /*bUserValue*/, uint32_t& /*uiValue*/, CParameterAccessContext& parameterAccessContext) const
+bool CParameterType::toBlackboard(bool /*bUserValue*/, uint32_t & /*uiValue*/,
+                                  CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
 
-bool CParameterType::fromBlackboard(bool& /*bUserValue*/, uint32_t /*uiValue*/, CParameterAccessContext& parameterAccessContext) const
+bool CParameterType::fromBlackboard(bool & /*bUserValue*/, uint32_t /*uiValue*/,
+                                    CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
 
 // Integer
-bool CParameterType::toBlackboard(uint32_t /*uiUserValue*/, uint32_t& /*uiValue*/, CParameterAccessContext& parameterAccessContext) const
+bool CParameterType::toBlackboard(uint32_t /*uiUserValue*/, uint32_t & /*uiValue*/,
+                                  CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
 
-bool CParameterType::fromBlackboard(uint32_t& /*uiUserValue*/, uint32_t /*uiValue*/, CParameterAccessContext& parameterAccessContext) const
+bool CParameterType::fromBlackboard(uint32_t & /*uiUserValue*/, uint32_t /*uiValue*/,
+                                    CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
     return false;
 }
 
 // Signed Integer
-bool CParameterType::toBlackboard(int32_t /*iUserValue*/, uint32_t& /*uiValue*/, CParameterAccessContext& parameterAccessContext) const
+bool CParameterType::toBlackboard(int32_t /*iUserValue*/, uint32_t & /*uiValue*/,
+                                  CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
 
     return false;
 }
 
-bool CParameterType::fromBlackboard(int32_t& /*iUserValue*/, uint32_t /*uiValue*/, CParameterAccessContext& parameterAccessContext) const
+bool CParameterType::fromBlackboard(int32_t & /*iUserValue*/, uint32_t /*uiValue*/,
+                                    CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
 
@@ -249,18 +258,18 @@ bool CParameterType::fromBlackboard(int32_t& /*iUserValue*/, uint32_t /*uiValue*
 }
 
 // Double
-bool CParameterType::toBlackboard(double /*dUserValue*/, uint32_t& /*uiValue*/, CParameterAccessContext& parameterAccessContext) const
+bool CParameterType::toBlackboard(double /*dUserValue*/, uint32_t & /*uiValue*/,
+                                  CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
 
     return false;
 }
 
-bool CParameterType::fromBlackboard(double& /*dUserValue*/, uint32_t /*uiValue*/, CParameterAccessContext& parameterAccessContext) const
+bool CParameterType::fromBlackboard(double & /*dUserValue*/, uint32_t /*uiValue*/,
+                                    CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.setError("Unsupported conversion");
 
     return false;
 }
-
-

--- a/parameter/ParameterType.h
+++ b/parameter/ParameterType.h
@@ -44,7 +44,7 @@ class CConfigurationAccessContext;
 class PARAMETER_EXPORT CParameterType : public CTypeElement
 {
 public:
-    CParameterType(const std::string& strName);
+    CParameterType(const std::string &strName);
     virtual ~CParameterType() = default;
 
     // Size
@@ -52,30 +52,40 @@ public:
 
     // Unit
     std::string getUnit() const;
-    void setUnit(const std::string& strUnit);
+    void setUnit(const std::string &strUnit);
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     /// Conversions
     // String
-    virtual bool toBlackboard(const std::string& strValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const = 0;
-    virtual bool fromBlackboard(std::string& strValue, const uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const = 0;
+    virtual bool toBlackboard(const std::string &strValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const = 0;
+    virtual bool fromBlackboard(std::string &strValue, const uint32_t &uiValue,
+                                CParameterAccessContext &parameterAccessContext) const = 0;
     // Boolean
-    virtual bool toBlackboard(bool bUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(bool& bUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(bool bUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(bool &bUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Integer
-    virtual bool toBlackboard(uint32_t uiUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(uint32_t& uiUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(uint32_t uiUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(uint32_t &uiUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Signed Integer
-    virtual bool toBlackboard(int32_t iUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(int32_t& iUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(int32_t iUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(int32_t &iUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
     // Double
-    virtual bool toBlackboard(double dUserValue, uint32_t& uiValue, CParameterAccessContext& parameterAccessContext) const;
-    virtual bool fromBlackboard(double& dUserValue, uint32_t uiValue, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool toBlackboard(double dUserValue, uint32_t &uiValue,
+                              CParameterAccessContext &parameterAccessContext) const;
+    virtual bool fromBlackboard(double &dUserValue, uint32_t uiValue,
+                                CParameterAccessContext &parameterAccessContext) const;
 
     /** Value space handling for settings import/export from/to XML
      *
@@ -89,10 +99,12 @@ public:
      * @param[in,out] xmlConfigurableElementSettingsElement the element being imported or exported
      * @param[in,out] configurationAccessContext the import or export context
      */
-    virtual void handleValueSpaceAttribute(CXmlElement& xmlConfigurableElementSettingsElement, CConfigurationAccessContext& configurationAccessContext) const;
+    virtual void handleValueSpaceAttribute(
+        CXmlElement &xmlConfigurableElementSettingsElement,
+        CConfigurationAccessContext &configurationAccessContext) const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // Default value handling (simulation only)
     virtual uint32_t getDefaultValue() const;
@@ -102,18 +114,18 @@ public:
      *
      * @param[in:out] iData the data which will be sign extended
      */
-    void signExtend(int32_t& iData) const;
+    void signExtend(int32_t &iData) const;
 
     /**
      * Sign extension (64 bits)
      *
      * @param[in:out] iData the data which will be sign extended
      */
-    void signExtend(int64_t& iData) const;
+    void signExtend(int64_t &iData) const;
 
 protected:
     // Object creation
-    virtual void populate(CElement* pElement) const;
+    virtual void populate(CElement *pElement) const;
     // Size
     void setSize(size_t size);
 
@@ -128,19 +140,21 @@ protected:
     template <typename type>
     type getMaxValue() const
     {
-        return getSize() < sizeof(type) ?
-                    (static_cast<type>(1) << (getSize() * std::numeric_limits<unsigned char>::digits - 1)) - 1 :
-                    std::numeric_limits<type>::max();
+        return getSize() < sizeof(type)
+                   ? (static_cast<type>(1)
+                      << (getSize() * std::numeric_limits<unsigned char>::digits - 1)) -
+                         1
+                   : std::numeric_limits<type>::max();
     }
 
 private:
-    void setXmlUnitAttribute(CXmlElement& xmlElement) const;
+    void setXmlUnitAttribute(CXmlElement &xmlElement) const;
 
     // Instantiation
-    virtual CInstanceConfigurableElement* doInstantiate() const;
+    virtual CInstanceConfigurableElement *doInstantiate() const;
     // Generic Access
     template <typename type>
-    void doSignExtend(type& data) const;
+    void doSignExtend(type &data) const;
     template <typename type>
     bool doIsEncodable(type data, bool bIsSigned) const;
 

--- a/parameter/PathNavigator.cpp
+++ b/parameter/PathNavigator.cpp
@@ -30,12 +30,12 @@
 #include "PathNavigator.h"
 #include "Tokenizer.h"
 
-CPathNavigator::CPathNavigator(const std::string& strPath)
+CPathNavigator::CPathNavigator(const std::string &strPath)
 {
     init(strPath);
 }
 
-void CPathNavigator::init(const std::string& strPath)
+void CPathNavigator::init(const std::string &strPath)
 {
     Tokenizer tokenizer(strPath, "/");
 
@@ -50,7 +50,7 @@ bool CPathNavigator::isPathValid() const
 }
 
 // Navigate through
-bool CPathNavigator::navigateThrough(const std::string& strItemName, std::string& strError)
+bool CPathNavigator::navigateThrough(const std::string &strItemName, std::string &strError)
 {
     if (!_bValid) {
 
@@ -59,20 +59,20 @@ bool CPathNavigator::navigateThrough(const std::string& strItemName, std::string
         return false;
     }
 
-    std::string* pStrChildName = next();
+    std::string *pStrChildName = next();
 
     if (!pStrChildName) {
 
-        strError = "Path not complete: " + getCurrentPath() +
-                   ", trying to access to " + strItemName;
+        strError =
+            "Path not complete: " + getCurrentPath() + ", trying to access to " + strItemName;
 
         return false;
     }
 
     if (*pStrChildName != strItemName) {
 
-        strError = "Path not found: " + getCurrentPath() +
-                   ", expected: " + strItemName + " but found: " + *pStrChildName;
+        strError = "Path not found: " + getCurrentPath() + ", expected: " + strItemName +
+                   " but found: " + *pStrChildName;
 
         return false;
     }
@@ -80,7 +80,7 @@ bool CPathNavigator::navigateThrough(const std::string& strItemName, std::string
     return true;
 }
 
-std::string* CPathNavigator::next()
+std::string *CPathNavigator::next()
 {
     if (_currentIndex < _astrItems.size()) {
 
@@ -110,8 +110,7 @@ std::string CPathNavigator::getCurrentPath() const
     return strPath;
 }
 
-
-bool CPathNavigator::checkPathFormat(const std::string& strUpl)
+bool CPathNavigator::checkPathFormat(const std::string &strUpl)
 {
     return strUpl[0] == '/';
 }

--- a/parameter/PathNavigator.h
+++ b/parameter/PathNavigator.h
@@ -36,23 +36,23 @@
 class CPathNavigator
 {
 public:
-    CPathNavigator(const std::string& strPath);
+    CPathNavigator(const std::string &strPath);
 
     // Path validity
     bool isPathValid() const;
 
     // Navigate through
-    bool navigateThrough(const std::string& strItemName, std::string& strError);
+    bool navigateThrough(const std::string &strItemName, std::string &strError);
 
     // Nagivate
-    std::string* next();
+    std::string *next();
 
     // Current path
     std::string getCurrentPath() const;
 
 private:
-    void init(const std::string& strPath);
-    static bool checkPathFormat(const std::string& strUpl);
+    void init(const std::string &strPath);
+    static bool checkPathFormat(const std::string &strUpl);
 
     bool _bValid;
     std::vector<std::string> _astrItems;

--- a/parameter/Plugin.h
+++ b/parameter/Plugin.h
@@ -42,9 +42,9 @@
 
 extern "C" {
 #if defined(__clang__) || defined(__GNUC__)
-    __attribute__((visibility("default")))
+__attribute__((visibility("default")))
 #elif defined(_MSC_VER)
-    __declspec(dllexport)
+__declspec(dllexport)
 #endif
     void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary*, core::log::Logger&);
 }

--- a/parameter/PluginLocation.cpp
+++ b/parameter/PluginLocation.cpp
@@ -31,22 +31,22 @@
 
 #define base CKindElement
 
-CPluginLocation::CPluginLocation(const std::string& strName, const std::string& strKind) : base(strName, strKind)
+CPluginLocation::CPluginLocation(const std::string &strName, const std::string &strKind)
+    : base(strName, strKind)
 {
-
 }
 
-const std::string& CPluginLocation::getFolder() const
+const std::string &CPluginLocation::getFolder() const
 {
     return _strFolder;
 }
 
-const std::list<std::string>& CPluginLocation::getPluginList() const
+const std::list<std::string> &CPluginLocation::getPluginList() const
 {
     return _pluginList;
 }
 
-bool CPluginLocation::fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &/*ctx*/)
+bool CPluginLocation::fromXml(const CXmlElement &xmlElement, CXmlSerializingContext & /*ctx*/)
 {
     // Retrieve folder
     xmlElement.getAttribute("Folder", _strFolder);

--- a/parameter/PluginLocation.h
+++ b/parameter/PluginLocation.h
@@ -36,19 +36,18 @@ class CPluginLocation : public CKindElement
 {
 
 public:
-    CPluginLocation(const std::string& strName, const std::string& strKind);
+    CPluginLocation(const std::string &strName, const std::string &strKind);
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // Folder
-    const std::string& getFolder() const;
+    const std::string &getFolder() const;
 
     // Plugin list
-    const std::list<std::string>& getPluginList() const;
+    const std::list<std::string> &getPluginList() const;
 
 private:
     std::string _strFolder;
     std::list<std::string> _pluginList;
-
 };

--- a/parameter/Results.h
+++ b/parameter/Results.h
@@ -35,7 +35,7 @@
 namespace core
 {
 
-    /** String list type which can hold list of error/info */
-    typedef std::list<std::string> Results;
+/** String list type which can hold list of error/info */
+typedef std::list<std::string> Results;
 
 } /** core namespace */

--- a/parameter/Rule.h
+++ b/parameter/Rule.h
@@ -40,7 +40,7 @@ class CRule : public CElement
 
 public:
     // Parse
-    virtual bool parse(CRuleParser& ruleParser, std::string& strError) = 0;
+    virtual bool parse(CRuleParser &ruleParser, std::string &strError) = 0;
 
     // Dump
     virtual std::string dump() const = 0;

--- a/parameter/RuleParser.cpp
+++ b/parameter/RuleParser.cpp
@@ -36,18 +36,19 @@
 using std::string;
 
 // Matches
-const char* CRuleParser::_acDelimiters[CRuleParser::ENbStatuses] = {
-    "{",    // EInit
-    "{} ",  // EBeginCompoundRule
-    ",}",   // EEndCompoundRule
-    ",}",   // ECriterionRule
-    "{ ",   // EContinue
-    ""      // EDone
+const char *CRuleParser::_acDelimiters[CRuleParser::ENbStatuses] = {
+    "{",   // EInit
+    "{} ", // EBeginCompoundRule
+    ",}",  // EEndCompoundRule
+    ",}",  // ECriterionRule
+    "{ ",  // EContinue
+    ""     // EDone
 };
 
-CRuleParser::CRuleParser(const string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition) :
-    _strApplicationRule(strApplicationRule),
-    _pSelectionCriteriaDefinition(pSelectionCriteriaDefinition)
+CRuleParser::CRuleParser(const string &strApplicationRule,
+                         const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition)
+    : _strApplicationRule(strApplicationRule),
+      _pSelectionCriteriaDefinition(pSelectionCriteriaDefinition)
 {
 }
 
@@ -57,7 +58,7 @@ CRuleParser::~CRuleParser()
 }
 
 // Parse
-bool CRuleParser::parse(CCompoundRule* pParentRule, string& strError)
+bool CRuleParser::parse(CCompoundRule *pParentRule, string &strError)
 {
     while (true) {
         // Iterate till next relevant delimiter
@@ -65,11 +66,11 @@ bool CRuleParser::parse(CCompoundRule* pParentRule, string& strError)
 
             return false;
         }
-        switch(_eStatus) {
+        switch (_eStatus) {
         case EBeginCompoundRule: {
 
             // Create new compound rule
-            CCompoundRule* pCompoundRule = new CCompoundRule;
+            CCompoundRule *pCompoundRule = new CCompoundRule;
 
             // Parse
             if (!pCompoundRule->parse(*this, strError)) {
@@ -103,7 +104,7 @@ bool CRuleParser::parse(CCompoundRule* pParentRule, string& strError)
             break;
         case ECriterionRule: {
             // Create new criterion rule
-            CSelectionCriterionRule* pCriterionRule = new CSelectionCriterionRule;
+            CSelectionCriterionRule *pCriterionRule = new CSelectionCriterionRule;
 
             // Parse
             if (!pCriterionRule->parse(*this, strError)) {
@@ -132,7 +133,6 @@ bool CRuleParser::parse(CCompoundRule* pParentRule, string& strError)
 
                 return false;
             }
-
         }
         default:
             assert(0);
@@ -144,7 +144,7 @@ bool CRuleParser::parse(CCompoundRule* pParentRule, string& strError)
 }
 
 // Iterate
-bool CRuleParser::iterate(string& strError)
+bool CRuleParser::iterate(string &strError)
 {
     string::size_type delimiter;
 
@@ -158,9 +158,11 @@ bool CRuleParser::iterate(string& strError)
     }
 
     // Parse
-    if ((_uiCurrentPos != _strApplicationRule.length()) && ((delimiter = _strApplicationRule.find_first_of(_acDelimiters[_eStatus], _uiCurrentPos)) != string::npos)) {
+    if ((_uiCurrentPos != _strApplicationRule.length()) &&
+        ((delimiter = _strApplicationRule.find_first_of(_acDelimiters[_eStatus], _uiCurrentPos)) !=
+         string::npos)) {
 
-        switch(_strApplicationRule[delimiter]) {
+        switch (_strApplicationRule[delimiter]) {
 
         case '{':
             _eStatus = EBeginCompoundRule;
@@ -212,21 +214,21 @@ bool CRuleParser::iterate(string& strError)
 }
 
 // Rule type
-const string& CRuleParser::getType() const
+const string &CRuleParser::getType() const
 {
     return _strRuleType;
 }
 
 // Criteria defintion
-const CSelectionCriteriaDefinition* CRuleParser::getSelectionCriteriaDefinition() const
+const CSelectionCriteriaDefinition *CRuleParser::getSelectionCriteriaDefinition() const
 {
     return _pSelectionCriteriaDefinition;
 }
 
 // Root rule
-CCompoundRule* CRuleParser::grabRootRule()
+CCompoundRule *CRuleParser::grabRootRule()
 {
-    CCompoundRule* pRootRule = _pRootRule;
+    CCompoundRule *pRootRule = _pRootRule;
 
     assert(pRootRule);
 
@@ -236,7 +238,7 @@ CCompoundRule* CRuleParser::grabRootRule()
 }
 
 // Next word
-bool CRuleParser::next(string& strNext, string& strError)
+bool CRuleParser::next(string &strNext, string &strError)
 {
     string::size_type delimiter;
 

--- a/parameter/RuleParser.h
+++ b/parameter/RuleParser.h
@@ -38,7 +38,8 @@ class CSelectionCriteriaDefinition;
 class CRuleParser
 {
 public:
-    enum Status {
+    enum Status
+    {
         EInit,
         EBeginCompoundRule,
         EEndCompoundRule,
@@ -49,35 +50,36 @@ public:
         ENbStatuses
     };
 
-    CRuleParser(const std::string& strApplicationRule, const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition);
+    CRuleParser(const std::string &strApplicationRule,
+                const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition);
     ~CRuleParser();
 
     // Parse
-    bool parse(CCompoundRule* pParentRule, std::string& strError);
+    bool parse(CCompoundRule *pParentRule, std::string &strError);
 
     // Iterate
-    bool iterate(std::string& strError);
+    bool iterate(std::string &strError);
 
     // Next word
-    bool next(std::string& strNext, std::string& strError);
+    bool next(std::string &strNext, std::string &strError);
 
     // Rule type
-    const std::string& getType() const;
+    const std::string &getType() const;
 
     // Criteria defintion
-    const CSelectionCriteriaDefinition* getSelectionCriteriaDefinition() const;
+    const CSelectionCriteriaDefinition *getSelectionCriteriaDefinition() const;
 
     // Root rule
-    CCompoundRule* grabRootRule();
-private:
+    CCompoundRule *grabRootRule();
 
-    CRuleParser(const CRuleParser&);
-    CRuleParser& operator=(const CRuleParser&);
+private:
+    CRuleParser(const CRuleParser &);
+    CRuleParser &operator=(const CRuleParser &);
 
     // Rule definition
     std::string _strApplicationRule;
     // Criteria defintion
-    const CSelectionCriteriaDefinition* _pSelectionCriteriaDefinition;
+    const CSelectionCriteriaDefinition *_pSelectionCriteriaDefinition;
     /** String iterator */
     std::string::size_type _uiCurrentPos{0};
     // Deepness
@@ -87,8 +89,7 @@ private:
     // Status
     Status _eStatus{EInit};
     // Root rule
-    CCompoundRule* _pRootRule{nullptr};
+    CCompoundRule *_pRootRule{nullptr};
     // Matches
-    static const char* _acDelimiters[ENbStatuses];
+    static const char *_acDelimiters[ENbStatuses];
 };
-

--- a/parameter/SelectionCriteria.cpp
+++ b/parameter/SelectionCriteria.cpp
@@ -45,29 +45,29 @@ std::string CSelectionCriteria::getKind() const
 }
 
 // Selection Criteria/Type creation
-CSelectionCriterionType* CSelectionCriteria::createSelectionCriterionType(bool bIsInclusive)
+CSelectionCriterionType *CSelectionCriteria::createSelectionCriterionType(bool bIsInclusive)
 {
     return getSelectionCriterionLibrary()->createSelectionCriterionType(bIsInclusive);
 }
 
-CSelectionCriterion*
-CSelectionCriteria::createSelectionCriterion(const std::string& strName,
-                                             const CSelectionCriterionType* pType,
-                                             core::log::Logger& logger)
+CSelectionCriterion *CSelectionCriteria::createSelectionCriterion(
+    const std::string &strName, const CSelectionCriterionType *pType, core::log::Logger &logger)
 {
     return getSelectionCriteriaDefinition()->createSelectionCriterion(strName, pType, logger);
 }
 
 // Selection criterion retrieval
-CSelectionCriterion* CSelectionCriteria::getSelectionCriterion(const std::string& strName)
+CSelectionCriterion *CSelectionCriteria::getSelectionCriterion(const std::string &strName)
 {
     return getSelectionCriteriaDefinition()->getSelectionCriterion(strName);
 }
 
 // List available criteria
-void CSelectionCriteria::listSelectionCriteria(std::list<std::string>& lstrResult, bool bWithTypeInfo, bool bHumanReadable) const
+void CSelectionCriteria::listSelectionCriteria(std::list<std::string> &lstrResult,
+                                               bool bWithTypeInfo, bool bHumanReadable) const
 {
-    getSelectionCriteriaDefinition()->listSelectionCriteria(lstrResult, bWithTypeInfo, bHumanReadable);
+    getSelectionCriteriaDefinition()->listSelectionCriteria(lstrResult, bWithTypeInfo,
+                                                            bHumanReadable);
 }
 
 // Reset the modified status of the children
@@ -77,17 +77,18 @@ void CSelectionCriteria::resetModifiedStatus()
 }
 
 // Children access
-CSelectionCriterionLibrary* CSelectionCriteria::getSelectionCriterionLibrary()
+CSelectionCriterionLibrary *CSelectionCriteria::getSelectionCriterionLibrary()
 {
-    return static_cast<CSelectionCriterionLibrary*>(getChild(ESelectionCriterionLibrary));
+    return static_cast<CSelectionCriterionLibrary *>(getChild(ESelectionCriterionLibrary));
 }
 
-CSelectionCriteriaDefinition* CSelectionCriteria::getSelectionCriteriaDefinition()
+CSelectionCriteriaDefinition *CSelectionCriteria::getSelectionCriteriaDefinition()
 {
-    return static_cast<CSelectionCriteriaDefinition*>(getChild(ESelectionCriteriaDefinition));
+    return static_cast<CSelectionCriteriaDefinition *>(getChild(ESelectionCriteriaDefinition));
 }
 
-const CSelectionCriteriaDefinition* CSelectionCriteria::getSelectionCriteriaDefinition() const
+const CSelectionCriteriaDefinition *CSelectionCriteria::getSelectionCriteriaDefinition() const
 {
-    return static_cast<const CSelectionCriteriaDefinition*>(getChild(ESelectionCriteriaDefinition));
+    return static_cast<const CSelectionCriteriaDefinition *>(
+        getChild(ESelectionCriteriaDefinition));
 }

--- a/parameter/SelectionCriteria.h
+++ b/parameter/SelectionCriteria.h
@@ -43,34 +43,38 @@ class ISelectionCriterionObserver;
 
 class CSelectionCriteria : public CElement
 {
-    enum ChildElementType {
+    enum ChildElementType
+    {
         ESelectionCriterionLibrary,
         ESelectionCriteriaDefinition
     };
+
 public:
     CSelectionCriteria();
 
     // Selection Criteria/Type creation
-    CSelectionCriterionType* createSelectionCriterionType(bool bIsInclusive);
-    CSelectionCriterion* createSelectionCriterion(const std::string& strName,
-                                                  const CSelectionCriterionType* pType,
-                                                  core::log::Logger& logger);
+    CSelectionCriterionType *createSelectionCriterionType(bool bIsInclusive);
+    CSelectionCriterion *createSelectionCriterion(const std::string &strName,
+                                                  const CSelectionCriterionType *pType,
+                                                  core::log::Logger &logger);
     // Selection criterion retrieval
-    CSelectionCriterion* getSelectionCriterion(const std::string& strName);
+    CSelectionCriterion *getSelectionCriterion(const std::string &strName);
 
     // Selection Criterion definition
-    const CSelectionCriteriaDefinition* getSelectionCriteriaDefinition() const;
+    const CSelectionCriteriaDefinition *getSelectionCriteriaDefinition() const;
 
     // List available criteria
-    void listSelectionCriteria(std::list<std::string>& strResult, bool bWithTypeInfo, bool bHumanReadable) const;
+    void listSelectionCriteria(std::list<std::string> &strResult, bool bWithTypeInfo,
+                               bool bHumanReadable) const;
 
     // Base
     virtual std::string getKind() const;
 
     // Reset the modified status of the children
     void resetModifiedStatus();
+
 private:
     // Children access
-    CSelectionCriterionLibrary* getSelectionCriterionLibrary();
-    CSelectionCriteriaDefinition* getSelectionCriteriaDefinition();
+    CSelectionCriterionLibrary *getSelectionCriterionLibrary();
+    CSelectionCriteriaDefinition *getSelectionCriteriaDefinition();
 };

--- a/parameter/SelectionCriteriaDefinition.cpp
+++ b/parameter/SelectionCriteriaDefinition.cpp
@@ -36,12 +36,10 @@ std::string CSelectionCriteriaDefinition::getKind() const
 }
 
 // Selection Criterion creation
-CSelectionCriterion*
-CSelectionCriteriaDefinition::createSelectionCriterion(const std::string& strName,
-                                                       const CSelectionCriterionType* pType,
-                                                       core::log::Logger& logger)
+CSelectionCriterion *CSelectionCriteriaDefinition::createSelectionCriterion(
+    const std::string &strName, const CSelectionCriterionType *pType, core::log::Logger &logger)
 {
-    CSelectionCriterion* pSelectionCriterion = new CSelectionCriterion(strName, pType, logger);
+    CSelectionCriterion *pSelectionCriterion = new CSelectionCriterion(strName, pType, logger);
 
     addChild(pSelectionCriterion);
 
@@ -49,18 +47,21 @@ CSelectionCriteriaDefinition::createSelectionCriterion(const std::string& strNam
 }
 
 // Selection Criterion access
-const CSelectionCriterion* CSelectionCriteriaDefinition::getSelectionCriterion(const std::string& strName) const
+const CSelectionCriterion *CSelectionCriteriaDefinition::getSelectionCriterion(
+    const std::string &strName) const
 {
-    return static_cast<const CSelectionCriterion*>(findChild(strName));
+    return static_cast<const CSelectionCriterion *>(findChild(strName));
 }
 
-CSelectionCriterion* CSelectionCriteriaDefinition::getSelectionCriterion(const std::string& strName)
+CSelectionCriterion *CSelectionCriteriaDefinition::getSelectionCriterion(const std::string &strName)
 {
-    return static_cast<CSelectionCriterion*>(findChild(strName));
+    return static_cast<CSelectionCriterion *>(findChild(strName));
 }
 
 // List available criteria
-void CSelectionCriteriaDefinition::listSelectionCriteria(std::list<std::string>& lstrResult, bool bWithTypeInfo, bool bHumanReadable) const
+void CSelectionCriteriaDefinition::listSelectionCriteria(std::list<std::string> &lstrResult,
+                                                         bool bWithTypeInfo,
+                                                         bool bHumanReadable) const
 {
     // Propagate
     size_t uiNbChildren = getNbChildren();
@@ -68,9 +69,11 @@ void CSelectionCriteriaDefinition::listSelectionCriteria(std::list<std::string>&
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        const CSelectionCriterion* pSelectionCriterion = static_cast<const CSelectionCriterion*>(getChild(uiChild));
+        const CSelectionCriterion *pSelectionCriterion =
+            static_cast<const CSelectionCriterion *>(getChild(uiChild));
 
-        lstrResult.push_back(pSelectionCriterion->getFormattedDescription(bWithTypeInfo, bHumanReadable));
+        lstrResult.push_back(
+            pSelectionCriterion->getFormattedDescription(bWithTypeInfo, bHumanReadable));
     }
 }
 
@@ -80,11 +83,11 @@ void CSelectionCriteriaDefinition::resetModifiedStatus()
     // Propagate
     size_t uiNbChildren = getNbChildren();
     size_t uiChild;
-    CSelectionCriterion* pSelectionCriterion;
+    CSelectionCriterion *pSelectionCriterion;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        pSelectionCriterion = static_cast<CSelectionCriterion*>(getChild(uiChild));
+        pSelectionCriterion = static_cast<CSelectionCriterion *>(getChild(uiChild));
 
         pSelectionCriterion->resetModifiedStatus();
     }

--- a/parameter/SelectionCriteriaDefinition.h
+++ b/parameter/SelectionCriteriaDefinition.h
@@ -39,16 +39,17 @@ class CSelectionCriteriaDefinition : public CElement
 {
 public:
     // Selection Criterion creation
-    CSelectionCriterion* createSelectionCriterion(const std::string& strName,
-                                                  const CSelectionCriterionType* pType,
-                                                  core::log::Logger& logger);
+    CSelectionCriterion *createSelectionCriterion(const std::string &strName,
+                                                  const CSelectionCriterionType *pType,
+                                                  core::log::Logger &logger);
 
     // Selection Criterion access
-    const CSelectionCriterion* getSelectionCriterion(const std::string& strName) const;
-    CSelectionCriterion* getSelectionCriterion(const std::string& strName);
+    const CSelectionCriterion *getSelectionCriterion(const std::string &strName) const;
+    CSelectionCriterion *getSelectionCriterion(const std::string &strName);
 
     // List available criteria
-    void listSelectionCriteria(std::list<std::string>& lstrResult, bool bWithTypeInfo, bool bHumanReadable) const;
+    void listSelectionCriteria(std::list<std::string> &lstrResult, bool bWithTypeInfo,
+                               bool bHumanReadable) const;
 
     // Base
     virtual std::string getKind() const;
@@ -56,4 +57,3 @@ public:
     // Reset the modified status of the children
     void resetModifiedStatus();
 };
-

--- a/parameter/SelectionCriterion.cpp
+++ b/parameter/SelectionCriterion.cpp
@@ -36,9 +36,9 @@
 
 using namespace core;
 
-CSelectionCriterion::CSelectionCriterion(const std::string& strName,
-                                         const CSelectionCriterionType* pType,
-                                         core::log::Logger& logger)
+CSelectionCriterion::CSelectionCriterion(const std::string &strName,
+                                         const CSelectionCriterionType *pType,
+                                         core::log::Logger &logger)
     : base(strName), _pType(pType), _logger(logger)
 {
 }
@@ -70,12 +70,13 @@ void CSelectionCriterion::setCriterionState(int iState)
         _logger.info() << "Selection criterion changed event: "
                        << getFormattedDescription(false, false);
 
-        // Check if the previous criterion value has been taken into account (i.e. at least one Configuration was applied
+        // Check if the previous criterion value has been taken into account (i.e. at least one
+        // Configuration was applied
         // since the last criterion change)
         if (_uiNbModifications != 0) {
 
-            _logger.warning() << "Selection criterion '" << getName()
-                              << "' has been modified " << _uiNbModifications
+            _logger.warning() << "Selection criterion '" << getName() << "' has been modified "
+                              << _uiNbModifications
                               << " time(s) without any configuration application";
         }
 
@@ -96,7 +97,7 @@ std::string CSelectionCriterion::getCriterionName() const
 }
 
 // Type
-const ISelectionCriterionTypeInterface* CSelectionCriterion::getCriterionType() const
+const ISelectionCriterionTypeInterface *CSelectionCriterion::getCriterionType() const
 {
     return _pType;
 }
@@ -125,7 +126,8 @@ bool CSelectionCriterion::excludes(int iState) const
 }
 
 /// User request
-std::string CSelectionCriterion::getFormattedDescription(bool bWithTypeInfo, bool bHumanReadable) const
+std::string CSelectionCriterion::getFormattedDescription(bool bWithTypeInfo,
+                                                         bool bHumanReadable) const
 {
     std::string strFormattedDescription;
 
@@ -163,24 +165,23 @@ std::string CSelectionCriterion::getFormattedDescription(bool bWithTypeInfo, boo
         if (bWithTypeInfo) {
             // Type Kind
             strFormattedDescription += ", type kind: ";
-            strFormattedDescription +=  _pType->isTypeInclusive() ? "inclusive" : "exclusive";
+            strFormattedDescription += _pType->isTypeInclusive() ? "inclusive" : "exclusive";
         }
 
         // Current State
-        strFormattedDescription += ", current state: " +
-                                   _pType->getFormattedState(_iState);
+        strFormattedDescription += ", current state: " + _pType->getFormattedState(_iState);
 
-         if (bWithTypeInfo) {
+        if (bWithTypeInfo) {
             // States
-            strFormattedDescription += ", states: " +
-                                       _pType->listPossibleValues();
+            strFormattedDescription += ", states: " + _pType->listPossibleValues();
         }
     }
     return strFormattedDescription;
 }
 
 // XML export
-void CSelectionCriterion::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CSelectionCriterion::toXml(CXmlElement &xmlElement,
+                                CXmlSerializingContext &serializingContext) const
 {
     // Current Value
     xmlElement.setAttribute("Value", _pType->getFormattedState(_iState));

--- a/parameter/SelectionCriterion.h
+++ b/parameter/SelectionCriterion.h
@@ -37,13 +37,13 @@
 
 #include <string>
 
-class CSelectionCriterion : public CElement, public ISelectionCriterionInterface,
+class CSelectionCriterion : public CElement,
+                            public ISelectionCriterionInterface,
                             private utility::NonCopyable
 {
 public:
-    CSelectionCriterion(const std::string& strName,
-                        const CSelectionCriterionType* pType,
-                        core::log::Logger& logger);
+    CSelectionCriterion(const std::string &strName, const CSelectionCriterionType *pType,
+                        core::log::Logger &logger);
 
     /// From ISelectionCriterionInterface
     // State
@@ -52,7 +52,7 @@ public:
     // Name
     virtual std::string getCriterionName() const;
     // Type
-    virtual const ISelectionCriterionTypeInterface* getCriterionType() const;
+    virtual const ISelectionCriterionTypeInterface *getCriterionType() const;
     // Modified status
     bool hasBeenModified() const;
     void resetModifiedStatus();
@@ -76,17 +76,17 @@ public:
       * @param[in] serializingContext The serializing context
       *
       */
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
+
 private:
     // Current state
     int _iState{0};
     // Type
-    const CSelectionCriterionType* _pType;
+    const CSelectionCriterionType *_pType;
 
     /** Counter to know how many modifications have been applied to this criterion */
     uint32_t _uiNbModifications{0};
 
     /** Application logger */
-    core::log::Logger& _logger;
+    core::log::Logger &_logger;
 };
-

--- a/parameter/SelectionCriterionLibrary.cpp
+++ b/parameter/SelectionCriterionLibrary.cpp
@@ -37,9 +37,9 @@ std::string CSelectionCriterionLibrary::getKind() const
 }
 
 // Type creation
-CSelectionCriterionType* CSelectionCriterionLibrary::createSelectionCriterionType(bool bIsInclusive)
+CSelectionCriterionType *CSelectionCriterionLibrary::createSelectionCriterionType(bool bIsInclusive)
 {
-    CSelectionCriterionType* pSelectionCriterionType = new CSelectionCriterionType(bIsInclusive);
+    CSelectionCriterionType *pSelectionCriterionType = new CSelectionCriterionType(bIsInclusive);
 
     addChild(pSelectionCriterionType);
 

--- a/parameter/SelectionCriterionLibrary.h
+++ b/parameter/SelectionCriterionLibrary.h
@@ -36,7 +36,7 @@ class CSelectionCriterionLibrary : public CElement
 {
 public:
     // Type creation
-    CSelectionCriterionType* createSelectionCriterionType(bool bIsInclusive);
+    CSelectionCriterionType *createSelectionCriterionType(bool bIsInclusive);
 
     // CElement
     virtual std::string getKind() const;

--- a/parameter/SelectionCriterionRule.cpp
+++ b/parameter/SelectionCriterionRule.cpp
@@ -40,12 +40,9 @@
 
 using std::string;
 
-const CSelectionCriterionRule::SMatchingRuleDescription CSelectionCriterionRule::_astMatchesWhen[CSelectionCriterionRule::ENbMatchesWhen] = {
-    { "Is", true },
-    { "IsNot", true },
-    { "Includes", false },
-    { "Excludes", false }
-};
+const CSelectionCriterionRule::SMatchingRuleDescription
+    CSelectionCriterionRule::_astMatchesWhen[CSelectionCriterionRule::ENbMatchesWhen] = {
+        {"Is", true}, {"IsNot", true}, {"Includes", false}, {"Excludes", false}};
 
 // Class kind
 string CSelectionCriterionRule::getKind() const
@@ -54,17 +51,18 @@ string CSelectionCriterionRule::getKind() const
 }
 
 // Content dumping
-string CSelectionCriterionRule::logValue(utility::ErrorContext& /*cxt*/) const
+string CSelectionCriterionRule::logValue(utility::ErrorContext & /*cxt*/) const
 {
     // Dump rule
     return dump();
 }
 
 // Parse
-bool CSelectionCriterionRule::parse(CRuleParser& ruleParser, string& strError)
+bool CSelectionCriterionRule::parse(CRuleParser &ruleParser, string &strError)
 {
     // Criterion
-    _pSelectionCriterion = ruleParser.getSelectionCriteriaDefinition()->getSelectionCriterion(ruleParser.getType());
+    _pSelectionCriterion =
+        ruleParser.getSelectionCriteriaDefinition()->getSelectionCriterion(ruleParser.getType());
 
     // Check existence
     if (!_pSelectionCriterion) {
@@ -117,12 +115,8 @@ string CSelectionCriterionRule::dump() const
     _pSelectionCriterion->getCriterionType()->getLiteralValue(_iMatchValue, value);
 
     // "<Name> <Verb> <Value>"
-    return
-        string(_pSelectionCriterion->getName()) +
-        " " +
-        _astMatchesWhen[_eMatchesWhen].pcMatchesWhen +
-        " " +
-        value;
+    return string(_pSelectionCriterion->getName()) + " " +
+           _astMatchesWhen[_eMatchesWhen].pcMatchesWhen + " " + value;
 }
 
 // Rule check
@@ -130,7 +124,7 @@ bool CSelectionCriterionRule::matches() const
 {
     assert(_pSelectionCriterion);
 
-    switch(_eMatchesWhen) {
+    switch (_eMatchesWhen) {
     case EIs:
         return _pSelectionCriterion->is(_iMatchValue);
     case EIsNot:
@@ -146,21 +140,27 @@ bool CSelectionCriterionRule::matches() const
 }
 
 // From IXmlSink
-bool CSelectionCriterionRule::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CSelectionCriterionRule::fromXml(const CXmlElement &xmlElement,
+                                      CXmlSerializingContext &serializingContext)
 {
     // Retrieve actual context
-    CXmlDomainImportContext& xmlDomainImportContext = static_cast<CXmlDomainImportContext&>(serializingContext);
+    CXmlDomainImportContext &xmlDomainImportContext =
+        static_cast<CXmlDomainImportContext &>(serializingContext);
 
     // Get selection criterion
     string strSelectionCriterion;
     xmlElement.getAttribute("SelectionCriterion", strSelectionCriterion);
 
-    _pSelectionCriterion = xmlDomainImportContext.getSelectionCriteriaDefinition()->getSelectionCriterion(strSelectionCriterion);
+    _pSelectionCriterion =
+        xmlDomainImportContext.getSelectionCriteriaDefinition()->getSelectionCriterion(
+            strSelectionCriterion);
 
     // Check existence
     if (!_pSelectionCriterion) {
 
-        xmlDomainImportContext.setError("Couldn't find selection criterion " + strSelectionCriterion + " in " + getKind() + " " + xmlElement.getPath());
+        xmlDomainImportContext.setError("Couldn't find selection criterion " +
+                                        strSelectionCriterion + " in " + getKind() + " " +
+                                        xmlElement.getPath());
 
         return false;
     }
@@ -172,7 +172,8 @@ bool CSelectionCriterionRule::fromXml(const CXmlElement& xmlElement, CXmlSeriali
 
     if (!setMatchesWhen(strMatchesWhen, strError)) {
 
-        xmlDomainImportContext.setError("Wrong MatchesWhen attribute " + strMatchesWhen + " in " + getKind() + " " + xmlElement.getPath() + ": " + strError);
+        xmlDomainImportContext.setError("Wrong MatchesWhen attribute " + strMatchesWhen + " in " +
+                                        getKind() + " " + xmlElement.getPath() + ": " + strError);
 
         return false;
     }
@@ -183,7 +184,8 @@ bool CSelectionCriterionRule::fromXml(const CXmlElement& xmlElement, CXmlSeriali
 
     if (!_pSelectionCriterion->getCriterionType()->getNumericalValue(strValue, _iMatchValue)) {
 
-        xmlDomainImportContext.setError("Wrong Value attribute value " + strValue + " in " + getKind() + " " + xmlElement.getPath());
+        xmlDomainImportContext.setError("Wrong Value attribute value " + strValue + " in " +
+                                        getKind() + " " + xmlElement.getPath());
 
         return false;
     }
@@ -193,7 +195,7 @@ bool CSelectionCriterionRule::fromXml(const CXmlElement& xmlElement, CXmlSeriali
 }
 
 // From IXmlSource
-void CSelectionCriterionRule::toXml(CXmlElement& xmlElement, CXmlSerializingContext& /*ctx*/) const
+void CSelectionCriterionRule::toXml(CXmlElement &xmlElement, CXmlSerializingContext & /*ctx*/) const
 {
     assert(_pSelectionCriterion);
 
@@ -206,27 +208,29 @@ void CSelectionCriterionRule::toXml(CXmlElement& xmlElement, CXmlSerializingCont
     // Set Value
     string strValue;
 
-     _pSelectionCriterion->getCriterionType()->getLiteralValue(_iMatchValue, strValue);
+    _pSelectionCriterion->getCriterionType()->getLiteralValue(_iMatchValue, strValue);
 
     xmlElement.setAttribute("Value", strValue);
 }
 
 // XML MatchesWhen attribute parsing
-bool CSelectionCriterionRule::setMatchesWhen(const string& strMatchesWhen, string& strError)
+bool CSelectionCriterionRule::setMatchesWhen(const string &strMatchesWhen, string &strError)
 {
     for (size_t matchesWhen = 0; matchesWhen < ENbMatchesWhen; matchesWhen++) {
 
-        const SMatchingRuleDescription* pstMatchingRuleDescription = &_astMatchesWhen[matchesWhen];
+        const SMatchingRuleDescription *pstMatchingRuleDescription = &_astMatchesWhen[matchesWhen];
 
         if (strMatchesWhen == pstMatchingRuleDescription->pcMatchesWhen) {
 
             // Found it!
 
             // Get Type
-            const ISelectionCriterionTypeInterface* pSelectionCriterionType = _pSelectionCriterion->getCriterionType();
+            const ISelectionCriterionTypeInterface *pSelectionCriterionType =
+                _pSelectionCriterion->getCriterionType();
 
             // Check compatibility if relevant
-            if (!pSelectionCriterionType->isTypeInclusive() && !pstMatchingRuleDescription->bExclusiveTypeCompatible) {
+            if (!pSelectionCriterionType->isTypeInclusive() &&
+                !pstMatchingRuleDescription->bExclusiveTypeCompatible) {
 
                 strError = "Value incompatible with exclusive kind of type";
 

--- a/parameter/SelectionCriterionRule.h
+++ b/parameter/SelectionCriterionRule.h
@@ -38,7 +38,8 @@ class CSelectionCriterion;
 class CSelectionCriterionRule : public CRule
 {
     // Matching rules
-    enum MatchesWhen {
+    enum MatchesWhen
+    {
         EIs,
         EIsNot,
         EIncludes,
@@ -49,13 +50,13 @@ class CSelectionCriterionRule : public CRule
     // Matching rule description
     struct SMatchingRuleDescription
     {
-        const char* pcMatchesWhen;
+        const char *pcMatchesWhen;
         bool bExclusiveTypeCompatible;
     };
 
 public:
     // Parse
-    virtual bool parse(CRuleParser& ruleParser, std::string& strError);
+    virtual bool parse(CRuleParser &ruleParser, std::string &strError);
 
     // Dump
     std::string dump() const override;
@@ -64,22 +65,24 @@ public:
     virtual bool matches() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // Class kind
     virtual std::string getKind() const;
+
 protected:
     // Content dumping
-    std::string logValue(utility::ErrorContext& errorContext) const override;
+    std::string logValue(utility::ErrorContext &errorContext) const override;
+
 private:
     // XML MatchesWhen attribute parsing
-    bool setMatchesWhen(const std::string& strMatchesWhen, std::string& strError);
+    bool setMatchesWhen(const std::string &strMatchesWhen, std::string &strError);
 
     // Selection criterion
-    const CSelectionCriterion* _pSelectionCriterion{nullptr};
+    const CSelectionCriterion *_pSelectionCriterion{nullptr};
 
     // MatchesWhen
     MatchesWhen _eMatchesWhen{EIs};
@@ -90,4 +93,3 @@ private:
     // Used for XML MatchesWhen attribute parsing
     static const SMatchingRuleDescription _astMatchesWhen[ENbMatchesWhen];
 };
-

--- a/parameter/SelectionCriterionType.cpp
+++ b/parameter/SelectionCriterionType.cpp
@@ -51,16 +51,15 @@ std::string CSelectionCriterionType::getKind() const
 }
 
 // From ISelectionCriterionTypeInterface
-bool CSelectionCriterionType::addValuePair(
-        int iValue, const std::string& strValue, std::string& strError)
+bool CSelectionCriterionType::addValuePair(int iValue, const std::string &strValue,
+                                           std::string &strError)
 {
     // Check 1 bit set only for inclusive types
     if (_bInclusive && (!iValue || (iValue & (iValue - 1)))) {
 
         std::ostringstream error;
-        error << "Rejecting value pair association: 0x" << std::hex << iValue
-              << " - " << strValue << " for Selection Criterion Type "
-              << getName();
+        error << "Rejecting value pair association: 0x" << std::hex << iValue << " - " << strValue
+              << " for Selection Criterion Type " << getName();
         strError = error.str();
 
         return false;
@@ -70,9 +69,8 @@ bool CSelectionCriterionType::addValuePair(
     if (_numToLitMap.find(strValue) != _numToLitMap.end()) {
 
         std::ostringstream error;
-        error << "Rejecting value pair association (literal already present): 0x"
-              << std::hex << iValue << " - " << strValue
-              << " for Selection Criterion Type " << getName();
+        error << "Rejecting value pair association (literal already present): 0x" << std::hex
+              << iValue << " - " << strValue << " for Selection Criterion Type " << getName();
         strError = error.str();
 
         return false;
@@ -92,7 +90,7 @@ bool CSelectionCriterionType::addValuePair(
     return true;
 }
 
-bool CSelectionCriterionType::getNumericalValue(const std::string& strValue, int& iValue) const
+bool CSelectionCriterionType::getNumericalValue(const std::string &strValue, int &iValue) const
 {
     if (_bInclusive) {
 
@@ -117,7 +115,8 @@ bool CSelectionCriterionType::getNumericalValue(const std::string& strValue, int
     return getAtomicNumericalValue(strValue, iValue);
 }
 
-bool CSelectionCriterionType::getAtomicNumericalValue(const std::string& strValue, int& iValue) const
+bool CSelectionCriterionType::getAtomicNumericalValue(const std::string &strValue,
+                                                      int &iValue) const
 {
     NumToLitMapConstIt it = _numToLitMap.find(strValue);
 
@@ -130,7 +129,7 @@ bool CSelectionCriterionType::getAtomicNumericalValue(const std::string& strValu
     return false;
 }
 
-bool CSelectionCriterionType::getLiteralValue(int iValue, std::string& strValue) const
+bool CSelectionCriterionType::getLiteralValue(int iValue, std::string &strValue) const
 {
     NumToLitMapConstIt it;
 
@@ -229,7 +228,8 @@ std::string CSelectionCriterionType::getFormattedState(int iValue) const
 }
 
 // From IXmlSource
-void CSelectionCriterionType::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CSelectionCriterionType::toXml(CXmlElement &xmlElement,
+                                    CXmlSerializingContext &serializingContext) const
 {
     // Type Kind
     xmlElement.setAttribute("Kind", isTypeInclusive() ? "Inclusive" : "Exclusive");

--- a/parameter/SelectionCriterionType.h
+++ b/parameter/SelectionCriterionType.h
@@ -42,7 +42,7 @@ public:
     CSelectionCriterionType(bool bIsInclusive);
 
     // From ISelectionCriterionTypeInterface
-    virtual bool addValuePair(int iValue, const std::string& strValue, std::string& strError);
+    virtual bool addValuePair(int iValue, const std::string &strValue, std::string &strError);
     /**
      * Retrieve the numerical value from the std::string representation of the criterion type.
      *
@@ -53,8 +53,8 @@ public:
      *
      * @return true if integer value retrieved from the std::string one, false otherwise.
      */
-    virtual bool getNumericalValue(const std::string& strValue, int& iValue) const;
-    virtual bool getLiteralValue(int iValue, std::string& strValue) const;
+    virtual bool getNumericalValue(const std::string &strValue, int &iValue) const;
+    virtual bool getLiteralValue(int iValue, std::string &strValue) const;
     virtual bool isTypeInclusive() const;
 
     // Value list
@@ -70,10 +70,11 @@ public:
       * @param[in] serializingContext The serializing context
       *
       */
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // From CElement
     virtual std::string getKind() const;
+
 private:
     /**
      * Retrieve the numerical value from the std::string representation of the criterion type.
@@ -84,10 +85,9 @@ private:
      *
      * @return true if integer value retrieved from the std::string one, false otherwise.
      */
-    bool getAtomicNumericalValue(const std::string& strValue, int& iValue) const;
+    bool getAtomicNumericalValue(const std::string &strValue, int &iValue) const;
     bool _bInclusive;
     std::map<std::string, int> _numToLitMap;
 
     static const std::string _strDelimiter; /**< Inclusive criterion type delimiter. */
 };
-

--- a/parameter/SimulatedBackSynchronizer.cpp
+++ b/parameter/SimulatedBackSynchronizer.cpp
@@ -32,7 +32,8 @@
 
 #define base CBackSynchronizer
 
-CSimulatedBackSynchronizer::CSimulatedBackSynchronizer(const CConfigurableElement* pConfigurableElement, CParameterBlackboard* pParameterBlackboard)
+CSimulatedBackSynchronizer::CSimulatedBackSynchronizer(
+    const CConfigurableElement *pConfigurableElement, CParameterBlackboard *pParameterBlackboard)
     : base(pConfigurableElement), _parameterAccessContext(_strError)
 {
     _parameterAccessContext.setParameterBlackboard(pParameterBlackboard);
@@ -42,11 +43,11 @@ CSimulatedBackSynchronizer::CSimulatedBackSynchronizer(const CConfigurableElemen
 void CSimulatedBackSynchronizer::sync()
 {
     // Set default values to simulate back synchronization
-    std::list<const CConfigurableElement*>::const_iterator it;
+    std::list<const CConfigurableElement *>::const_iterator it;
 
     for (it = _needingBackSyncList.begin(); it != _needingBackSyncList.end(); ++it) {
 
-        const CConfigurableElement* pConfigurableElement = *it;
+        const CConfigurableElement *pConfigurableElement = *it;
 
         pConfigurableElement->setDefaultValues(_parameterAccessContext);
     }

--- a/parameter/SimulatedBackSynchronizer.h
+++ b/parameter/SimulatedBackSynchronizer.h
@@ -39,14 +39,15 @@ class CParameterBlackboard;
 class CSimulatedBackSynchronizer : public CBackSynchronizer
 {
 public:
-    CSimulatedBackSynchronizer(const CConfigurableElement* pConfigurableElement, CParameterBlackboard* pParameterBlackboard);
+    CSimulatedBackSynchronizer(const CConfigurableElement *pConfigurableElement,
+                               CParameterBlackboard *pParameterBlackboard);
 
     // Back synchronization
     virtual void sync();
+
 private:
     // Fake error for parameter context creation
     std::string _strError;
     // Parameter context
     CParameterAccessContext _parameterAccessContext;
 };
-

--- a/parameter/StringParameter.cpp
+++ b/parameter/StringParameter.cpp
@@ -37,7 +37,8 @@
 
 using std::string;
 
-CStringParameter::CStringParameter(const string& strName, const CTypeElement* pTypeElement) : base(strName, pTypeElement)
+CStringParameter::CStringParameter(const string &strName, const CTypeElement *pTypeElement)
+    : base(strName, pTypeElement)
 {
 }
 
@@ -53,39 +54,41 @@ size_t CStringParameter::getFootPrint() const
 
 size_t CStringParameter::getSize() const
 {
-    return static_cast<const CStringParameterType*>(getTypeElement())->getMaxLength() + 1;
+    return static_cast<const CStringParameterType *>(getTypeElement())->getMaxLength() + 1;
 }
 
 // Used for simulation and virtual subsystems
-void CStringParameter::setDefaultValues(CParameterAccessContext& parameterAccessContext) const
+void CStringParameter::setDefaultValues(CParameterAccessContext &parameterAccessContext) const
 {
     // Write blackboard
-    CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     pBlackboard->writeString("", getOffset());
 }
 
 // Actual parameter access (tuning)
-bool CStringParameter::doSetValue(const string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const
+bool CStringParameter::doSetValue(const string &strValue, size_t offset,
+                                  CParameterAccessContext &parameterAccessContext) const
 {
     if (strValue.length() >= getSize()) {
         using std::to_string;
-        parameterAccessContext.setError(
-                "Can not set a string of length " + to_string(strValue.length()) +
-                ": maximum length is " + std::to_string(getSize() - 1));
+        parameterAccessContext.setError("Can not set a string of length " +
+                                        to_string(strValue.length()) + ": maximum length is " +
+                                        std::to_string(getSize() - 1));
 
         return false;
     }
 
     // Write blackboard
-    CParameterBlackboard* pBlackboard = parameterAccessContext.getParameterBlackboard();
+    CParameterBlackboard *pBlackboard = parameterAccessContext.getParameterBlackboard();
 
     pBlackboard->writeString(strValue, offset);
 
     return true;
 }
 
-void CStringParameter::doGetValue(string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const
+void CStringParameter::doGetValue(string &strValue, size_t offset,
+                                  CParameterAccessContext &parameterAccessContext) const
 {
     parameterAccessContext.getParameterBlackboard()->readString(strValue, offset);
 }

--- a/parameter/StringParameter.h
+++ b/parameter/StringParameter.h
@@ -36,22 +36,24 @@
 class CStringParameter : public CBaseParameter
 {
 public:
-    CStringParameter(const std::string& strName, const CTypeElement* pTypeElement);
+    CStringParameter(const std::string &strName, const CTypeElement *pTypeElement);
 
     // Instantiation, allocation
     virtual size_t getFootPrint() const;
 
     // Type
     virtual Type getType() const;
+
 protected:
     // Used for simulation and virtual subsystems
-    virtual void setDefaultValues(CParameterAccessContext& parameterAccessContext) const;
+    virtual void setDefaultValues(CParameterAccessContext &parameterAccessContext) const;
 
     // Actual value access (tuning)
-    virtual bool doSetValue(const std::string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const;
-    virtual void doGetValue(std::string& strValue, size_t offset, CParameterAccessContext& parameterAccessContext) const;
+    virtual bool doSetValue(const std::string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const;
+    virtual void doGetValue(std::string &strValue, size_t offset,
+                            CParameterAccessContext &parameterAccessContext) const;
 
     // Size
     size_t getSize() const;
 };
-

--- a/parameter/StringParameterType.cpp
+++ b/parameter/StringParameterType.cpp
@@ -35,7 +35,7 @@
 
 using std::string;
 
-CStringParameterType::CStringParameterType(const string& strName) : base(strName)
+CStringParameterType::CStringParameterType(const string &strName) : base(strName)
 {
 }
 
@@ -46,7 +46,7 @@ string CStringParameterType::getKind() const
 }
 
 // Element properties
-void CStringParameterType::showProperties(string& strResult) const
+void CStringParameterType::showProperties(string &strResult) const
 {
     base::showProperties(strResult);
 
@@ -57,7 +57,8 @@ void CStringParameterType::showProperties(string& strResult) const
 }
 
 // From IXmlSink
-bool CStringParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CStringParameterType::fromXml(const CXmlElement &xmlElement,
+                                   CXmlSerializingContext &serializingContext)
 {
     // MaxLength
     xmlElement.getAttribute("MaxLength", _maxLength);
@@ -66,7 +67,7 @@ bool CStringParameterType::fromXml(const CXmlElement& xmlElement, CXmlSerializin
     return base::fromXml(xmlElement, serializingContext);
 }
 
-CInstanceConfigurableElement* CStringParameterType::doInstantiate() const
+CInstanceConfigurableElement *CStringParameterType::doInstantiate() const
 {
     return new CStringParameter(getName(), this);
 }
@@ -78,7 +79,8 @@ size_t CStringParameterType::getMaxLength() const
 }
 
 // From IXmlSource
-void CStringParameterType::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
+void CStringParameterType::toXml(CXmlElement &xmlElement,
+                                 CXmlSerializingContext &serializingContext) const
 {
     // MaxLength
     xmlElement.setAttribute("MaxLength", _maxLength);

--- a/parameter/StringParameterType.h
+++ b/parameter/StringParameterType.h
@@ -38,25 +38,26 @@
 class CStringParameterType : public CTypeElement
 {
 public:
-    CStringParameterType(const std::string& strName);
+    CStringParameterType(const std::string &strName);
 
     // Max length
     size_t getMaxLength() const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // CElement
     virtual std::string getKind() const;
+
 private:
     // Instantiation
-    virtual CInstanceConfigurableElement* doInstantiate() const;
+    virtual CInstanceConfigurableElement *doInstantiate() const;
 
     // Max length in bytes
     size_t _maxLength{0};

--- a/parameter/Subsystem.cpp
+++ b/parameter/Subsystem.cpp
@@ -44,7 +44,7 @@ using std::string;
 using std::list;
 using std::ostringstream;
 
-CSubsystem::CSubsystem(const string& strName, core::log::Logger& logger)
+CSubsystem::CSubsystem(const string &strName, core::log::Logger &logger)
     : base(strName), _pComponentLibrary(new CComponentLibrary),
       _pInstanceDefinition(new CInstanceDefinition), _logger(logger)
 {
@@ -92,8 +92,8 @@ bool CSubsystem::needResync(bool /*bClear*/)
     return false;
 }
 
-bool CSubsystem::structureFromXml(const CXmlElement& xmlElement,
-                                  CXmlSerializingContext& serializingContext)
+bool CSubsystem::structureFromXml(const CXmlElement &xmlElement,
+                                  CXmlSerializingContext &serializingContext)
 {
     // Subsystem class does not rely on generic fromXml algorithm of Element class.
     // So, setting here the description if found as XML attribute.
@@ -102,7 +102,8 @@ bool CSubsystem::structureFromXml(const CXmlElement& xmlElement,
     setDescription(description);
 
     // Context
-    CXmlParameterSerializingContext& parameterBuildContext = static_cast<CXmlParameterSerializingContext&>(serializingContext);
+    CXmlParameterSerializingContext &parameterBuildContext =
+        static_cast<CXmlParameterSerializingContext &>(serializingContext);
 
     // Install temporary component library for further component creation
     parameterBuildContext.setComponentLibrary(_pComponentLibrary);
@@ -154,7 +155,7 @@ bool CSubsystem::structureFromXml(const CXmlElement& xmlElement,
     return true;
 }
 
-bool CSubsystem::mapSubsystemElements(string& strError)
+bool CSubsystem::mapSubsystemElements(string &strError)
 {
     // Default mapping context
     CMappingContext context(_contextMappingKeyArray.size());
@@ -168,7 +169,8 @@ bool CSubsystem::mapSubsystemElements(string& strError)
 
     for (size_t child = 0; child < nbChildren; child++) {
 
-        CInstanceConfigurableElement* pInstanceConfigurableChildElement = static_cast<CInstanceConfigurableElement*>(getChild(child));
+        CInstanceConfigurableElement *pInstanceConfigurableChildElement =
+            static_cast<CInstanceConfigurableElement *>(getChild(child));
 
         if (!pInstanceConfigurableChildElement->map(*this, strError)) {
 
@@ -180,16 +182,16 @@ bool CSubsystem::mapSubsystemElements(string& strError)
 
 // Formats the mapping of the ConfigurableElements
 string CSubsystem::formatMappingDataList(
-        const list<const CConfigurableElement*>& configurableElementPath) const
+    const list<const CConfigurableElement *> &configurableElementPath) const
 {
     // The list is parsed in reverse order because it has been filled from the leaf to the trunk
     // of the tree. When formatting the mapping, we want to start from the subsystem level
     ostringstream ossStream;
-    list<const CConfigurableElement*>::const_reverse_iterator it;
+    list<const CConfigurableElement *>::const_reverse_iterator it;
     for (it = configurableElementPath.rbegin(); it != configurableElementPath.rend(); ++it) {
 
-        const CInstanceConfigurableElement* pInstanceConfigurableElement =
-                static_cast<const CInstanceConfigurableElement*>(*it);
+        const CInstanceConfigurableElement *pInstanceConfigurableElement =
+            static_cast<const CInstanceConfigurableElement *>(*it);
 
         ossStream << pInstanceConfigurableElement->getFormattedMapping() << ", ";
     }
@@ -197,12 +199,13 @@ string CSubsystem::formatMappingDataList(
 }
 
 // Find the CSubystemObject containing a specific CInstanceConfigurableElement
-const CSubsystemObject* CSubsystem::findSubsystemObjectFromConfigurableElement(
-        const CInstanceConfigurableElement* pInstanceConfigurableElement) const {
+const CSubsystemObject *CSubsystem::findSubsystemObjectFromConfigurableElement(
+    const CInstanceConfigurableElement *pInstanceConfigurableElement) const
+{
 
-    const CSubsystemObject* pSubsystemObject = NULL;
+    const CSubsystemObject *pSubsystemObject = NULL;
 
-    list<CSubsystemObject*>::const_iterator it;
+    list<CSubsystemObject *>::const_iterator it;
     for (it = _subsystemObjectList.begin(); it != _subsystemObjectList.end(); ++it) {
 
         // Check if one of the SubsystemObjects is associated with a ConfigurableElement
@@ -218,21 +221,20 @@ const CSubsystemObject* CSubsystem::findSubsystemObjectFromConfigurableElement(
 }
 
 void CSubsystem::findSubsystemLevelMappingKeyValue(
-        const CInstanceConfigurableElement* pInstanceConfigurableElement,
-        string& strMappingKey,
-        string& strMappingValue) const
+    const CInstanceConfigurableElement *pInstanceConfigurableElement, string &strMappingKey,
+    string &strMappingValue) const
 {
     // Find creator to get key name
-    std::vector<CSubsystemObjectCreator*>::const_iterator it;
-    for (it = _subsystemObjectCreatorArray.begin();
-         it != _subsystemObjectCreatorArray.end(); ++it) {
+    std::vector<CSubsystemObjectCreator *>::const_iterator it;
+    for (it = _subsystemObjectCreatorArray.begin(); it != _subsystemObjectCreatorArray.end();
+         ++it) {
 
-        const CSubsystemObjectCreator* pSubsystemObjectCreator = *it;
+        const CSubsystemObjectCreator *pSubsystemObjectCreator = *it;
 
         strMappingKey = pSubsystemObjectCreator->getMappingKey();
 
         // Check if the ObjectCreator MappingKey corresponds to the element mapping data
-        const string* pStrValue;
+        const string *pStrValue;
         if (pInstanceConfigurableElement->getMappingData(strMappingKey, pStrValue)) {
 
             strMappingValue = *pStrValue;
@@ -244,11 +246,11 @@ void CSubsystem::findSubsystemLevelMappingKeyValue(
 
 // Formats the mapping data as a comma separated list of key value pairs
 string CSubsystem::getFormattedSubsystemMappingData(
-        const CInstanceConfigurableElement* pInstanceConfigurableElement) const
+    const CInstanceConfigurableElement *pInstanceConfigurableElement) const
 {
     // Find the SubsystemObject related to pInstanceConfigurableElement
-    const CSubsystemObject* pSubsystemObject = findSubsystemObjectFromConfigurableElement(
-                pInstanceConfigurableElement);
+    const CSubsystemObject *pSubsystemObject =
+        findSubsystemObjectFromConfigurableElement(pInstanceConfigurableElement);
 
     // Exit if node does not correspond to a SubsystemObject
     if (pSubsystemObject == NULL) {
@@ -265,7 +267,7 @@ string CSubsystem::getFormattedSubsystemMappingData(
     return strMappingKey + ":" + pSubsystemObject->getFormattedMappingValue();
 }
 
-string CSubsystem::getMapping(list<const CConfigurableElement*>& configurableElementPath) const
+string CSubsystem::getMapping(list<const CConfigurableElement *> &configurableElementPath) const
 {
     if (configurableElementPath.empty()) {
 
@@ -273,8 +275,8 @@ string CSubsystem::getMapping(list<const CConfigurableElement*>& configurableEle
     }
 
     // Get the first element, which is the element containing the amended mapping
-    const CInstanceConfigurableElement* pInstanceConfigurableElement =
-            static_cast<const CInstanceConfigurableElement*>(configurableElementPath.front());
+    const CInstanceConfigurableElement *pInstanceConfigurableElement =
+        static_cast<const CInstanceConfigurableElement *>(configurableElementPath.front());
     configurableElementPath.pop_front();
     // Now the list only contains elements whose mapping are related to the context
 
@@ -288,43 +290,38 @@ string CSubsystem::getMapping(list<const CConfigurableElement*>& configurableEle
 }
 
 // Used for simulation and virtual subsystems
-void CSubsystem::setDefaultValues(CParameterAccessContext& parameterAccessContext) const
+void CSubsystem::setDefaultValues(CParameterAccessContext &parameterAccessContext) const
 {
     base::setDefaultValues(parameterAccessContext);
 }
 
 // Belonging subsystem
-const CSubsystem* CSubsystem::getBelongingSubsystem() const
+const CSubsystem *CSubsystem::getBelongingSubsystem() const
 {
     return this;
 }
 
 // Subsystem context mapping keys publication
-void CSubsystem::addContextMappingKey(const string& strMappingKey)
+void CSubsystem::addContextMappingKey(const string &strMappingKey)
 {
     _contextMappingKeyArray.push_back(strMappingKey);
 }
 
 // Subsystem object creator publication (strong reference)
-void CSubsystem::addSubsystemObjectFactory(CSubsystemObjectCreator* pSubsystemObjectCreator)
+void CSubsystem::addSubsystemObjectFactory(CSubsystemObjectCreator *pSubsystemObjectCreator)
 {
     _subsystemObjectCreatorArray.push_back(pSubsystemObjectCreator);
 }
 
 // Generic error handling from derived subsystem classes
-string CSubsystem::getMappingError(
-        const string& strKey,
-        const string& strMessage,
-        const CConfigurableElement* pConfigurableElement) const
+string CSubsystem::getMappingError(const string &strKey, const string &strMessage,
+                                   const CConfigurableElement *pConfigurableElement) const
 {
-    return getName() + " " + getKind() + " " +
-            "mapping:\n" + strKey + " " +
-            "error: \"" + strMessage + "\" " +
-            "for element " + pConfigurableElement->getPath();
+    return getName() + " " + getKind() + " " + "mapping:\n" + strKey + " " + "error: \"" +
+           strMessage + "\" " + "for element " + pConfigurableElement->getPath();
 }
 
-
-bool CSubsystem::getMappingData(const std::string& strKey, const std::string*& pStrValue) const
+bool CSubsystem::getMappingData(const std::string &strKey, const std::string *&pStrValue) const
 {
     if (_pMappingData) {
 
@@ -334,16 +331,14 @@ bool CSubsystem::getMappingData(const std::string& strKey, const std::string*& p
 }
 
 // Mapping generic context handling
-bool CSubsystem::handleMappingContext(
-        const CConfigurableElement* pConfigurableElement,
-        CMappingContext& context,
-        string& strError) const
+bool CSubsystem::handleMappingContext(const CConfigurableElement *pConfigurableElement,
+                                      CMappingContext &context, string &strError) const
 {
     // Feed context with found mapping data
     for (size_t item = 0; item < _contextMappingKeyArray.size(); item++) {
 
-        const string& strKey = _contextMappingKeyArray[item];
-        const string* pStrValue;
+        const string &strKey = _contextMappingKeyArray[item];
+        const string *pStrValue;
 
         if (pConfigurableElement->getMappingData(strKey, pStrValue)) {
             // Assign item to context
@@ -360,8 +355,8 @@ bool CSubsystem::handleMappingContext(
 
 // Subsystem object creation handling
 bool CSubsystem::handleSubsystemObjectCreation(
-        CInstanceConfigurableElement* pInstanceConfigurableElement,
-        CMappingContext& context, bool& bHasCreatedSubsystemObject, string& strError)
+    CInstanceConfigurableElement *pInstanceConfigurableElement, CMappingContext &context,
+    bool &bHasCreatedSubsystemObject, string &strError)
 {
     bHasCreatedSubsystemObject = false;
 
@@ -370,7 +365,7 @@ bool CSubsystem::handleSubsystemObjectCreation(
         // Mapping key
         string strKey = pSubsystemObjectCreator->getMappingKey();
         // Object id
-        const string* pStrValue;
+        const string *pStrValue;
 
         if (pInstanceConfigurableElement->getMappingData(strKey, pStrValue)) {
 
@@ -378,7 +373,8 @@ bool CSubsystem::handleSubsystemObjectCreation(
             // (required ancestors must have been set prior to object creation)
             uint32_t uiAncestorMask = pSubsystemObjectCreator->getAncestorMask();
 
-            for (size_t uiAncestorKey = 0; uiAncestorKey < _contextMappingKeyArray.size(); uiAncestorKey++) {
+            for (size_t uiAncestorKey = 0; uiAncestorKey < _contextMappingKeyArray.size();
+                 uiAncestorKey++) {
 
                 if (!((1 << uiAncestorKey) & uiAncestorMask)) {
                     // Ancestor not required
@@ -387,8 +383,9 @@ bool CSubsystem::handleSubsystemObjectCreation(
                 // Check ancestor was provided
                 if (!context.iSet(uiAncestorKey)) {
 
-                    strError = getMappingError(strKey, _contextMappingKeyArray[uiAncestorKey] +
-                                               " not set", pInstanceConfigurableElement);
+                    strError =
+                        getMappingError(strKey, _contextMappingKeyArray[uiAncestorKey] + " not set",
+                                        pInstanceConfigurableElement);
 
                     return false;
                 }
@@ -398,9 +395,9 @@ bool CSubsystem::handleSubsystemObjectCreation(
             if (pInstanceConfigurableElement->getFootPrint() >
                 pSubsystemObjectCreator->getMaxConfigurableElementSize()) {
 
-                string strSizeError = "Size should not exceed " +
-                                      std::to_string(
-                                        pSubsystemObjectCreator->getMaxConfigurableElementSize());
+                string strSizeError =
+                    "Size should not exceed " +
+                    std::to_string(pSubsystemObjectCreator->getMaxConfigurableElementSize());
 
                 strError = getMappingError(strKey, strSizeError, pInstanceConfigurableElement);
 
@@ -409,7 +406,7 @@ bool CSubsystem::handleSubsystemObjectCreation(
 
             // Do create object and keep its track
             _subsystemObjectList.push_back(pSubsystemObjectCreator->objectCreate(
-                    *pStrValue, pInstanceConfigurableElement, context, _logger));
+                *pStrValue, pInstanceConfigurableElement, context, _logger));
 
             // Indicate subsytem creation to caller
             bHasCreatedSubsystemObject = true;
@@ -425,15 +422,14 @@ bool CSubsystem::handleSubsystemObjectCreation(
 
 // From IMapper
 // Handle a configurable element mapping
-bool CSubsystem::mapBegin(CInstanceConfigurableElement* pInstanceConfigurableElement,
-                          bool& bKeepDiving, string& strError)
+bool CSubsystem::mapBegin(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                          bool &bKeepDiving, string &strError)
 {
     // Get current context
     CMappingContext context = _contextStack.top();
 
     // Add mapping in context
-    if (!handleMappingContext(pInstanceConfigurableElement, context,
-                              strError)) {
+    if (!handleMappingContext(pInstanceConfigurableElement, context, strError)) {
 
         return false;
     }
@@ -447,40 +443,39 @@ bool CSubsystem::mapBegin(CInstanceConfigurableElement* pInstanceConfigurableEle
     // Deal with ambiguous usage of parameter blocks
     bool bShouldCreateSubsystemObject = true;
 
-    switch(pInstanceConfigurableElement->getType()) {
+    switch (pInstanceConfigurableElement->getType()) {
 
-        case CInstanceConfigurableElement::EComponent:
-        case CInstanceConfigurableElement::EParameterBlock:
-            // Subsystem object creation is optional in parameter blocks
-            bShouldCreateSubsystemObject = false;
-            // No break
-        case CInstanceConfigurableElement::EBitParameterBlock:
-        case CInstanceConfigurableElement::EParameter:
-        case CInstanceConfigurableElement::EStringParameter:
+    case CInstanceConfigurableElement::EComponent:
+    case CInstanceConfigurableElement::EParameterBlock:
+        // Subsystem object creation is optional in parameter blocks
+        bShouldCreateSubsystemObject = false;
+    // No break
+    case CInstanceConfigurableElement::EBitParameterBlock:
+    case CInstanceConfigurableElement::EParameter:
+    case CInstanceConfigurableElement::EStringParameter:
 
-            bool bHasCreatedSubsystemObject;
+        bool bHasCreatedSubsystemObject;
 
-            if (!handleSubsystemObjectCreation(pInstanceConfigurableElement, context,
-                                               bHasCreatedSubsystemObject, strError)) {
+        if (!handleSubsystemObjectCreation(pInstanceConfigurableElement, context,
+                                           bHasCreatedSubsystemObject, strError)) {
 
-                return false;
-            }
-            // Check for creation error
-            if (bShouldCreateSubsystemObject && !bHasCreatedSubsystemObject) {
-
-                strError = getMappingError("Not found",
-                                           "Subsystem object mapping key is missing",
-                                           pInstanceConfigurableElement);
-                return false;
-            }
-            // Not created and no error, keep diving
-            bKeepDiving = !bHasCreatedSubsystemObject;
-
-            return true;
-
-        default:
-            assert(0);
             return false;
+        }
+        // Check for creation error
+        if (bShouldCreateSubsystemObject && !bHasCreatedSubsystemObject) {
+
+            strError = getMappingError("Not found", "Subsystem object mapping key is missing",
+                                       pInstanceConfigurableElement);
+            return false;
+        }
+        // Not created and no error, keep diving
+        bKeepDiving = !bHasCreatedSubsystemObject;
+
+        return true;
+
+    default:
+        assert(0);
+        return false;
     }
 }
 

--- a/parameter/Subsystem.h
+++ b/parameter/Subsystem.h
@@ -51,20 +51,20 @@ class CMappingData;
 class PARAMETER_EXPORT CSubsystem : public CConfigurableElement, private IMapper
 {
     // Subsystem objects iterator
-    typedef std::list<CSubsystemObject*>::const_iterator SubsystemObjectListIterator;
-public:
+    typedef std::list<CSubsystemObject *>::const_iterator SubsystemObjectListIterator;
 
+public:
     /**
      * Class Constructor
      *
      * @param[in] strName subsystem name
      * @param[in] logger the main logger of the application
      */
-    CSubsystem(const std::string& strName, core::log::Logger& logger);
+    CSubsystem(const std::string &strName, core::log::Logger &logger);
     virtual ~CSubsystem();
 
-    virtual bool structureFromXml(const CXmlElement& xmlElement,
-                                  CXmlSerializingContext& serializingContext);
+    virtual bool structureFromXml(const CXmlElement &xmlElement,
+                                  CXmlSerializingContext &serializingContext);
 
     // Susbsystem sanity
     virtual bool isAlive() const;
@@ -75,12 +75,13 @@ public:
     // from CElement
     virtual std::string getKind() const;
 
-    virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const;
+    virtual bool getMappingData(const std::string &strKey, const std::string *&pStrValue) const;
 
     /**
      * Fetch mapping data of an element.
      *
-     * The mapping is represented as a std::string of all the mapping data (key:value) defined in the
+     * The mapping is represented as a std::string of all the mapping data (key:value) defined in
+     * the
      * context of the element.
      * This method gathers the mapping data found in each Element of the configurableElementPath
      * list to format the resulting std::string.
@@ -91,26 +92,28 @@ public:
      *
      * @return Formatted std::string of the mapping data
      */
-    virtual std::string getMapping(std::list<const CConfigurableElement*>& configurableElementPath) const;
+    virtual std::string getMapping(
+        std::list<const CConfigurableElement *> &configurableElementPath) const;
 
 protected:
     // Used for simulation and virtual subsystems
-    virtual void setDefaultValues(CParameterAccessContext& parameterAccessContext) const;
+    virtual void setDefaultValues(CParameterAccessContext &parameterAccessContext) const;
 
     /// Functionality intendedn for derived Subsystems
     // Subsystem context mapping keys publication
-    void addContextMappingKey(const std::string& strMappingKey);
+    void addContextMappingKey(const std::string &strMappingKey);
     // Subsystem object creator publication (strong reference)
-    void addSubsystemObjectFactory(CSubsystemObjectCreator* pSubsystemObjectCreator);
+    void addSubsystemObjectFactory(CSubsystemObjectCreator *pSubsystemObjectCreator);
+
 private:
-    CSubsystem(const CSubsystem&);
-    CSubsystem& operator=(const CSubsystem&);
+    CSubsystem(const CSubsystem &);
+    CSubsystem &operator=(const CSubsystem &);
 
     // Belonging subsystem
-    virtual const CSubsystem* getBelongingSubsystem() const;
+    virtual const CSubsystem *getBelongingSubsystem() const;
 
     // Mapping execution
-    bool mapSubsystemElements(std::string& strError);
+    bool mapSubsystemElements(std::string &strError);
 
     /**
      * Handle a configurable element mapping.
@@ -126,7 +129,8 @@ private:
      *
      * @return true on success, false on failure
      */
-    virtual bool mapBegin(CInstanceConfigurableElement* pInstanceConfigurableElement, bool& bKeepDiving, std::string& strError);
+    virtual bool mapBegin(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                          bool &bKeepDiving, std::string &strError);
     virtual void mapEnd();
 
     // Mapping access
@@ -141,10 +145,8 @@ private:
      *
      * returns The formated error std::string
      */
-    std::string getMappingError(
-            const std::string& strKey,
-            const std::string& strMessage,
-            const CConfigurableElement* pConfigurableElement) const;
+    std::string getMappingError(const std::string &strKey, const std::string &strMessage,
+                                const CConfigurableElement *pConfigurableElement) const;
 
     /**
      * Format the mapping data of the ConfigurableElements that have been gathered through recursive
@@ -157,7 +159,7 @@ private:
      * @return String containing the formatted mapping
      */
     std::string formatMappingDataList(
-            const std::list<const CConfigurableElement*>& configurableElementPath) const;
+        const std::list<const CConfigurableElement *> &configurableElementPath) const;
 
     /**
      * Find the SubystemObject which contains a specific CInstanceConfigurableElement.
@@ -168,8 +170,8 @@ private:
      *
      * @return A pointer to the SubsystemObject related to pInstanceConfigurableElement
      */
-    const CSubsystemObject* findSubsystemObjectFromConfigurableElement(
-            const CInstanceConfigurableElement* pInstanceConfigurableElement) const;
+    const CSubsystemObject *findSubsystemObjectFromConfigurableElement(
+        const CInstanceConfigurableElement *pInstanceConfigurableElement) const;
 
     /**
      * Find the mapping data defined for the CInstanceConfigurableElement given in parameter, that
@@ -183,9 +185,8 @@ private:
      * @param[out] strMappingValue Mapping value contained in pInstanceConfigurableElement
      */
     void findSubsystemLevelMappingKeyValue(
-            const CInstanceConfigurableElement* pInstanceConfigurableElement,
-            std::string& strMappingKey,
-            std::string& strMappingValue) const;
+        const CInstanceConfigurableElement *pInstanceConfigurableElement,
+        std::string &strMappingKey, std::string &strMappingValue) const;
 
     /**
      * Formats the mapping of a SubsystemObject
@@ -195,7 +196,7 @@ private:
      * @return String containing the formatted mapping
      */
     std::string getFormattedSubsystemMappingData(
-            const CInstanceConfigurableElement* pInstanceConfigurableElement) const;
+        const CInstanceConfigurableElement *pInstanceConfigurableElement) const;
     /**
      * Generic context handling
      *
@@ -207,10 +208,8 @@ private:
      *
      * @return true on success
      */
-    bool handleMappingContext(
-            const CConfigurableElement* pConfigurableElement,
-            CMappingContext& context,
-            std::string& strError) const;
+    bool handleMappingContext(const CConfigurableElement *pConfigurableElement,
+                              CMappingContext &context, std::string &strError) const;
 
     /**
      * Looks if a subsystem object needs to be instantiated for the given configurable
@@ -226,29 +225,29 @@ private:
      *
      * @return true on success, false on failure
      */
-    bool handleSubsystemObjectCreation(CInstanceConfigurableElement* pInstanceConfigurableElement,
-                                       CMappingContext& context, bool& bHasCreatedSubsystemObject,
-                                       std::string& strError);
+    bool handleSubsystemObjectCreation(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                                       CMappingContext &context, bool &bHasCreatedSubsystemObject,
+                                       std::string &strError);
 
     // Subsystem context mapping keys
     std::vector<std::string> _contextMappingKeyArray;
 
     // Subsystem object creator map
-    std::vector<CSubsystemObjectCreator*> _subsystemObjectCreatorArray;
+    std::vector<CSubsystemObjectCreator *> _subsystemObjectCreatorArray;
 
     // Subsystem sync objects (house keeping)
-    std::list<CSubsystemObject*> _subsystemObjectList;
+    std::list<CSubsystemObject *> _subsystemObjectList;
 
     // Mapping Context stack
     std::stack<CMappingContext> _contextStack;
 
     // Subelements
-    CComponentLibrary* _pComponentLibrary;
-    CInstanceDefinition* _pInstanceDefinition;
+    CComponentLibrary *_pComponentLibrary;
+    CInstanceDefinition *_pInstanceDefinition;
 
     //! Contains the mapping info at Subsystem level
-    CMappingData* _pMappingData{nullptr};
+    CMappingData *_pMappingData{nullptr};
 
     /** Logger which has to be provided to subsystem objects */
-    core::log::Logger& _logger;
+    core::log::Logger &_logger;
 };

--- a/parameter/SubsystemElementBuilder.cpp
+++ b/parameter/SubsystemElementBuilder.cpp
@@ -30,12 +30,12 @@
 #include "SubsystemElementBuilder.h"
 #include "SubsystemLibrary.h"
 
-CSubsystemElementBuilder::CSubsystemElementBuilder(const CSubsystemLibrary* pSubsystemLibrary) :
-    CElementBuilder(), _pSubsystemLibrary(pSubsystemLibrary)
+CSubsystemElementBuilder::CSubsystemElementBuilder(const CSubsystemLibrary *pSubsystemLibrary)
+    : CElementBuilder(), _pSubsystemLibrary(pSubsystemLibrary)
 {
 }
 
-CElement* CSubsystemElementBuilder::createElement(const CXmlElement& xmlElement) const
+CElement *CSubsystemElementBuilder::createElement(const CXmlElement &xmlElement) const
 {
     return _pSubsystemLibrary->createElement(xmlElement);
 }

--- a/parameter/SubsystemElementBuilder.h
+++ b/parameter/SubsystemElementBuilder.h
@@ -36,11 +36,10 @@ class CSubsystemLibrary;
 class CSubsystemElementBuilder : public CElementBuilder
 {
 public:
-    CSubsystemElementBuilder(const CSubsystemLibrary* pSubsystemLibrary);
+    CSubsystemElementBuilder(const CSubsystemLibrary *pSubsystemLibrary);
 
-    virtual CElement* createElement(const CXmlElement& xmlElement) const;
+    virtual CElement *createElement(const CXmlElement &xmlElement) const;
 
 private:
-    const CSubsystemLibrary* _pSubsystemLibrary;
+    const CSubsystemLibrary *_pSubsystemLibrary;
 };
-

--- a/parameter/SubsystemLibrary.h
+++ b/parameter/SubsystemLibrary.h
@@ -43,12 +43,12 @@
  */
 #define PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1 ParameterFrameworkPluginEntryPointMagicV1
 
-class CSubsystemLibrary :
-        public CDefaultElementLibrary<TLoggingElementBuilderTemplate<CVirtualSubsystem> >
+class CSubsystemLibrary
+    : public CDefaultElementLibrary<TLoggingElementBuilderTemplate<CVirtualSubsystem>>
 {
 private:
     // Builder type (based on element's name attribute)
-    virtual std::string getBuilderType(const CXmlElement& xmlElement) const
+    virtual std::string getBuilderType(const CXmlElement &xmlElement) const
     {
         // Xml element's name attribute
         std::string type;

--- a/parameter/SubsystemObject.cpp
+++ b/parameter/SubsystemObject.cpp
@@ -43,10 +43,9 @@
 
 using std::string;
 
-CSubsystemObject::CSubsystemObject(CInstanceConfigurableElement* pInstanceConfigurableElement,
-                                   core::log::Logger& logger)
-    : _logger(logger),
-      _pInstanceConfigurableElement(pInstanceConfigurableElement),
+CSubsystemObject::CSubsystemObject(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                                   core::log::Logger &logger)
+    : _logger(logger), _pInstanceConfigurableElement(pInstanceConfigurableElement),
       _dataSize(pInstanceConfigurableElement->getFootPrint())
 {
     // Syncer
@@ -65,7 +64,7 @@ string CSubsystemObject::getFormattedMappingValue() const
 }
 
 // Blackboard data location
-uint8_t* CSubsystemObject::getBlackboardLocation() const
+uint8_t *CSubsystemObject::getBlackboardLocation() const
 {
     return _blackboard->getLocation(getOffset());
 }
@@ -77,8 +76,7 @@ size_t CSubsystemObject::getSize() const
 }
 
 int CSubsystemObject::toPlainInteger(
-        const CInstanceConfigurableElement *instanceConfigurableElement,
-        int sizeOptimizedData)
+    const CInstanceConfigurableElement *instanceConfigurableElement, int sizeOptimizedData)
 {
     if (instanceConfigurableElement) {
 
@@ -94,7 +92,7 @@ int CSubsystemObject::toPlainInteger(
 }
 
 // Default back synchronization
-void CSubsystemObject::setDefaultValues(CParameterBlackboard& parameterBlackboard) const
+void CSubsystemObject::setDefaultValues(CParameterBlackboard &parameterBlackboard) const
 {
     string strError;
 
@@ -106,7 +104,7 @@ void CSubsystemObject::setDefaultValues(CParameterBlackboard& parameterBlackboar
 }
 
 // Synchronization
-bool CSubsystemObject::sync(CParameterBlackboard& parameterBlackboard, bool bBack, string& strError)
+bool CSubsystemObject::sync(CParameterBlackboard &parameterBlackboard, bool bBack, string &strError)
 {
     // Get blackboard location
     _blackboard = &parameterBlackboard;
@@ -118,7 +116,7 @@ bool CSubsystemObject::sync(CParameterBlackboard& parameterBlackboard, bool bBac
 #endif
 
     // Retrieve subsystem
-    const CSubsystem* pSubsystem = _pInstanceConfigurableElement->getBelongingSubsystem();
+    const CSubsystem *pSubsystem = _pInstanceConfigurableElement->getBelongingSubsystem();
 
     // Get it's health insdicator
     bool bIsSubsystemAlive = pSubsystem->isAlive();
@@ -135,7 +133,7 @@ bool CSubsystemObject::sync(CParameterBlackboard& parameterBlackboard, bool bBac
         // Fall back to parameter default initialization
         if (bBack) {
 
-           setDefaultValues(parameterBlackboard);
+            setDefaultValues(parameterBlackboard);
         }
         return false;
     }
@@ -144,14 +142,14 @@ bool CSubsystemObject::sync(CParameterBlackboard& parameterBlackboard, bool bBac
 }
 
 // Sync to/from HW
-bool CSubsystemObject::sendToHW(string& strError)
+bool CSubsystemObject::sendToHW(string &strError)
 {
     strError = "Send to HW interface not implemented at subsystem level";
 
     return false;
 }
 
-bool CSubsystemObject::receiveFromHW(string& /*strError*/)
+bool CSubsystemObject::receiveFromHW(string & /*strError*/)
 {
     // Back synchronization is not supported at subsystem level.
     // Rely on blackboard content
@@ -160,7 +158,7 @@ bool CSubsystemObject::receiveFromHW(string& /*strError*/)
 }
 
 // Fall back HW access
-bool CSubsystemObject::accessHW(bool bReceive, string& strError)
+bool CSubsystemObject::accessHW(bool bReceive, string &strError)
 {
     // Default access fall back
     if (bReceive) {
@@ -173,14 +171,14 @@ bool CSubsystemObject::accessHW(bool bReceive, string& strError)
 }
 
 // Blackboard access from subsystems
-void CSubsystemObject::blackboardRead(void* pvData, size_t size)
+void CSubsystemObject::blackboardRead(void *pvData, size_t size)
 {
     _blackboard->readBuffer(pvData, size, getOffset() + _accessedIndex);
 
     _accessedIndex += size;
 }
 
-void CSubsystemObject::blackboardWrite(const void* pvData, size_t size)
+void CSubsystemObject::blackboardWrite(const void *pvData, size_t size)
 {
     _blackboard->writeBuffer(pvData, size, getOffset() + _accessedIndex);
 
@@ -188,12 +186,12 @@ void CSubsystemObject::blackboardWrite(const void* pvData, size_t size)
 }
 
 // Configurable element retrieval
-const CInstanceConfigurableElement* CSubsystemObject::getConfigurableElement() const
+const CInstanceConfigurableElement *CSubsystemObject::getConfigurableElement() const
 {
     return _pInstanceConfigurableElement;
 }
 // Belonging Subsystem retrieval
-const CSubsystem* CSubsystemObject::getSubsystem() const
+const CSubsystem *CSubsystemObject::getSubsystem() const
 {
     return _pInstanceConfigurableElement->getBelongingSubsystem();
 }

--- a/parameter/SubsystemObject.h
+++ b/parameter/SubsystemObject.h
@@ -44,8 +44,8 @@ class CSubsystem;
 class PARAMETER_EXPORT CSubsystemObject : private ISyncer
 {
 public:
-    CSubsystemObject(CInstanceConfigurableElement* pInstanceConfigurableElement,
-                     core::log::Logger& logger);
+    CSubsystemObject(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                     core::log::Logger &logger);
     virtual ~CSubsystemObject();
 
     /**
@@ -56,13 +56,13 @@ public:
     virtual std::string getFormattedMappingValue() const;
 
     // Configurable element retrieval
-    const CInstanceConfigurableElement* getConfigurableElement() const;
+    const CInstanceConfigurableElement *getConfigurableElement() const;
 
 protected:
     /** FIXME: plugins should not have direct access to blackboard memory.
      *         Ie: This method should be removed or return a abstracted iterator.
      */
-    uint8_t* getBlackboardLocation() const;
+    uint8_t *getBlackboardLocation() const;
     // Size
     size_t getSize() const;
 
@@ -78,15 +78,15 @@ protected:
                        int sizeOptimizedData);
 
     // Sync to/from HW
-    virtual bool sendToHW(std::string& strError);
-    virtual bool receiveFromHW(std::string& strError);
+    virtual bool sendToHW(std::string &strError);
+    virtual bool receiveFromHW(std::string &strError);
     // Fall back HW access
-    virtual bool accessHW(bool bReceive, std::string& strError);
+    virtual bool accessHW(bool bReceive, std::string &strError);
     // Blackboard access from subsystems
-    void blackboardRead(void* pvData, size_t size);
-    void blackboardWrite(const void* pvData, size_t size);
+    void blackboardRead(void *pvData, size_t size);
+    void blackboardWrite(const void *pvData, size_t size);
     // Belonging Subsystem retrieval
-    const CSubsystem* getSubsystem() const;
+    const CSubsystem *getSubsystem() const;
 
     /** Logging methods
      *@{
@@ -100,30 +100,30 @@ private:
     /** This method is not supposed to be overridden by plugins
      *  as if not called, plugins will not work (sets _blackboard).
      */
-    bool sync(CParameterBlackboard& parameterBlackboard, bool bBack, std::string& strError) override final;
+    bool sync(CParameterBlackboard &parameterBlackboard, bool bBack,
+              std::string &strError) override final;
 
     // Default back synchronization
-    void setDefaultValues(CParameterBlackboard& parameterBlackboard) const;
+    void setDefaultValues(CParameterBlackboard &parameterBlackboard) const;
 
     /** @return the offset in the main blackboard of the sync values. */
     size_t getOffset() const;
 
     // Prevent unsupported operators
-    CSubsystemObject(const CSubsystemObject&);
+    CSubsystemObject(const CSubsystemObject &);
 
     // Define affection operator
-    const CSubsystemObject& operator=(const CSubsystemObject&);
+    const CSubsystemObject &operator=(const CSubsystemObject &);
 
     /** Application Logger */
-    core::log::Logger& _logger;
+    core::log::Logger &_logger;
 
     // Instance element to sync from/to
-    CInstanceConfigurableElement* _pInstanceConfigurableElement;
+    CInstanceConfigurableElement *_pInstanceConfigurableElement;
     // Data size
     size_t _dataSize;
     // Blackboard data location
-    CParameterBlackboard* _blackboard{nullptr};
+    CParameterBlackboard *_blackboard{nullptr};
     // Accessed index for Subsystem read/write from/to blackboard
     size_t _accessedIndex{0};
 };
-

--- a/parameter/SubsystemObjectCreator.cpp
+++ b/parameter/SubsystemObjectCreator.cpp
@@ -31,13 +31,16 @@
 
 using std::string;
 
-CSubsystemObjectCreator::CSubsystemObjectCreator(const string& strMappingKey, uint32_t uiAncestorIdMask, size_t maxConfigurableElementSize)
-    : _strMappingKey(strMappingKey), _uiAncestorIdMask(uiAncestorIdMask), _maxConfigurableElementSize(maxConfigurableElementSize)
+CSubsystemObjectCreator::CSubsystemObjectCreator(const string &strMappingKey,
+                                                 uint32_t uiAncestorIdMask,
+                                                 size_t maxConfigurableElementSize)
+    : _strMappingKey(strMappingKey), _uiAncestorIdMask(uiAncestorIdMask),
+      _maxConfigurableElementSize(maxConfigurableElementSize)
 {
 }
 
 // Accessors
-const string& CSubsystemObjectCreator::getMappingKey() const
+const string &CSubsystemObjectCreator::getMappingKey() const
 {
     return _strMappingKey;
 }

--- a/parameter/SubsystemObjectCreator.h
+++ b/parameter/SubsystemObjectCreator.h
@@ -38,19 +38,19 @@
 class PARAMETER_EXPORT CSubsystemObjectCreator
 {
 public:
-    CSubsystemObjectCreator(const std::string& strMappingKey, uint32_t uiAncestorIdMask, size_t maxConfigurableElementSize);
+    CSubsystemObjectCreator(const std::string &strMappingKey, uint32_t uiAncestorIdMask,
+                            size_t maxConfigurableElementSize);
 
     // Accessors
-    const std::string& getMappingKey() const;
+    const std::string &getMappingKey() const;
     uint32_t getAncestorMask() const;
     size_t getMaxConfigurableElementSize() const;
 
     // Object creation
-    virtual CSubsystemObject* objectCreate(
-            const std::string& strMappingValue,
-            CInstanceConfigurableElement* pInstanceConfigurableElement,
-            const CMappingContext& context,
-            core::log::Logger& logger) const = 0;
+    virtual CSubsystemObject *objectCreate(
+        const std::string &strMappingValue,
+        CInstanceConfigurableElement *pInstanceConfigurableElement, const CMappingContext &context,
+        core::log::Logger &logger) const = 0;
 
     virtual ~CSubsystemObjectCreator() = default;
 
@@ -62,4 +62,3 @@ private:
     // Masximum expected size for configurable elment (-1 means none)
     size_t _maxConfigurableElementSize;
 };
-

--- a/parameter/SubsystemObjectFactory.h
+++ b/parameter/SubsystemObjectFactory.h
@@ -37,17 +37,19 @@ template <class SubsystemObjectType>
 class TSubsystemObjectFactory : public CSubsystemObjectCreator
 {
 public:
-    TSubsystemObjectFactory(const std::string& strMappingKey, uint32_t uiAncestorIdMask, size_t maxConfigurableElementSize = std::numeric_limits<size_t>::max()) :
-        CSubsystemObjectCreator(strMappingKey, uiAncestorIdMask, maxConfigurableElementSize) {}
+    TSubsystemObjectFactory(const std::string &strMappingKey, uint32_t uiAncestorIdMask,
+                            size_t maxConfigurableElementSize = std::numeric_limits<size_t>::max())
+        : CSubsystemObjectCreator(strMappingKey, uiAncestorIdMask, maxConfigurableElementSize)
+    {
+    }
 
     // Object creation
-    virtual CSubsystemObject* objectCreate(
-            const std::string& strMappingValue,
-            CInstanceConfigurableElement* pInstanceConfigurableElement,
-            const CMappingContext& context,
-            core::log::Logger& logger) const
+    virtual CSubsystemObject *objectCreate(
+        const std::string &strMappingValue,
+        CInstanceConfigurableElement *pInstanceConfigurableElement, const CMappingContext &context,
+        core::log::Logger &logger) const
     {
-        return new SubsystemObjectType(
-                strMappingValue, pInstanceConfigurableElement, context, logger);
+        return new SubsystemObjectType(strMappingValue, pInstanceConfigurableElement, context,
+                                       logger);
     }
 };

--- a/parameter/SubsystemPlugins.h
+++ b/parameter/SubsystemPlugins.h
@@ -36,13 +36,11 @@ class CSubsystemPlugins : public CKindElement
 {
 
 public:
-    CSubsystemPlugins(const std::string& strName, const std::string& strKind) : CKindElement(strName, strKind)
+    CSubsystemPlugins(const std::string &strName, const std::string &strKind)
+        : CKindElement(strName, strKind)
     {
     }
 
 private:
-    virtual bool childrenAreDynamic() const
-    {
-        return true;
-    }
+    virtual bool childrenAreDynamic() const { return true; }
 };

--- a/parameter/Syncer.h
+++ b/parameter/Syncer.h
@@ -36,7 +36,8 @@ class CParameterBlackboard;
 class ISyncer
 {
 public:
-    virtual bool sync(CParameterBlackboard& parameterBlackboard, bool bBack, std::string& strError) = 0;
+    virtual bool sync(CParameterBlackboard &parameterBlackboard, bool bBack,
+                      std::string &strError) = 0;
 
 protected:
     virtual ~ISyncer() = default;

--- a/parameter/SyncerSet.cpp
+++ b/parameter/SyncerSet.cpp
@@ -30,14 +30,14 @@
 #include "SyncerSet.h"
 #include "Syncer.h"
 
-const CSyncerSet& CSyncerSet::operator+=(ISyncer* pRightSyncer)
+const CSyncerSet &CSyncerSet::operator+=(ISyncer *pRightSyncer)
 {
     _syncerSet.insert(pRightSyncer);
 
     return *this;
 }
 
-const CSyncerSet& CSyncerSet::operator+=(const CSyncerSet& rightSyncerSet)
+const CSyncerSet &CSyncerSet::operator+=(const CSyncerSet &rightSyncerSet)
 {
     if (&rightSyncerSet != this) {
 
@@ -52,9 +52,8 @@ void CSyncerSet::clear()
     _syncerSet.clear();
 }
 
-bool CSyncerSet::sync(CParameterBlackboard& parameterBlackboard,
-                      bool bBack,
-                      core::Results* errors) const
+bool CSyncerSet::sync(CParameterBlackboard &parameterBlackboard, bool bBack,
+                      core::Results *errors) const
 {
     bool bSuccess = true;
 
@@ -65,7 +64,7 @@ bool CSyncerSet::sync(CParameterBlackboard& parameterBlackboard,
 
     for (it = _syncerSet.begin(); it != _syncerSet.end(); ++it) {
 
-        ISyncer* pSyncer = *it;
+        ISyncer *pSyncer = *it;
 
         if (!pSyncer->sync(parameterBlackboard, bBack, strError)) {
 

--- a/parameter/SyncerSet.h
+++ b/parameter/SyncerSet.h
@@ -37,11 +37,12 @@ class CParameterBlackboard;
 
 class CSyncerSet
 {
-    typedef std::set<ISyncer*>::const_iterator SyncerSetConstIterator;
+    typedef std::set<ISyncer *>::const_iterator SyncerSetConstIterator;
+
 public:
     // Filling
-    const CSyncerSet& operator+=(ISyncer* pRightSyncer);
-    const CSyncerSet& operator+=(const CSyncerSet& rightSyncerSet);
+    const CSyncerSet &operator+=(ISyncer *pRightSyncer);
+    const CSyncerSet &operator+=(const CSyncerSet &rightSyncerSet);
 
     // Clearing
     void clear();
@@ -53,8 +54,8 @@ public:
      * @param[out] errors, errors encountered during restoration
      * @return true if success false otherwise
      */
-    bool sync(CParameterBlackboard& parameterBlackboard, bool bBack, core::Results* errors) const;
+    bool sync(CParameterBlackboard &parameterBlackboard, bool bBack, core::Results *errors) const;
 
 private:
-    std::set<ISyncer*> _syncerSet;
+    std::set<ISyncer *> _syncerSet;
 };

--- a/parameter/SystemClass.cpp
+++ b/parameter/SystemClass.cpp
@@ -41,12 +41,13 @@
 #define base CConfigurableElement
 
 #ifndef PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1
-#   error Missing PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1 macro definition
+#error Missing PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1 macro definition
 #endif
 #define QUOTE(X) #X
 #define MACRO_TO_STR(X) QUOTE(X)
-const char CSystemClass::entryPointSymbol[] = MACRO_TO_STR(PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1);
-using PluginEntryPointV1 = void (*)(CSubsystemLibrary*, core::log::Logger&);
+const char CSystemClass::entryPointSymbol[] =
+    MACRO_TO_STR(PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1);
+using PluginEntryPointV1 = void (*)(CSubsystemLibrary *, core::log::Logger &);
 
 using std::list;
 using std::string;
@@ -54,7 +55,7 @@ using std::string;
 // FIXME: integrate SystemClass to core namespace
 using namespace core;
 
-CSystemClass::CSystemClass(log::Logger& logger)
+CSystemClass::CSystemClass(log::Logger &logger)
     : _pSubsystemLibrary(new CSubsystemLibrary()), _logger(logger)
 {
 }
@@ -78,16 +79,15 @@ string CSystemClass::getKind() const
     return "SystemClass";
 }
 
-bool CSystemClass::getMappingData(const std::string& /*strKey*/,
-                    const std::string*& /*pStrValue*/) const
+bool CSystemClass::getMappingData(const std::string & /*strKey*/,
+                                  const std::string *& /*pStrValue*/) const
 {
     // Although it could make sense to have mapping in the system class,
     // just like at subsystem level, it is currently not supported.
     return false;
 }
 
-bool CSystemClass::loadSubsystems(string& strError,
-                                  const CSubsystemPlugins* pSubsystemPlugins,
+bool CSystemClass::loadSubsystems(string &strError, const CSubsystemPlugins *pSubsystemPlugins,
                                   bool bVirtualSubsystemFallback)
 {
     // Start clean
@@ -98,7 +98,8 @@ bool CSystemClass::loadSubsystems(string& strError,
     _pSubsystemLibrary->addElementBuilder("Virtual", new VirtualSubsystemBuilder(_logger));
     // Set virtual subsytem as builder fallback if required
     if (bVirtualSubsystemFallback) {
-        _pSubsystemLibrary->setDefaultBuilder(utility::make_unique<VirtualSubsystemBuilder>(_logger));
+        _pSubsystemLibrary->setDefaultBuilder(
+            utility::make_unique<VirtualSubsystemBuilder>(_logger));
     }
 
     // Add subsystem defined in shared libraries
@@ -112,18 +113,20 @@ bool CSystemClass::loadSubsystems(string& strError,
     return bLoadPluginsSuccess || bVirtualSubsystemFallback;
 }
 
-bool CSystemClass::loadSubsystemsFromSharedLibraries(core::Results& errors,
-                                                     const CSubsystemPlugins* pSubsystemPlugins)
+bool CSystemClass::loadSubsystemsFromSharedLibraries(core::Results &errors,
+                                                     const CSubsystemPlugins *pSubsystemPlugins)
 {
     // Plugin list
     list<string> lstrPluginFiles;
 
     size_t pluginLocation;
 
-    for (pluginLocation = 0; pluginLocation <  pSubsystemPlugins->getNbChildren(); pluginLocation++) {
+    for (pluginLocation = 0; pluginLocation < pSubsystemPlugins->getNbChildren();
+         pluginLocation++) {
 
         // Get Folder for current Plugin Location
-        const CPluginLocation* pPluginLocation = static_cast<const CPluginLocation*>(pSubsystemPlugins->getChild(pluginLocation));
+        const CPluginLocation *pPluginLocation =
+            static_cast<const CPluginLocation *>(pSubsystemPlugins->getChild(pluginLocation));
 
         string strFolder(pPluginLocation->getFolder());
         if (!strFolder.empty()) {
@@ -132,7 +135,7 @@ bool CSystemClass::loadSubsystemsFromSharedLibraries(core::Results& errors,
         // Iterator on Plugin List:
         list<string>::const_iterator it;
 
-        const list<string>& pluginList = pPluginLocation->getPluginList();
+        const list<string> &pluginList = pPluginLocation->getPluginList();
 
         for (it = pluginList.begin(); it != pluginList.end(); ++it) {
 
@@ -167,9 +170,8 @@ bool CSystemClass::loadSubsystemsFromSharedLibraries(core::Results& errors,
     return true;
 }
 
-
 // Plugin loading
-bool CSystemClass::loadPlugins(list<string>& lstrPluginFiles, core::Results& errors)
+bool CSystemClass::loadPlugins(list<string> &lstrPluginFiles, core::Results &errors)
 {
     assert(lstrPluginFiles.size());
 
@@ -186,8 +188,7 @@ bool CSystemClass::loadPlugins(list<string>& lstrPluginFiles, core::Results& err
             auto library = utility::make_unique<DynamicLibrary>(strPluginFileName);
 
             // Load symbol from library
-            auto subSystemBuilder =
-                library->getSymbol<PluginEntryPointV1>(entryPointSymbol);
+            auto subSystemBuilder = library->getSymbol<PluginEntryPointV1>(entryPointSymbol);
 
             // Store libraries handles
             _subsystemLibraryHandleList.push_back(std::move(library));
@@ -195,7 +196,7 @@ bool CSystemClass::loadPlugins(list<string>& lstrPluginFiles, core::Results& err
             // Fill library
             subSystemBuilder(_pSubsystemLibrary, _logger);
 
-        } catch (std::exception& e) {
+        } catch (std::exception &e) {
             errors.push_back(e.what());
 
             // Next plugin
@@ -214,19 +215,19 @@ bool CSystemClass::loadPlugins(list<string>& lstrPluginFiles, core::Results& err
     return bAtLeastOneSubsystemPluginSuccessfullyLoaded;
 }
 
-const CSubsystemLibrary* CSystemClass::getSubsystemLibrary() const
+const CSubsystemLibrary *CSystemClass::getSubsystemLibrary() const
 {
     return _pSubsystemLibrary;
 }
 
-void CSystemClass::checkForSubsystemsToResync(CSyncerSet& syncerSet, core::Results& infos)
+void CSystemClass::checkForSubsystemsToResync(CSyncerSet &syncerSet, core::Results &infos)
 {
     size_t uiNbChildren = getNbChildren();
     size_t uiChild;
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        CSubsystem* pSubsystem = static_cast<CSubsystem*>(getChild(uiChild));
+        CSubsystem *pSubsystem = static_cast<CSubsystem *>(getChild(uiChild));
 
         // Collect and consume the need for a resync
         if (pSubsystem->needResync(true)) {
@@ -245,7 +246,7 @@ void CSystemClass::cleanSubsystemsNeedToResync()
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        CSubsystem* pSubsystem = static_cast<CSubsystem*>(getChild(uiChild));
+        CSubsystem *pSubsystem = static_cast<CSubsystem *>(getChild(uiChild));
 
         // Consume the need for a resync
         pSubsystem->needResync(true);

--- a/parameter/SystemClass.h
+++ b/parameter/SystemClass.h
@@ -43,12 +43,11 @@ class DynamicLibrary;
 class CSystemClass final : public CConfigurableElement
 {
 public:
-
     /**
      * @param[in] logger the logger provided by the client
      * it need to be given to the subsystem library
      */
-    CSystemClass(core::log::Logger& logger);
+    CSystemClass(core::log::Logger &logger);
     virtual ~CSystemClass();
 
     /** Load subsystem plugin and fill the corresponding libraries.
@@ -61,10 +60,10 @@ public:
      * @return true if the plugins succesfully started or that a fallback is available,
                false otherwise.
      */
-    bool loadSubsystems(std::string& strError, const CSubsystemPlugins* pSubsystemPlugins,
+    bool loadSubsystems(std::string &strError, const CSubsystemPlugins *pSubsystemPlugins,
                         bool bVirtualSubsystemFallback = false);
     // Subsystem factory
-    const CSubsystemLibrary* getSubsystemLibrary() const;
+    const CSubsystemLibrary *getSubsystemLibrary() const;
 
     /**
       * Look for subsystems that need to be resynchronized.
@@ -74,7 +73,7 @@ public:
       * @param[out] syncerSet The syncer set to fill
       * @param[out] infos Relevant informations client may want to log
       */
-    void checkForSubsystemsToResync(CSyncerSet& syncerSet, core::Results& infos);
+    void checkForSubsystemsToResync(CSyncerSet &syncerSet, core::Results &infos);
 
     /**
       * Reset subsystems need to resync flag.
@@ -84,11 +83,11 @@ public:
     // base
     virtual std::string getKind() const;
 
-    bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const override;
+    bool getMappingData(const std::string &strKey, const std::string *&pStrValue) const override;
 
 private:
-    CSystemClass(const CSystemClass&);
-    CSystemClass& operator=(const CSystemClass&);
+    CSystemClass(const CSystemClass &);
+    CSystemClass &operator=(const CSystemClass &);
     // base
     virtual bool childrenAreDynamic() const;
 
@@ -99,8 +98,8 @@ private:
      *
      * @return true if all plugins have been succesfully loaded, false otherwises.
      */
-    bool loadSubsystemsFromSharedLibraries(core::Results& errors,
-                                           const CSubsystemPlugins* pSubsystemPlugins);
+    bool loadSubsystemsFromSharedLibraries(core::Results &errors,
+                                           const CSubsystemPlugins *pSubsystemPlugins);
 
     /** Load subsystem plugin shared libraries.
      *
@@ -112,17 +111,17 @@ private:
      *         When false is returned, some plugins MIHGT have been loaded
      *         but the lstrPluginFiles is accurate.
      */
-    bool loadPlugins(std::list<std::string>& lstrPluginFiles, core::Results& errors);
+    bool loadPlugins(std::list<std::string> &lstrPluginFiles, core::Results &errors);
 
     // Subsystem factory
-    CSubsystemLibrary* _pSubsystemLibrary;
-    std::list<std::unique_ptr<DynamicLibrary> > _subsystemLibraryHandleList; /**< Contains the list of all open plugin libs. */
+    CSubsystemLibrary *_pSubsystemLibrary;
+    std::list<std::unique_ptr<DynamicLibrary>>
+        _subsystemLibraryHandleList; /**< Contains the list of all open plugin libs. */
 
     /** Application Logger we need to provide to plugins */
-    core::log::Logger& _logger;
+    core::log::Logger &_logger;
 
     /** The entry point symbol that must be implemented by plugins
      */
     static const char entryPointSymbol[];
 };
-

--- a/parameter/TypeElement.cpp
+++ b/parameter/TypeElement.cpp
@@ -35,7 +35,7 @@
 
 #define base CElement
 
-CTypeElement::CTypeElement(const std::string& strName) : base(strName)
+CTypeElement::CTypeElement(const std::string &strName) : base(strName)
 {
 }
 
@@ -59,7 +59,7 @@ int CTypeElement::toPlainInteger(int iSizeOptimizedData) const
     return iSizeOptimizedData;
 }
 
-bool CTypeElement::getMappingData(const std::string& strKey, const std::string*& pStrValue) const
+bool CTypeElement::getMappingData(const std::string &strKey, const std::string *&pStrValue) const
 {
     if (_pMappingData) {
 
@@ -74,7 +74,7 @@ bool CTypeElement::hasMappingData() const
 }
 
 // Element properties
-void CTypeElement::showProperties(std::string& strResult) const
+void CTypeElement::showProperties(std::string &strResult) const
 {
     // The description attribute may be found in the type and not from instance.
     showDescriptionProperty(strResult);
@@ -83,7 +83,7 @@ void CTypeElement::showProperties(std::string& strResult) const
     // which have a common base Element)
 }
 
-void CTypeElement::populate(CElement* pElement) const
+void CTypeElement::populate(CElement *pElement) const
 {
     // Populate children
     size_t uiChild;
@@ -91,16 +91,19 @@ void CTypeElement::populate(CElement* pElement) const
 
     for (uiChild = 0; uiChild < uiNbChildren; uiChild++) {
 
-        const CTypeElement* pChildTypeElement = static_cast<const CTypeElement*>(getChild(uiChild));
+        const CTypeElement *pChildTypeElement =
+            static_cast<const CTypeElement *>(getChild(uiChild));
 
-        CInstanceConfigurableElement* pInstanceConfigurableChildElement = pChildTypeElement->instantiate();
+        CInstanceConfigurableElement *pInstanceConfigurableChildElement =
+            pChildTypeElement->instantiate();
 
         // Affiliate
         pElement->addChild(pInstanceConfigurableChildElement);
     }
 }
 
-bool CTypeElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CTypeElement::fromXml(const CXmlElement &xmlElement,
+                           CXmlSerializingContext &serializingContext)
 {
     // Array Length attribute
     xmlElement.getAttribute("ArrayLength", _arrayLength);
@@ -119,9 +122,9 @@ bool CTypeElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext
     return base::fromXml(xmlElement, serializingContext);
 }
 
-CInstanceConfigurableElement* CTypeElement::instantiate() const
+CInstanceConfigurableElement *CTypeElement::instantiate() const
 {
-    CInstanceConfigurableElement* pInstanceConfigurableElement = doInstantiate();
+    CInstanceConfigurableElement *pInstanceConfigurableElement = doInstantiate();
 
     // Populate
     populate(pInstanceConfigurableElement);
@@ -129,7 +132,7 @@ CInstanceConfigurableElement* CTypeElement::instantiate() const
     return pInstanceConfigurableElement;
 }
 
-CMappingData* CTypeElement::getMappingData()
+CMappingData *CTypeElement::getMappingData()
 {
     if (!_pMappingData) {
 
@@ -148,7 +151,7 @@ std::string CTypeElement::getFormattedMapping() const
 }
 
 // From IXmlSource
-void CTypeElement::toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const
+void CTypeElement::toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const
 {
     if (!isScalar()) {
 

--- a/parameter/TypeElement.h
+++ b/parameter/TypeElement.h
@@ -40,14 +40,14 @@ class CInstanceConfigurableElement;
 class PARAMETER_EXPORT CTypeElement : public CElement
 {
 public:
-    CTypeElement(const std::string& strName = "");
+    CTypeElement(const std::string &strName = "");
     virtual ~CTypeElement();
 
     // Instantiation
-    CInstanceConfigurableElement* instantiate() const;
+    CInstanceConfigurableElement *instantiate() const;
 
     // Mapping info
-    virtual bool getMappingData(const std::string& strKey, const std::string*& pStrValue) const;
+    virtual bool getMappingData(const std::string &strKey, const std::string *&pStrValue) const;
     virtual bool hasMappingData() const;
 
     /**
@@ -58,13 +58,13 @@ public:
     virtual std::string getFormattedMapping() const;
 
     // Element properties
-    virtual void showProperties(std::string& strResult) const;
+    virtual void showProperties(std::string &strResult) const;
 
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
 
     // From IXmlSource
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const;
+    virtual void toXml(CXmlElement &xmlElement, CXmlSerializingContext &serializingContext) const;
 
     // Scalar or Array?
     bool isScalar() const;
@@ -83,19 +83,20 @@ public:
 
 protected:
     // Object creation
-    virtual void populate(CElement* pElement) const;
+    virtual void populate(CElement *pElement) const;
+
 private:
-    CTypeElement(const CTypeElement&);
-    CTypeElement& operator=(const CTypeElement&);
+    CTypeElement(const CTypeElement &);
+    CTypeElement &operator=(const CTypeElement &);
     // Actual instance creation
-    virtual CInstanceConfigurableElement* doInstantiate() const = 0;
+    virtual CInstanceConfigurableElement *doInstantiate() const = 0;
 
     // Mapping data creation and access
-    CMappingData* getMappingData();
+    CMappingData *getMappingData();
 
     // For Arrays. 0 means scalar
     size_t _arrayLength{0};
 
     // Mapping info
-    CMappingData* _pMappingData{nullptr};
+    CMappingData *_pMappingData{nullptr};
 };

--- a/parameter/VirtualSubsystem.cpp
+++ b/parameter/VirtualSubsystem.cpp
@@ -35,10 +35,11 @@
 
 using std::string;
 
-CVirtualSubsystem::CVirtualSubsystem(const string& strName, core::log::Logger& logger)
+CVirtualSubsystem::CVirtualSubsystem(const string &strName, core::log::Logger &logger)
     : base(strName, logger), _pVirtualSyncer(new CVirtualSyncer(this))
 {
-    logger.warning() << "Subsystem " <<  strName << " loaded as virtual. "
+    logger.warning() << "Subsystem " << strName
+                     << " loaded as virtual. "
                         "Its parameters will not be synced with any external system.";
 }
 
@@ -48,18 +49,19 @@ CVirtualSubsystem::~CVirtualSubsystem()
 }
 
 // Syncer
-ISyncer* CVirtualSubsystem::getSyncer() const
+ISyncer *CVirtualSubsystem::getSyncer() const
 {
     return _pVirtualSyncer;
 }
 
-void CVirtualSubsystem::fillSyncerSetFromDescendant(CSyncerSet& syncerSet) const
+void CVirtualSubsystem::fillSyncerSetFromDescendant(CSyncerSet &syncerSet) const
 {
     syncerSet += _pVirtualSyncer;
 }
 
 // From IMapper
-bool CVirtualSubsystem::mapBegin(CInstanceConfigurableElement* /*elem*/, bool& bKeepDiving, string& /*strError*/)
+bool CVirtualSubsystem::mapBegin(CInstanceConfigurableElement * /*elem*/, bool &bKeepDiving,
+                                 string & /*strError*/)
 {
     // Do nothing: prevent any subsystem object from being mapped
 

--- a/parameter/VirtualSubsystem.h
+++ b/parameter/VirtualSubsystem.h
@@ -38,17 +38,16 @@ class CVirtualSyncer;
 class CVirtualSubsystem final : public CSubsystem
 {
 public:
-
     /**
      * @param[in] strName subsystem name
      * @param[in] logger the main logger of the application
      */
-    CVirtualSubsystem(const std::string& strName, core::log::Logger& logger);
+    CVirtualSubsystem(const std::string &strName, core::log::Logger &logger);
     virtual ~CVirtualSubsystem();
 
 protected:
     // Syncer
-    virtual ISyncer* getSyncer() const;
+    virtual ISyncer *getSyncer() const;
 
     /**
      * Fill Syncer Set From descendant nodes
@@ -56,12 +55,14 @@ protected:
      * This functionality allows to collect the syncers when crawling down the
      * parameter tree.
      */
-    void fillSyncerSetFromDescendant(CSyncerSet& syncerSet) const override;
+    void fillSyncerSetFromDescendant(CSyncerSet &syncerSet) const override;
+
 private:
     // From IMapper
-    virtual bool mapBegin(CInstanceConfigurableElement* pInstanceConfigurableElement, bool& bKeepDiving, std::string& strError);
+    virtual bool mapBegin(CInstanceConfigurableElement *pInstanceConfigurableElement,
+                          bool &bKeepDiving, std::string &strError);
     virtual void mapEnd();
 
     // Subsystem level dummy syncer
-    CVirtualSyncer* _pVirtualSyncer;
+    CVirtualSyncer *_pVirtualSyncer;
 };

--- a/parameter/VirtualSyncer.cpp
+++ b/parameter/VirtualSyncer.cpp
@@ -33,12 +33,13 @@
 
 using std::string;
 
-CVirtualSyncer::CVirtualSyncer(const CConfigurableElement* pConfigurableElement) : _pConfigurableElement(pConfigurableElement)
+CVirtualSyncer::CVirtualSyncer(const CConfigurableElement *pConfigurableElement)
+    : _pConfigurableElement(pConfigurableElement)
 {
 }
 
 // Synchronization
-bool CVirtualSyncer::sync(CParameterBlackboard& parameterBlackboard, bool bBack, string& strError)
+bool CVirtualSyncer::sync(CParameterBlackboard &parameterBlackboard, bool bBack, string &strError)
 {
     // Synchronize to/from HW
     if (bBack) {

--- a/parameter/VirtualSyncer.h
+++ b/parameter/VirtualSyncer.h
@@ -36,10 +36,11 @@ class CConfigurableElement;
 class CVirtualSyncer : public ISyncer
 {
 public:
-    CVirtualSyncer(const CConfigurableElement* pConfigurableElement);
+    CVirtualSyncer(const CConfigurableElement *pConfigurableElement);
 
     // from ISyncer
-    virtual bool sync(CParameterBlackboard& parameterBlackboard, bool bBack, std::string& strError);
+    virtual bool sync(CParameterBlackboard &parameterBlackboard, bool bBack, std::string &strError);
+
 private:
-    const CConfigurableElement* _pConfigurableElement;
+    const CConfigurableElement *_pConfigurableElement;
 };

--- a/parameter/XmlDomainExportContext.h
+++ b/parameter/XmlDomainExportContext.h
@@ -35,36 +35,22 @@
 class CXmlDomainExportContext : public CXmlDomainSerializingContext
 {
 public:
-    CXmlDomainExportContext(std::string& strError,
-                            bool bWithSettings = true,
-                            bool bValueSpaceIsRaw = true,
-                            bool bOutputRawFormatIsHex = true):
-        base(strError, bWithSettings),
-        _bValueSpaceIsRaw(bValueSpaceIsRaw),
-        _bOutputRawFormatIsHex(bOutputRawFormatIsHex)
-    {}
+    CXmlDomainExportContext(std::string &strError, bool bWithSettings = true,
+                            bool bValueSpaceIsRaw = true, bool bOutputRawFormatIsHex = true)
+        : base(strError, bWithSettings), _bValueSpaceIsRaw(bValueSpaceIsRaw),
+          _bOutputRawFormatIsHex(bOutputRawFormatIsHex)
+    {
+    }
 
     // Value interpretation as Real or Raw
-    void setValueSpaceRaw(bool bIsRaw)
-    {
-        _bValueSpaceIsRaw = bIsRaw;
-    }
+    void setValueSpaceRaw(bool bIsRaw) { _bValueSpaceIsRaw = bIsRaw; }
 
-    bool valueSpaceIsRaw() const
-    {
-        return _bValueSpaceIsRaw;
-    }
+    bool valueSpaceIsRaw() const { return _bValueSpaceIsRaw; }
 
     // Output Raw Format for user get value interpretation
-    void setOutputRawFormat(bool bIsHex)
-    {
-        _bOutputRawFormatIsHex = bIsHex;
-    }
+    void setOutputRawFormat(bool bIsHex) { _bOutputRawFormatIsHex = bIsHex; }
 
-    bool outputRawFormatIsHex() const
-    {
-        return _bOutputRawFormatIsHex;
-    }
+    bool outputRawFormatIsHex() const { return _bOutputRawFormatIsHex; }
 
 private:
     typedef CXmlDomainSerializingContext base;
@@ -74,5 +60,4 @@ private:
 
     // Output Raw Format
     bool _bOutputRawFormatIsHex;
-
 };

--- a/parameter/XmlDomainImportContext.h
+++ b/parameter/XmlDomainImportContext.h
@@ -38,23 +38,22 @@
 class CXmlDomainImportContext : public CXmlDomainSerializingContext
 {
 public:
-    CXmlDomainImportContext(std::string& strError, bool bWithSettings, CSystemClass& systemClass):
-        base(strError, bWithSettings), _systemClass(systemClass) {}
+    CXmlDomainImportContext(std::string &strError, bool bWithSettings, CSystemClass &systemClass)
+        : base(strError, bWithSettings), _systemClass(systemClass)
+    {
+    }
 
     // System Class
-    CSystemClass& getSystemClass() const
-    {
-        return _systemClass;
-    }
+    CSystemClass &getSystemClass() const { return _systemClass; }
 
     // Criteria defintion
     void setSelectionCriteriaDefinition(
-            const CSelectionCriteriaDefinition* pSelectionCriteriaDefinition)
+        const CSelectionCriteriaDefinition *pSelectionCriteriaDefinition)
     {
         _pSelectionCriteriaDefinition = pSelectionCriteriaDefinition;
     }
 
-    const CSelectionCriteriaDefinition* getSelectionCriteriaDefinition() const
+    const CSelectionCriteriaDefinition *getSelectionCriteriaDefinition() const
     {
         return _pSelectionCriteriaDefinition;
     }
@@ -65,21 +64,17 @@ public:
         _bAutoValidationRequired = bAutoValidationRequired;
     }
 
-    bool autoValidationRequired() const
-    {
-        return _bAutoValidationRequired;
-    }
+    bool autoValidationRequired() const { return _bAutoValidationRequired; }
 
 private:
     typedef CXmlDomainSerializingContext base;
 
     // System Class
-    CSystemClass& _systemClass;
+    CSystemClass &_systemClass;
 
     // Criteria defintion
-    const CSelectionCriteriaDefinition* _pSelectionCriteriaDefinition{nullptr};
+    const CSelectionCriteriaDefinition *_pSelectionCriteriaDefinition{nullptr};
 
     // Auto validation of configurations
     bool _bAutoValidationRequired{true};
 };
-

--- a/parameter/XmlDomainSerializingContext.h
+++ b/parameter/XmlDomainSerializingContext.h
@@ -36,14 +36,13 @@
 class CXmlDomainSerializingContext : public CXmlElementSerializingContext
 {
 public:
-    CXmlDomainSerializingContext(std::string& strError, bool bWithSettings):
-        base(strError), _bWithSettings(bWithSettings) {}
+    CXmlDomainSerializingContext(std::string &strError, bool bWithSettings)
+        : base(strError), _bWithSettings(bWithSettings)
+    {
+    }
 
     // Settings to be serialized or not
-    bool withSettings() const
-    {
-        return _bWithSettings;
-    }
+    bool withSettings() const { return _bWithSettings; }
 
 private:
     typedef CXmlElementSerializingContext base;

--- a/parameter/XmlElementSerializingContext.cpp
+++ b/parameter/XmlElementSerializingContext.cpp
@@ -33,25 +33,26 @@
 
 using std::string;
 
-CXmlElementSerializingContext::CXmlElementSerializingContext(string& strError) : base(strError)
+CXmlElementSerializingContext::CXmlElementSerializingContext(string &strError) : base(strError)
 {
 }
 
 // Init
-void CXmlElementSerializingContext::set(const CElementLibrary* pElementLibrary, const string& xmlUri)
+void CXmlElementSerializingContext::set(const CElementLibrary *pElementLibrary,
+                                        const string &xmlUri)
 {
     _pElementLibrary = pElementLibrary;
     _xmlUri = xmlUri;
 }
 
 // ElementLibrary
-const CElementLibrary* CXmlElementSerializingContext::getElementLibrary() const
+const CElementLibrary *CXmlElementSerializingContext::getElementLibrary() const
 {
     return _pElementLibrary;
 }
 
 // XML Folder Path
-const string& CXmlElementSerializingContext::getXmlUri() const
+const string &CXmlElementSerializingContext::getXmlUri() const
 {
     return _xmlUri;
 }

--- a/parameter/XmlElementSerializingContext.h
+++ b/parameter/XmlElementSerializingContext.h
@@ -38,17 +38,18 @@ class CElementLibrary;
 class CXmlElementSerializingContext : public CXmlSerializingContext
 {
 public:
-    CXmlElementSerializingContext(std::string& strError);
+    CXmlElementSerializingContext(std::string &strError);
 
     // Init
-    void set(const CElementLibrary* pElementLibrary, const std::string& xmlUri);
+    void set(const CElementLibrary *pElementLibrary, const std::string &xmlUri);
 
     // ElementLibrary
-    const CElementLibrary* getElementLibrary() const;
+    const CElementLibrary *getElementLibrary() const;
 
     // Xml URI
-    const std::string& getXmlUri() const;
+    const std::string &getXmlUri() const;
+
 private:
-    const CElementLibrary* _pElementLibrary{nullptr};
+    const CElementLibrary *_pElementLibrary{nullptr};
     std::string _xmlUri;
 };

--- a/parameter/XmlFileIncluderElement.cpp
+++ b/parameter/XmlFileIncluderElement.cpp
@@ -36,18 +36,20 @@
 #include <fstream>
 
 #define base CKindElement
-CXmlFileIncluderElement::CXmlFileIncluderElement(const std::string& strName,
-                                                 const std::string& strKind,
+CXmlFileIncluderElement::CXmlFileIncluderElement(const std::string &strName,
+                                                 const std::string &strKind,
                                                  bool bValidateWithSchemas)
     : base(strName, strKind), _bValidateSchemasOnStart(bValidateWithSchemas)
 {
 }
 
 // From IXmlSink
-bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext)
+bool CXmlFileIncluderElement::fromXml(const CXmlElement &xmlElement,
+                                      CXmlSerializingContext &serializingContext)
 {
     // Context
-    CXmlElementSerializingContext& elementSerializingContext = static_cast<CXmlElementSerializingContext&>(serializingContext);
+    CXmlElementSerializingContext &elementSerializingContext =
+        static_cast<CXmlElementSerializingContext &>(serializingContext);
 
     // Parse included document
     std::string strPath;
@@ -59,8 +61,7 @@ bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSeriali
     {
         _xmlDoc *doc = CXmlDocSource::mkXmlDoc(strPath, true, true, elementSerializingContext);
 
-        CXmlDocSource docSource(doc, _bValidateSchemasOnStart,
-                                strIncludedElementType);
+        CXmlDocSource docSource(doc, _bValidateSchemasOnStart, strIncludedElementType);
 
         if (!docSource.isParsable()) {
 
@@ -75,7 +76,8 @@ bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSeriali
         docSource.getRootElement(childElement);
 
         // Create child element
-        CElement* pChild = elementSerializingContext.getElementLibrary()->createElement(childElement);
+        CElement *pChild =
+            elementSerializingContext.getElementLibrary()->createElement(childElement);
 
         if (pChild) {
 
@@ -83,7 +85,8 @@ bool CXmlFileIncluderElement::fromXml(const CXmlElement& xmlElement, CXmlSeriali
             getParent()->addChild(pChild);
         } else {
 
-            elementSerializingContext.setError("Unable to create XML element " + childElement.getPath());
+            elementSerializingContext.setError("Unable to create XML element " +
+                                               childElement.getPath());
 
             return false;
         }

--- a/parameter/XmlFileIncluderElement.h
+++ b/parameter/XmlFileIncluderElement.h
@@ -37,11 +37,11 @@
 class CXmlFileIncluderElement : public CKindElement
 {
 public:
-    CXmlFileIncluderElement(const std::string& strName,
-                            const std::string& strKind,
+    CXmlFileIncluderElement(const std::string &strName, const std::string &strKind,
                             bool bValidateWithSchemas);
     // From IXmlSink
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext);
+    virtual bool fromXml(const CXmlElement &xmlElement, CXmlSerializingContext &serializingContext);
+
 private:
     // Element type
     std::string getIncludedElementType() const;

--- a/parameter/XmlParameterSerializingContext.cpp
+++ b/parameter/XmlParameterSerializingContext.cpp
@@ -34,21 +34,19 @@
 using std::string;
 
 CXmlParameterSerializingContext::CXmlParameterSerializingContext(CParameterAccessContext &context,
-                                                                 string& strError) :
-    base(strError),
-    mAccessContext(context)
+                                                                 string &strError)
+    : base(strError), mAccessContext(context)
 {
 }
 
 // ComponentLibrary
-void CXmlParameterSerializingContext::setComponentLibrary(const CComponentLibrary* pComponentLibrary)
+void CXmlParameterSerializingContext::setComponentLibrary(
+    const CComponentLibrary *pComponentLibrary)
 {
     _pComponentLibrary = pComponentLibrary;
 }
 
-const CComponentLibrary* CXmlParameterSerializingContext::getComponentLibrary() const
+const CComponentLibrary *CXmlParameterSerializingContext::getComponentLibrary() const
 {
     return _pComponentLibrary;
 }
-
-

--- a/parameter/XmlParameterSerializingContext.h
+++ b/parameter/XmlParameterSerializingContext.h
@@ -39,16 +39,16 @@ class CComponentLibrary;
 class CXmlParameterSerializingContext : public CXmlElementSerializingContext
 {
 public:
-    CXmlParameterSerializingContext(CParameterAccessContext &context, std::string& strError);
+    CXmlParameterSerializingContext(CParameterAccessContext &context, std::string &strError);
 
     // ComponentLibrary
-    void setComponentLibrary(const CComponentLibrary* pComponentLibrary);
-    const CComponentLibrary* getComponentLibrary() const;
+    void setComponentLibrary(const CComponentLibrary *pComponentLibrary);
+    const CComponentLibrary *getComponentLibrary() const;
 
     CParameterAccessContext &getAccessContext() const { return mAccessContext; }
 
 private:
-    const CComponentLibrary* _pComponentLibrary{nullptr};
+    const CComponentLibrary *_pComponentLibrary{nullptr};
 
     CParameterAccessContext &mAccessContext;
 };

--- a/parameter/include/ElementHandle.h
+++ b/parameter/include/ElementHandle.h
@@ -43,7 +43,7 @@
 class CParameterMgr;
 class CConfigurableElement;
 class CBaseParameter;
- /** @} */
+/** @} */
 
 /** TODO */
 class PARAMETER_EXPORT ElementHandle
@@ -99,7 +99,7 @@ public:
      * @param[out] strValue the resulting mapping value in case of success
      * @return true for if mapping key exists, false otherwise
      */
-    bool getMappingData(const std::string& strKey, std::string& strValue) const;
+    bool getMappingData(const std::string &strKey, std::string &strValue) const;
 
     /** Gets element structure description as XML string
      *
@@ -131,7 +131,7 @@ public:
      *
      * @return true on success, false on failure
      */
-     bool getAsXML(std::string& xmlValue, std::string& error) const;
+    bool getAsXML(std::string &xmlValue, std::string &error) const;
 
     /** Sets element settings as XML string
      *
@@ -147,7 +147,7 @@ public:
      *
      * @return true on success, false otherwise
      */
-    bool setAsXML(const std::string& xmlValue, std::string& error);
+    bool setAsXML(const std::string &xmlValue, std::string &error);
 
     /** Gets element settings in binary format
      *
@@ -156,7 +156,7 @@ public:
      *
      * @returns true
      */
-     bool getAsBytes(std::vector<uint8_t>& bytesValue, std::string& error) const;
+    bool getAsBytes(std::vector<uint8_t> &bytesValue, std::string &error) const;
 
     /** Sets element settings in binary format
      *
@@ -164,7 +164,7 @@ public:
      *    - targeted element needs to be rogue for this operation to be allowed
      *    - size of the passed array must match that of the element
      */
-    bool setAsBytes(const std::vector<uint8_t>& bytesValue, std::string& error);
+    bool setAsBytes(const std::vector<uint8_t> &bytesValue, std::string &error);
 
     /** @} */
 
@@ -189,51 +189,51 @@ public:
      */
 
     /** Boolean access @{ */
-    bool getAsBoolean(bool& bValue, std::string& strError) const;
-    bool setAsBoolean(bool bValue, std::string& strError);
-    bool setAsBooleanArray(const std::vector<bool>& abValues, std::string& strError);
-    bool getAsBooleanArray(std::vector<bool>& abValues, std::string& strError) const;
+    bool getAsBoolean(bool &bValue, std::string &strError) const;
+    bool setAsBoolean(bool bValue, std::string &strError);
+    bool setAsBooleanArray(const std::vector<bool> &abValues, std::string &strError);
+    bool getAsBooleanArray(std::vector<bool> &abValues, std::string &strError) const;
     /** @} */
 
     /** Integer Access @{ */
-    bool setAsInteger(uint32_t uiValue, std::string& strError);
-    bool getAsInteger(uint32_t& uiValue, std::string& strError) const;
-    bool setAsIntegerArray(const std::vector<uint32_t>& auiValues, std::string& strError);
-    bool getAsIntegerArray(std::vector<uint32_t>& auiValues, std::string& strError) const;
+    bool setAsInteger(uint32_t uiValue, std::string &strError);
+    bool getAsInteger(uint32_t &uiValue, std::string &strError) const;
+    bool setAsIntegerArray(const std::vector<uint32_t> &auiValues, std::string &strError);
+    bool getAsIntegerArray(std::vector<uint32_t> &auiValues, std::string &strError) const;
     /** @} */
 
     /** Signed Integer Access @{ */
-    bool setAsSignedInteger(int32_t iValue, std::string& strError);
-    bool getAsSignedInteger(int32_t& iValue, std::string& strError) const;
-    bool setAsSignedIntegerArray(const std::vector<int32_t>& aiValues, std::string& strError);
-    bool getAsSignedIntegerArray(std::vector<int32_t>& aiValues, std::string& strError) const;
+    bool setAsSignedInteger(int32_t iValue, std::string &strError);
+    bool getAsSignedInteger(int32_t &iValue, std::string &strError) const;
+    bool setAsSignedIntegerArray(const std::vector<int32_t> &aiValues, std::string &strError);
+    bool getAsSignedIntegerArray(std::vector<int32_t> &aiValues, std::string &strError) const;
     /** @} */
 
     /** Double Access @{ */
-    bool setAsDouble(double dValue, std::string& strError);
-    bool getAsDouble(double& dValue, std::string& strError) const;
-    bool setAsDoubleArray(const std::vector<double>& adValues, std::string& strError);
-    bool getAsDoubleArray(std::vector<double>& adValues, std::string& strError) const;
+    bool setAsDouble(double dValue, std::string &strError);
+    bool getAsDouble(double &dValue, std::string &strError) const;
+    bool setAsDoubleArray(const std::vector<double> &adValues, std::string &strError);
+    bool getAsDoubleArray(std::vector<double> &adValues, std::string &strError) const;
     /** @} */
 
     /** String Access @{ */
-    bool setAsString(const std::string& strValue, std::string& strError);
-    bool getAsString(std::string& strValue, std::string& strError) const;
-    bool setAsStringArray(const std::vector<std::string>& astrValues, std::string& strError);
-    bool getAsStringArray(std::vector<std::string>& astrValues, std::string& strError) const;
+    bool setAsString(const std::string &strValue, std::string &strError);
+    bool getAsString(std::string &strValue, std::string &strError) const;
+    bool setAsStringArray(const std::vector<std::string> &astrValues, std::string &strError);
+    bool getAsStringArray(std::vector<std::string> &astrValues, std::string &strError) const;
     /** @} */
 
     /** @} */
 
 protected:
-    ElementHandle(CConfigurableElement& element, CParameterMgr& parameterMgr);
+    ElementHandle(CConfigurableElement &element, CParameterMgr &parameterMgr);
     friend CParameterMgr; // So that it can build the handler
 
 private:
     template <class T>
     bool setAs(const T value, std::string &error) const;
     template <class T>
-    bool getAs(T& value, std::string &error) const;
+    bool getAs(T &value, std::string &error) const;
 
     template <class T>
     static size_t getSize(T value);
@@ -252,7 +252,7 @@ private:
      *
      * @return true if the parameter value can be retrieved, false otherwise.
      */
-    bool checkSetValidity(size_t arrayLength, std::string& error) const;
+    bool checkSetValidity(size_t arrayLength, std::string &error) const;
 
     /** Check that the parameter value can be retrieved.
      *
@@ -262,10 +262,10 @@ private:
      *
      * @return true if the parameter value can be retrieved, false otherwise.
      */
-    bool checkGetValidity(bool asArray, std::string& error) const;
+    bool checkGetValidity(bool asArray, std::string &error) const;
 
     /** Reference to the handled Configurable element. */
-    CConfigurableElement& mElement;
+    CConfigurableElement &mElement;
 
-    CParameterMgr& mParameterMgr;
+    CParameterMgr &mParameterMgr;
 };

--- a/parameter/include/ParameterHandle.h
+++ b/parameter/include/ParameterHandle.h
@@ -45,7 +45,9 @@
 class PARAMETER_EXPORT CParameterHandle : public ElementHandle
 {
 private:
-    CParameterHandle(CConfigurableElement& element, CParameterMgr& parameterMgr)
-        : ElementHandle(element, parameterMgr) {}
+    CParameterHandle(CConfigurableElement &element, CParameterMgr &parameterMgr)
+        : ElementHandle(element, parameterMgr)
+    {
+    }
     friend CParameterMgr; // So that it can build the handler
 };

--- a/parameter/include/ParameterMgrFullConnector.h
+++ b/parameter/include/ParameterMgrFullConnector.h
@@ -47,11 +47,10 @@ class CParameterMgr;
 class PARAMETER_EXPORT CParameterMgrFullConnector : public CParameterMgrPlatformConnector
 {
 public:
-
     /** String list type which can hold list of error/info and can be presented to client */
     typedef std::list<std::string> Results;
 
-    CParameterMgrFullConnector(const std::string& strConfigurationFilePath);
+    CParameterMgrFullConnector(const std::string &strConfigurationFilePath);
 
     /** @deprecated Same as its overload without error handling.
      * @note this deprecated method in not available in the python wrapper.
@@ -73,7 +72,7 @@ public:
 
     //////////// Tuning /////////////
     // Tuning mode
-    bool setTuningMode(bool bOn, std::string& strError);
+    bool setTuningMode(bool bOn, std::string &strError);
     bool isTuningModeOn() const;
 
     // Current value space for user set/get value interpretation
@@ -84,13 +83,16 @@ public:
     void setOutputRawFormat(bool bIsHex);
     bool isOutputRawFormatHex() const;
     // Automatic hardware synchronization control (during tuning session)
-    bool setAutoSync(bool bAutoSyncOn, std::string& strError);
+    bool setAutoSync(bool bAutoSyncOn, std::string &strError);
     bool isAutoSyncOn() const;
-    bool sync(std::string& strError);
+    bool sync(std::string &strError);
 
     // User set/get parameters
-    bool accessParameterValue(const std::string& strPath, std::string& strValue, bool bSet, std::string& strError);
-    bool accessConfigurationValue(const std::string &strDomain, const std::string &strConfiguration, const std::string& strPath, std::string& strValue, bool bSet, std::string& strError);
+    bool accessParameterValue(const std::string &strPath, std::string &strValue, bool bSet,
+                              std::string &strError);
+    bool accessConfigurationValue(const std::string &strDomain, const std::string &strConfiguration,
+                                  const std::string &strPath, std::string &strValue, bool bSet,
+                                  std::string &strError);
 
     /**
      * Returns the element mapping corresponding to the path given in parameter.
@@ -100,18 +102,24 @@ public:
      *
      * @return true if a mapping was found for this element
      */
-    bool getParameterMapping(const std::string& strPath, std::string& strValue) const;
+    bool getParameterMapping(const std::string &strPath, std::string &strValue) const;
     ////////// Configuration/Domains handling //////////////
     // Creation/Deletion
-    bool createDomain(const std::string& strName, std::string& strError);
-    bool deleteDomain(const std::string& strName, std::string& strError);
-    bool renameDomain(const std::string& strName, const std::string& strNewName, std::string& strError);
-    bool deleteAllDomains(std::string& strError);
-    bool setSequenceAwareness(const std::string& strName, bool bSequenceAware, std::string& strResult);
-    bool getSequenceAwareness(const std::string& strName, bool& bSequenceAware, std::string& strResult);
-    bool createConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
-    bool deleteConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
-    bool renameConfiguration(const std::string& strDomain, const std::string& strConfiguration, const std::string& strNewConfiguration, std::string& strError);
+    bool createDomain(const std::string &strName, std::string &strError);
+    bool deleteDomain(const std::string &strName, std::string &strError);
+    bool renameDomain(const std::string &strName, const std::string &strNewName,
+                      std::string &strError);
+    bool deleteAllDomains(std::string &strError);
+    bool setSequenceAwareness(const std::string &strName, bool bSequenceAware,
+                              std::string &strResult);
+    bool getSequenceAwareness(const std::string &strName, bool &bSequenceAware,
+                              std::string &strResult);
+    bool createConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                             std::string &strError);
+    bool deleteConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                             std::string &strError);
+    bool renameConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                             const std::string &strNewConfiguration, std::string &strError);
 
     /** Restore a configuration
      *
@@ -120,23 +128,31 @@ public:
      * @param[out] errors, errors encountered during restoration
      * @return true if success false otherwise
      */
-    bool restoreConfiguration(const std::string& strDomain,
-                              const std::string& strConfiguration,
-                              Results& errors);
+    bool restoreConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                              Results &errors);
 
-    bool saveConfiguration(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
+    bool saveConfiguration(const std::string &strDomain, const std::string &strConfiguration,
+                           std::string &strError);
 
     // Configurable element - domain association
-    bool addConfigurableElementToDomain(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
-    bool removeConfigurableElementFromDomain(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
-    bool split(const std::string& strDomain, const std::string& strConfigurableElementPath, std::string& strError);
-    bool setElementSequence(const std::string& strDomain, const std::string& strConfiguration, const std::vector<std::string>& astrNewElementSequence, std::string& strError);
+    bool addConfigurableElementToDomain(const std::string &strDomain,
+                                        const std::string &strConfigurableElementPath,
+                                        std::string &strError);
+    bool removeConfigurableElementFromDomain(const std::string &strDomain,
+                                             const std::string &strConfigurableElementPath,
+                                             std::string &strError);
+    bool split(const std::string &strDomain, const std::string &strConfigurableElementPath,
+               std::string &strError);
+    bool setElementSequence(const std::string &strDomain, const std::string &strConfiguration,
+                            const std::vector<std::string> &astrNewElementSequence,
+                            std::string &strError);
 
-    bool setApplicationRule(const std::string& strDomain, const std::string& strConfiguration,
-                            const std::string& strApplicationRule, std::string& strError);
-    bool getApplicationRule(const std::string& strDomain, const std::string& strConfiguration,
-                            std::string& strResult);
-    bool clearApplicationRule(const std::string& strDomain, const std::string& strConfiguration, std::string& strError);
+    bool setApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                            const std::string &strApplicationRule, std::string &strError);
+    bool getApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                            std::string &strResult);
+    bool clearApplicationRule(const std::string &strDomain, const std::string &strConfiguration,
+                              std::string &strError);
 
     /**
       * Method that imports Configurable Domains from an Xml source.
@@ -150,8 +166,8 @@ public:
       *
       * @return false if any error occures
       */
-    bool importDomainsXml(const std::string& strXmlSource, bool bWithSettings, bool bFromFile,
-                          std::string& strError);
+    bool importDomainsXml(const std::string &strXmlSource, bool bWithSettings, bool bFromFile,
+                          std::string &strError);
     /**
       * Method that imports a single Configurable Domain from an Xml source.
       *
@@ -166,8 +182,8 @@ public:
       *
       * @return false if any error occurs
       */
-    bool importSingleDomainXml(const std::string& xmlSource, bool overwrite, bool withSettings,
-                               bool toFile, std::string& errorMsg);
+    bool importSingleDomainXml(const std::string &xmlSource, bool overwrite, bool withSettings,
+                               bool toFile, std::string &errorMsg);
     /**
       * Method that imports a single Configurable Domain from an string
       * describing an Xml source.
@@ -181,9 +197,8 @@ public:
       *
       * @return false if any error occurs
       */
-    bool importSingleDomainXml(const std::string& strXmlSource, bool bOverwrite,
-                               std::string& strError);
-
+    bool importSingleDomainXml(const std::string &strXmlSource, bool bOverwrite,
+                               std::string &strError);
 
     /**
       * Method that exports Configurable Domains to an Xml destination.
@@ -197,8 +212,8 @@ public:
       *
       * @return false if any error occures, true otherwise.
       */
-    bool exportDomainsXml(std::string& strXmlDest, bool bWithSettings, bool bToFile,
-                          std::string& strError) const;
+    bool exportDomainsXml(std::string &strXmlDest, bool bWithSettings, bool bToFile,
+                          std::string &strError) const;
 
     /**
       * Method that exports a given Configurable Domain to an Xml destination.
@@ -213,11 +228,11 @@ public:
       *
       * @return false if any error occurs, true otherwise.
       */
-    bool exportSingleDomainXml(std::string& strXmlDest, const std::string& strDomainName, bool bWithSettings,
-                               bool bToFile, std::string& strError) const;
+    bool exportSingleDomainXml(std::string &strXmlDest, const std::string &strDomainName,
+                               bool bWithSettings, bool bToFile, std::string &strError) const;
 
 private:
     // disallow copying because this class manages raw pointers' lifecycle
-    CParameterMgrFullConnector(const CParameterMgrFullConnector&);
-    CParameterMgrFullConnector& operator=(const CParameterMgrFullConnector&);
+    CParameterMgrFullConnector(const CParameterMgrFullConnector &);
+    CParameterMgrFullConnector &operator=(const CParameterMgrFullConnector &);
 };

--- a/parameter/include/ParameterMgrLoggerForward.h
+++ b/parameter/include/ParameterMgrLoggerForward.h
@@ -30,4 +30,5 @@
 #pragma once
 
 // Shared forward declaration, to ensure declaration alignment
-template<class T> class CParameterMgrLogger;
+template <class T>
+class CParameterMgrLogger;

--- a/parameter/include/ParameterMgrPlatformConnector.h
+++ b/parameter/include/ParameterMgrPlatformConnector.h
@@ -42,6 +42,7 @@ class CParameterMgr;
 class PARAMETER_EXPORT CParameterMgrPlatformConnector
 {
     friend class CParameterMgrLogger<CParameterMgrPlatformConnector>;
+
 public:
     /** Interface to implement to provide a custom logger to the PF.
      *
@@ -53,29 +54,33 @@ public:
     class ILogger
     {
     public:
-        virtual void info(const std::string& strLog) = 0;
-        virtual void warning(const std::string& strLog) = 0;
+        virtual void info(const std::string &strLog) = 0;
+        virtual void warning(const std::string &strLog) = 0;
+
     protected:
         virtual ~ILogger() {}
     };
 
     // Construction
-    CParameterMgrPlatformConnector(const std::string& strConfigurationFilePath);
+    CParameterMgrPlatformConnector(const std::string &strConfigurationFilePath);
     virtual ~CParameterMgrPlatformConnector();
 
-    // Selection Criteria interface. Beware returned objects are lent, clients shall not delete them!
+    // Selection Criteria interface. Beware returned objects are lent, clients shall not delete
+    // them!
     // Should be called before start
-    ISelectionCriterionTypeInterface* createSelectionCriterionType(bool bIsInclusive = false);
-    ISelectionCriterionInterface* createSelectionCriterion(const std::string& strName, const ISelectionCriterionTypeInterface* pSelectionCriterionType);
+    ISelectionCriterionTypeInterface *createSelectionCriterionType(bool bIsInclusive = false);
+    ISelectionCriterionInterface *createSelectionCriterion(
+        const std::string &strName,
+        const ISelectionCriterionTypeInterface *pSelectionCriterionType);
     // Selection criterion retrieval
-    ISelectionCriterionInterface* getSelectionCriterion(const std::string& strName) const;
+    ISelectionCriterionInterface *getSelectionCriterion(const std::string &strName) const;
 
     // Logging
     // Should be called before start
-    void setLogger(ILogger* pLogger);
+    void setLogger(ILogger *pLogger);
 
     // Start
-    bool start(std::string& strError);
+    bool start(std::string &strError);
 
     // Started state
     bool isStarted() const;
@@ -86,7 +91,8 @@ public:
     // Dynamic parameter handling
     // Returned objects are owned by clients
     // Must be cassed after successfull start
-    CParameterHandle* createParameterHandle(const std::string& strPath, std::string& strError) const;
+    CParameterHandle *createParameterHandle(const std::string &strPath,
+                                            std::string &strError) const;
 
     /** Creates a handle to a configurable element.
      *
@@ -125,7 +131,7 @@ public:
       *
       * @return false if unable to set, true otherwise.
       */
-    bool setFailureOnMissingSubsystem(bool bFail, std::string& strError);
+    bool setFailureOnMissingSubsystem(bool bFail, std::string &strError);
 
     /** Would start fail in case of missing subsystems.
       *
@@ -143,7 +149,7 @@ public:
       *
       * @return false if unable to set, true otherwise.
       */
-    bool setFailureOnFailedSettingsLoad(bool bFail, std::string& strError);
+    bool setFailureOnFailedSettingsLoad(bool bFail, std::string &strError);
     /** Would start fail in case of failed settings load.
       *
       * @return failure on failed settings load policy state.
@@ -154,13 +160,13 @@ public:
      *
      * @returns the XML Schemas URI
      */
-    const std::string& getSchemaUri() const;
+    const std::string &getSchemaUri() const;
 
     /** Override the XML Schemas URI
      *
      * @param[in] schemaUri the XML Schemas URI
      */
-    void setSchemaUri(const std::string& schemaUri);
+    void setSchemaUri(const std::string &schemaUri);
 
     /** Should .xml files be validated on start ?
      *
@@ -180,19 +186,19 @@ public:
     bool getValidateSchemasOnStart() const;
 
 private:
-    CParameterMgrPlatformConnector(const CParameterMgrPlatformConnector&);
-    CParameterMgrPlatformConnector& operator=(const CParameterMgrPlatformConnector&);
+    CParameterMgrPlatformConnector(const CParameterMgrPlatformConnector &);
+    CParameterMgrPlatformConnector &operator=(const CParameterMgrPlatformConnector &);
     // Private logging
-    void info(const std::string& log);
-    void warning(const std::string& log);
+    void info(const std::string &log);
+    void warning(const std::string &log);
 
 protected:
     // Private logging
-    CParameterMgrLogger<CParameterMgrPlatformConnector>* _pParameterMgrLogger;
+    CParameterMgrLogger<CParameterMgrPlatformConnector> *_pParameterMgrLogger;
     // Implementation
-    CParameterMgr* _pParameterMgr;
+    CParameterMgr *_pParameterMgr;
     // State
     bool _bStarted;
     // Logging
-    ILogger* _pLogger;
+    ILogger *_pLogger;
 };

--- a/parameter/include/SelectionCriterionInterface.h
+++ b/parameter/include/SelectionCriterionInterface.h
@@ -39,7 +39,7 @@ public:
     virtual void setCriterionState(int iState) = 0;
     virtual int getCriterionState() const = 0;
     virtual std::string getCriterionName() const = 0;
-    virtual const ISelectionCriterionTypeInterface* getCriterionType() const = 0;
+    virtual const ISelectionCriterionTypeInterface *getCriterionType() const = 0;
 
 protected:
     virtual ~ISelectionCriterionInterface() {}

--- a/parameter/include/SelectionCriterionTypeInterface.h
+++ b/parameter/include/SelectionCriterionTypeInterface.h
@@ -34,7 +34,6 @@
 class ISelectionCriterionTypeInterface
 {
 public:
-
     /**
      * Add a new pair [integer, litteral] which represents a criterion
      *
@@ -43,13 +42,12 @@ public:
      * @param[out] strError string containing error information we can provide to client
      * @return true if succeed false otherwise
      */
-    virtual bool addValuePair(int iValue, const std::string& strValue, std::string& strError) = 0;
-    virtual bool getNumericalValue(const std::string& strValue, int& iValue) const = 0;
-    virtual bool getLiteralValue(int iValue, std::string& strValue) const = 0;
+    virtual bool addValuePair(int iValue, const std::string &strValue, std::string &strError) = 0;
+    virtual bool getNumericalValue(const std::string &strValue, int &iValue) const = 0;
+    virtual bool getLiteralValue(int iValue, std::string &strValue) const = 0;
     virtual bool isTypeInclusive() const = 0;
     virtual std::string getFormattedState(int iValue) const = 0;
 
 protected:
     virtual ~ISelectionCriterionTypeInterface() {}
 };
-

--- a/parameter/log/include/log/Context.h
+++ b/parameter/log/include/log/Context.h
@@ -38,17 +38,16 @@ namespace log
 {
 
 /** Log formatter which provide context indentation */
-class Context {
+class Context
+{
 public:
-
     /**
      * Class Constructor
      *
      * @param[in] logger application logger
      * @param[in] context name of the context to open
      */
-    Context(Logger& logger, const std::string& context)
-        : mLogger(logger)
+    Context(Logger &logger, const std::string &context) : mLogger(logger)
     {
         mLogger.info() << context << " {";
         mLogger.mProlog += "    ";
@@ -62,11 +61,11 @@ public:
     }
 
 private:
-    Context(const Context&);
-    Context& operator=(const Context&);
+    Context(const Context &);
+    Context &operator=(const Context &);
 
     /** Application logger */
-    Logger& mLogger;
+    Logger &mLogger;
 };
 
 } /** log namespace */

--- a/parameter/log/include/log/ILogger.h
+++ b/parameter/log/include/log/ILogger.h
@@ -40,8 +40,9 @@ namespace log
 class ILogger
 {
 public:
-    virtual void info(const std::string& strLog) = 0;
-    virtual void warning(const std::string& strLog) = 0;
+    virtual void info(const std::string &strLog) = 0;
+    virtual void warning(const std::string &strLog) = 0;
+
 protected:
     virtual ~ILogger() {}
 };

--- a/parameter/log/include/log/LogWrapper.h
+++ b/parameter/log/include/log/LogWrapper.h
@@ -49,24 +49,24 @@ namespace details
  *
  * @tparam isWarning indicates which log canal to use
  */
-template<bool isWarning>
+template <bool isWarning>
 class LogWrapper
 {
 public:
-
     /** @param logger the ILogger to wrap */
-    LogWrapper(ILogger& logger, const std::string& prolog = "")
-        : mLogger(logger), mProlog(prolog)
-    {}
+    LogWrapper(ILogger &logger, const std::string &prolog = "") : mLogger(logger), mProlog(prolog)
+    {
+    }
 
     /**
      * Class copy constructor
      *
      * @param[in] logWrapper the instance to copy
      */
-    LogWrapper(const LogWrapper& logWrapper)
+    LogWrapper(const LogWrapper &logWrapper)
         : mLogger(logWrapper.mLogger), mProlog(logWrapper.mProlog)
-    {}
+    {
+    }
 
     /** Class destructor */
     ~LogWrapper()
@@ -87,7 +87,7 @@ public:
      * @param[in] log the information to log
      */
     template <class T>
-    LogWrapper& operator<<(const T &log)
+    LogWrapper &operator<<(const T &log)
     {
         mLog << log;
         return *this;
@@ -98,7 +98,7 @@ public:
      *
      * @param[in] logs list of information to log
      */
-    LogWrapper& operator<<(const std::list<std::string>& logs)
+    LogWrapper &operator<<(const std::list<std::string> &logs)
     {
         std::string separator = "\n" + mProlog;
         std::string formatedLogs = utility::asString(logs, separator);
@@ -113,16 +113,16 @@ public:
     }
 
 private:
-    LogWrapper& operator=(const LogWrapper&);
+    LogWrapper &operator=(const LogWrapper &);
 
     /** Log stream holder */
     std::ostringstream mLog;
 
     /** Wrapped logger */
-    ILogger& mLogger;
+    ILogger &mLogger;
 
     /** Log Prefix */
-    const std::string& mProlog;
+    const std::string &mProlog;
 };
 
 /** Default information logger type */

--- a/parameter/log/include/log/Logger.h
+++ b/parameter/log/include/log/Logger.h
@@ -48,37 +48,29 @@ namespace log
 class Logger : private utility::NonCopyable
 {
 public:
-
     /** Context class is friend let the prolog by externally modified */
     friend class Context;
 
     /** @param[in] logger, raw logger provided by client */
-    Logger(ILogger& logger) : mLogger(logger) {}
+    Logger(ILogger &logger) : mLogger(logger) {}
 
     /**
      * Retrieve wrapped information logger
      *
      * @return Info logger
      */
-    details::Info info()
-    {
-        return details::Info(mLogger, mProlog);
-    }
+    details::Info info() { return details::Info(mLogger, mProlog); }
 
     /**
      * Retrieve wrapped warning logger
      *
      * @return Warning logger
      */
-    details::Warning warning()
-    {
-        return details::Warning(mLogger, mProlog);
-    }
+    details::Warning warning() { return details::Warning(mLogger, mProlog); }
 
 private:
-
     /** Raw logger provided by client */
-    ILogger& mLogger;
+    ILogger &mLogger;
 
     /** Log prolog, owns the context indentation */
     std::string mProlog;

--- a/remote-process/main.cpp
+++ b/remote-process/main.cpp
@@ -43,8 +43,7 @@ bool sendAndDisplayCommand(asio::ip::tcp::socket &socket, CRequestMessage &reque
 {
     string strError;
 
-    if (requestMessage.serialize(socket, true, strError)
-            != CRequestMessage::success) {
+    if (requestMessage.serialize(socket, true, strError) != CRequestMessage::success) {
 
         cerr << "Unable to send command to target: " << strError << endl;
         return false;
@@ -52,8 +51,7 @@ bool sendAndDisplayCommand(asio::ip::tcp::socket &socket, CRequestMessage &reque
 
     ///// Get answer
     CAnswerMessage answerMessage;
-    if (answerMessage.serialize(socket, false, strError)
-            != CRequestMessage::success) {
+    if (answerMessage.serialize(socket, false, strError) != CRequestMessage::success) {
 
         cerr << "Unable to received answer from target: " << strError << endl;
         return false;
@@ -99,7 +97,7 @@ int main(int argc, char *argv[])
     try {
         asio::connect(connectionSocket, resolver.resolve(tcp::resolver::query(host, port)));
     } catch (const asio::system_error &e) {
-        cerr << "Connection to '" << host << ":"<< port << "' failed: " << e.what() << endl;
+        cerr << "Connection to '" << host << ":" << port << "' failed: " << e.what() << endl;
         return 1;
     }
 

--- a/remote-processor/AnswerMessage.cpp
+++ b/remote-processor/AnswerMessage.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -34,9 +34,8 @@
 
 using std::string;
 
-CAnswerMessage::CAnswerMessage(const string& strAnswer, bool bSuccess) :
-    base(bSuccess ? MsgType::ESuccessAnswer : MsgType::EFailureAnswer),
-    _strAnswer(strAnswer)
+CAnswerMessage::CAnswerMessage(const string &strAnswer, bool bSuccess)
+    : base(bSuccess ? MsgType::ESuccessAnswer : MsgType::EFailureAnswer), _strAnswer(strAnswer)
 {
 }
 
@@ -45,12 +44,12 @@ CAnswerMessage::CAnswerMessage()
 }
 
 // Answer
-void CAnswerMessage::setAnswer(const string& strAnswer)
+void CAnswerMessage::setAnswer(const string &strAnswer)
 {
     _strAnswer = strAnswer;
 }
 
-const string& CAnswerMessage::getAnswer() const
+const string &CAnswerMessage::getAnswer() const
 {
     return _strAnswer;
 }

--- a/remote-processor/AnswerMessage.h
+++ b/remote-processor/AnswerMessage.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -36,14 +36,15 @@
 class REMOTE_PROCESSOR_EXPORT CAnswerMessage : public CMessage
 {
 public:
-    CAnswerMessage(const std::string& strAnswer, bool bSuccess);
+    CAnswerMessage(const std::string &strAnswer, bool bSuccess);
     CAnswerMessage();
 
     // Answer
-    const std::string& getAnswer() const;
+    const std::string &getAnswer() const;
 
     // Status
     bool success() const;
+
 private:
     // Fill data to send
     virtual void fillDataToSend();
@@ -54,9 +55,8 @@ private:
     */
     virtual size_t getDataSize() const;
     // Answer
-    void setAnswer(const std::string& strAnswer);
+    void setAnswer(const std::string &strAnswer);
 
     // Answer
     std::string _strAnswer;
 };
-

--- a/remote-processor/BackgroundRemoteProcessorServerBuilder.h
+++ b/remote-processor/BackgroundRemoteProcessorServerBuilder.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -35,8 +35,10 @@ class BackgroundRemoteProcessorServer final : public IRemoteProcessorServerInter
 {
 public:
     BackgroundRemoteProcessorServer(uint16_t uiPort,
-                                    std::unique_ptr<IRemoteCommandHandler> &commandHandler) :
-        _server(uiPort), mCommandHandler(std::move(commandHandler)) {}
+                                    std::unique_ptr<IRemoteCommandHandler> &commandHandler)
+        : _server(uiPort), mCommandHandler(std::move(commandHandler))
+    {
+    }
 
     ~BackgroundRemoteProcessorServer() { stop(); }
 
@@ -46,9 +48,8 @@ public:
             return false;
         }
         try {
-            mServerSuccess = std::async(std::launch::async,
-                                        &CRemoteProcessorServer::process, &_server,
-                                        std::ref(*mCommandHandler));
+            mServerSuccess = std::async(std::launch::async, &CRemoteProcessorServer::process,
+                                        &_server, std::ref(*mCommandHandler));
         } catch (std::exception &e) {
             error = "Could not create a remote processor thread: " + std::string(e.what());
             return false;
@@ -57,7 +58,8 @@ public:
         return true;
     }
 
-    bool stop() override {
+    bool stop() override
+    {
         _server.stop();
         return mServerSuccess.get();
     }
@@ -67,4 +69,3 @@ private:
     std::unique_ptr<IRemoteCommandHandler> mCommandHandler;
     std::future<bool> mServerSuccess;
 };
-

--- a/remote-processor/Message.cpp
+++ b/remote-processor/Message.cpp
@@ -35,13 +35,11 @@
 
 using std::string;
 
-CMessage::CMessage(MsgType ucMsgId) :
-    _ucMsgId(ucMsgId), _uiIndex(0)
+CMessage::CMessage(MsgType ucMsgId) : _ucMsgId(ucMsgId), _uiIndex(0)
 {
 }
 
-CMessage::CMessage() :
-    _ucMsgId(MsgType::EInvalid), _uiIndex(0)
+CMessage::CMessage() : _ucMsgId(MsgType::EInvalid), _uiIndex(0)
 {
 }
 
@@ -57,7 +55,7 @@ bool CMessage::isValidAccess(size_t offset, size_t size) const
 }
 
 // Data
-void CMessage::writeData(const void* pvData, size_t size)
+void CMessage::writeData(const void *pvData, size_t size)
 {
     assert(isValidAccess(_uiIndex, size));
 
@@ -70,7 +68,7 @@ void CMessage::writeData(const void* pvData, size_t size)
     _uiIndex += size;
 }
 
-void CMessage::readData(void* pvData, size_t size)
+void CMessage::readData(void *pvData, size_t size)
 {
     assert(isValidAccess(_uiIndex, size));
 
@@ -83,7 +81,7 @@ void CMessage::readData(void* pvData, size_t size)
     _uiIndex += size;
 }
 
-void CMessage::writeString(const string& strData)
+void CMessage::writeString(const string &strData)
 {
     // Size
     uint32_t size = static_cast<uint32_t>(strData.length());
@@ -94,7 +92,7 @@ void CMessage::writeString(const string& strData)
     writeData(strData.c_str(), size);
 }
 
-void CMessage::readString(string& strData)
+void CMessage::readString(string &strData)
 {
     // Size
     uint32_t uiSize;
@@ -114,7 +112,7 @@ void CMessage::readString(string& strData)
     strData = string.data();
 }
 
-size_t CMessage::getStringSize(const string& strData) const
+size_t CMessage::getStringSize(const string &strData) const
 {
     // Return string length plus room to store its length
     return strData.length() + sizeof(uint32_t);
@@ -127,7 +125,7 @@ size_t CMessage::getRemainingDataSize() const
 }
 
 // Send/Receive
-CMessage::Result CMessage::serialize(asio::ip::tcp::socket &socket, bool bOut, string& strError)
+CMessage::Result CMessage::serialize(asio::ip::tcp::socket &socket, bool bOut, string &strError)
 {
     if (bOut) {
         asio::error_code ec;

--- a/remote-processor/Message.h
+++ b/remote-processor/Message.h
@@ -36,11 +36,9 @@
 
 #include <remote_processor_export.h>
 
-
 class REMOTE_PROCESSOR_EXPORT CMessage : private utility::NonCopyable
 {
 public:
-
     enum class MsgType : std::uint8_t
     {
         ECommandRequest,
@@ -52,7 +50,8 @@ public:
     CMessage();
     virtual ~CMessage() = default;
 
-    enum Result {
+    enum Result
+    {
         success,
         peerDisconnected,
         error
@@ -81,32 +80,32 @@ protected:
     * @param[in] pvData pointer to the data array
     * @param[in] uiSize array size in bytes
     */
-    void writeData(const void* pvData, size_t uiSize);
+    void writeData(const void *pvData, size_t uiSize);
 
     /** Read raw data from the message
     *
     * @param[out] pvData pointer to the data array
     * @param[in] uiSize array size in bytes
     */
-    void readData(void* pvData, size_t uiSize);
+    void readData(void *pvData, size_t uiSize);
 
     /** Write string to the message
     *
     * @param[in] strData the string to write
     */
-    void writeString(const std::string& strData);
+    void writeString(const std::string &strData);
 
     /** Write string to the message
     *
     * @param[out] strData the string to read to
     */
-    void readString(std::string& strData);
+    void readString(std::string &strData);
 
     /** @return string length plus room to store its length
     *
     * @param[in] strData the string to get the size from
     */
-    size_t getStringSize(const std::string& strData) const;
+    size_t getStringSize(const std::string &strData) const;
 
     /** @return remaining data size to read or to write depending on the context
     * (request: write, answer: read)

--- a/remote-processor/RemoteCommand.h
+++ b/remote-processor/RemoteCommand.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -37,17 +37,17 @@ class IRemoteCommand
 {
 public:
     // Command Name
-    virtual const std::string& getCommand() const = 0;
+    virtual const std::string &getCommand() const = 0;
 
     // Arguments
-    virtual void addArgument(const std::string& strArgument) = 0;
+    virtual void addArgument(const std::string &strArgument) = 0;
     virtual size_t getArgumentCount() const = 0;
-    virtual const std::string& getArgument(size_t argument) const = 0;
+    virtual const std::string &getArgument(size_t argument) const = 0;
     /** Get all the arguments in a vector
      *
      * @returns a reference to a vector containing all the arguments.
      */
-    virtual const std::vector<std::string>& getArguments() const = 0;
+    virtual const std::vector<std::string> &getArguments() const = 0;
     virtual const std::string packArguments(size_t startArgument, size_t nbArguments) const = 0;
 
 protected:

--- a/remote-processor/RemoteCommandHandler.h
+++ b/remote-processor/RemoteCommandHandler.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -36,7 +36,8 @@ class IRemoteCommandHandler
 {
 public:
     // Return true on success, fill result in any cases
-    virtual bool remoteCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult) = 0;
+    virtual bool remoteCommandProcess(const IRemoteCommand &remoteCommand,
+                                      std::string &strResult) = 0;
 
     virtual ~IRemoteCommandHandler() {}
 };

--- a/remote-processor/RemoteCommandHandlerTemplate.h
+++ b/remote-processor/RemoteCommandHandlerTemplate.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -37,11 +37,12 @@ class TRemoteCommandHandlerTemplate : public IRemoteCommandHandler
 {
 public:
     /** Remote command parser execution return status */
-    enum CommandStatus {
-        EDone, /**< Command succeded, return "Done" */
+    enum CommandStatus
+    {
+        EDone,      /**< Command succeded, return "Done" */
         ESucceeded, /**< Command succeeded */
-        EFailed, /**< Command failed */
-        EShowUsage /**< Command failed, show usage */
+        EFailed,    /**< Command failed */
+        EShowUsage  /**< Command failed, show usage */
     };
 
     /** Type of the remote command callbacks
@@ -51,41 +52,32 @@ public:
      *
      * @return the command execution status, @see CommandStatus
      */
-    typedef CommandStatus (CCommandParser::*RemoteCommandParser)(const IRemoteCommand& remoteCommand, std::string& strResult);
+    typedef CommandStatus (CCommandParser::*RemoteCommandParser)(
+        const IRemoteCommand &remoteCommand, std::string &strResult);
 
 private:
     // Parser descriptions
     class CRemoteCommandParserItem
     {
     public:
-        CRemoteCommandParserItem(const std::string& strCommandName,
-                                 RemoteCommandParser pfnParser,
-                                 size_t minArgumentCount,
-                                 const std::string& strHelp,
-                                 const std::string& strDescription)
-            : _strCommandName(strCommandName),
-              _pfnParser(pfnParser),
-              _minArgumentCount(minArgumentCount),
-              _strHelp(strHelp),
-              _strDescription(strDescription) {}
-
-        const std::string& getCommandName() const
+        CRemoteCommandParserItem(const std::string &strCommandName, RemoteCommandParser pfnParser,
+                                 size_t minArgumentCount, const std::string &strHelp,
+                                 const std::string &strDescription)
+            : _strCommandName(strCommandName), _pfnParser(pfnParser),
+              _minArgumentCount(minArgumentCount), _strHelp(strHelp),
+              _strDescription(strDescription)
         {
-            return _strCommandName;
         }
 
-        const std::string& getDescription() const
-        {
-            return _strDescription;
-        }
+        const std::string &getCommandName() const { return _strCommandName; }
+
+        const std::string &getDescription() const { return _strDescription; }
 
         // Usage
-        std::string usage() const
-        {
-            return _strCommandName + " " + _strHelp;
-        }
+        std::string usage() const { return _strCommandName + " " + _strHelp; }
 
-        bool parse(CCommandParser* pCommandParser, const IRemoteCommand& remoteCommand, std::string& strResult) const
+        bool parse(CCommandParser *pCommandParser, const IRemoteCommand &remoteCommand,
+                   std::string &strResult) const
         {
             // Check enough arguments supplied
             if (remoteCommand.getArgumentCount() < _minArgumentCount) {
@@ -98,12 +90,12 @@ private:
             switch ((pCommandParser->*_pfnParser)(remoteCommand, strResult)) {
             case EDone:
                 strResult = "Done";
-                // Fall through intentionally
+            // Fall through intentionally
             case ESucceeded:
                 return true;
             case EShowUsage:
                 strResult = usage();
-                // Fall through intentionally
+            // Fall through intentionally
             case EFailed:
                 return false;
             }
@@ -120,7 +112,8 @@ private:
     };
 
 public:
-    TRemoteCommandHandlerTemplate(CCommandParser* pCommandParser) : _pCommandParser(pCommandParser), _maxCommandUsageLength(0)
+    TRemoteCommandHandlerTemplate(CCommandParser *pCommandParser)
+        : _pCommandParser(pCommandParser), _maxCommandUsageLength(0)
     {
         // Help Command
         addCommandParser("help", NULL, 0, "", "Show commands description and usage");
@@ -135,11 +128,9 @@ public:
     }
 
     // Parsers
-    bool addCommandParser(const std::string& strCommandName,
-        RemoteCommandParser pfnParser,
-        size_t minArgumentCount,
-        const std::string& strHelp,
-        const std::string& strDescription)
+    bool addCommandParser(const std::string &strCommandName, RemoteCommandParser pfnParser,
+                          size_t minArgumentCount, const std::string &strHelp,
+                          const std::string &strDescription)
     {
         if (findCommandParserItem(strCommandName)) {
 
@@ -148,17 +139,19 @@ public:
         }
 
         // Add command
-        _remoteCommandParserVector.push_back(new CRemoteCommandParserItem(strCommandName, pfnParser, minArgumentCount, strHelp, strDescription));
+        _remoteCommandParserVector.push_back(new CRemoteCommandParserItem(
+            strCommandName, pfnParser, minArgumentCount, strHelp, strDescription));
 
         return true;
     }
 
 private:
     // Command processing
-    bool remoteCommandProcess(const IRemoteCommand& remoteCommand, std::string& strResult)
+    bool remoteCommandProcess(const IRemoteCommand &remoteCommand, std::string &strResult)
     {
         // Dispatch
-        const CRemoteCommandParserItem* pRemoteCommandParserItem = findCommandParserItem(remoteCommand.getCommand());
+        const CRemoteCommandParserItem *pRemoteCommandParserItem =
+            findCommandParserItem(remoteCommand.getCommand());
 
         if (!pRemoteCommandParserItem) {
 
@@ -183,7 +176,7 @@ private:
     {
         if (!_maxCommandUsageLength) {
             // Show usages
-            for (const auto * pRemoteCommandParserItem : _remoteCommandParserVector) {
+            for (const auto *pRemoteCommandParserItem : _remoteCommandParserVector) {
 
                 size_t remoteCommandUsageLength = pRemoteCommandParserItem->usage().length();
 
@@ -197,7 +190,7 @@ private:
 
     /////////////////// Remote command parsers
     /// Help
-    void helpCommandProcess(std::string& strResult)
+    void helpCommandProcess(std::string &strResult)
     {
         initMaxCommandUsageLength();
 
@@ -216,7 +209,7 @@ private:
         }
     }
 
-    const CRemoteCommandParserItem* findCommandParserItem(const std::string& strCommandName) const
+    const CRemoteCommandParserItem *findCommandParserItem(const std::string &strCommandName) const
     {
         for (const auto *pRemoteCommandParserItem : _remoteCommandParserVector) {
 
@@ -229,8 +222,7 @@ private:
     }
 
 private:
-    CCommandParser* _pCommandParser;
-    std::vector<CRemoteCommandParserItem*> _remoteCommandParserVector;
+    CCommandParser *_pCommandParser;
+    std::vector<CRemoteCommandParserItem *> _remoteCommandParserVector;
     size_t _maxCommandUsageLength;
 };
-

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -38,8 +38,8 @@
 
 using std::string;
 
-CRemoteProcessorServer::CRemoteProcessorServer(uint16_t uiPort) :
-    _uiPort(uiPort), _io_service(), _acceptor(_io_service), _socket(_io_service)
+CRemoteProcessorServer::CRemoteProcessorServer(uint16_t uiPort)
+    : _uiPort(uiPort), _io_service(), _acceptor(_io_service), _socket(_io_service)
 {
 }
 
@@ -81,8 +81,7 @@ bool CRemoteProcessorServer::stop()
 
 void CRemoteProcessorServer::acceptRegister(IRemoteCommandHandler &commandHandler)
 {
-    auto peerHandler = [this, &commandHandler](asio::error_code ec)
-    {
+    auto peerHandler = [this, &commandHandler](asio::error_code ec) {
         if (ec) {
             std::cerr << "Accept failed: " << ec.message() << std::endl;
             return;
@@ -132,7 +131,7 @@ void CRemoteProcessorServer::handleNewConnection(IRemoteCommandHandler &commandH
         switch (res) {
         case CRequestMessage::error:
             std::cout << "Error while receiving message: " << strError << std::endl;
-            // fall through
+        // fall through
         case CRequestMessage::peerDisconnected:
             // Consider peer disconnection as normal, no log
             return; // Bail out
@@ -156,8 +155,8 @@ void CRemoteProcessorServer::handleNewConnection(IRemoteCommandHandler &commandH
 
         switch (res) {
         case CRequestMessage::peerDisconnected:
-            // Peer should not disconnect while waiting for an answer
-            // Fall through to log the error and bail out
+        // Peer should not disconnect while waiting for an answer
+        // Fall through to log the error and bail out
         case CRequestMessage::error:
             std::cout << "Error while receiving message: " << strError << std::endl;
             return; // Bail out

--- a/remote-processor/RemoteProcessorServer.h
+++ b/remote-processor/RemoteProcessorServer.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
@@ -61,4 +61,3 @@ private:
     asio::ip::tcp::acceptor _acceptor;
     asio::ip::tcp::socket _socket;
 };
-

--- a/remote-processor/RemoteProcessorServerInterface.h
+++ b/remote-processor/RemoteProcessorServerInterface.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *

--- a/remote-processor/RequestMessage.cpp
+++ b/remote-processor/RequestMessage.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -36,10 +36,10 @@
 
 using std::string;
 
-const char* const CRequestMessage::gacDelimiters = " \t\n\v\f\r";
+const char *const CRequestMessage::gacDelimiters = " \t\n\v\f\r";
 
-CRequestMessage::CRequestMessage(const string& strCommand) :
-    base(MsgType::ECommandRequest), _strCommand(strCommand)
+CRequestMessage::CRequestMessage(const string &strCommand)
+    : base(MsgType::ECommandRequest), _strCommand(strCommand)
 {
 }
 
@@ -48,18 +48,18 @@ CRequestMessage::CRequestMessage()
 }
 
 // Command Name
-void CRequestMessage::setCommand(const string& strCommand)
+void CRequestMessage::setCommand(const string &strCommand)
 {
     _strCommand = trim(strCommand);
 }
 
-const string& CRequestMessage::getCommand() const
+const string &CRequestMessage::getCommand() const
 {
     return _strCommand;
 }
 
 // Arguments
-void CRequestMessage::addArgument(const string& strArgument)
+void CRequestMessage::addArgument(const string &strArgument)
 {
     _argumentVector.push_back(trim(strArgument));
 }
@@ -69,12 +69,12 @@ size_t CRequestMessage::getArgumentCount() const
     return _argumentVector.size();
 }
 
-const std::vector<string>& CRequestMessage::getArguments() const
+const std::vector<string> &CRequestMessage::getArguments() const
 {
     return _argumentVector;
 }
 
-const string& CRequestMessage::getArgument(size_t argument) const
+const string &CRequestMessage::getArgument(size_t argument) const
 {
     assert(argument < _argumentVector.size());
 
@@ -90,7 +90,8 @@ const string CRequestMessage::packArguments(size_t uiStartArgument, size_t uiNbA
     // Pack arguments, separating them with a space
     bool bFirst = true;
 
-    for (size_t argument = uiStartArgument; argument < uiStartArgument + uiNbArguments; argument++) {
+    for (size_t argument = uiStartArgument; argument < uiStartArgument + uiNbArguments;
+         argument++) {
 
         if (!bFirst) {
 
@@ -155,12 +156,12 @@ size_t CRequestMessage::getDataSize() const
 }
 
 // Trim input string
-string CRequestMessage::trim(const string& strToTrim)
+string CRequestMessage::trim(const string &strToTrim)
 {
     // Trim string
     string strTrimmed = strToTrim;
 
-    strTrimmed.erase(strTrimmed.find_last_not_of(gacDelimiters) + 1 );
+    strTrimmed.erase(strTrimmed.find_last_not_of(gacDelimiters) + 1);
 
     strTrimmed.erase(0, strTrimmed.find_first_not_of(gacDelimiters));
 

--- a/remote-processor/RequestMessage.h
+++ b/remote-processor/RequestMessage.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -39,28 +39,27 @@
 class REMOTE_PROCESSOR_EXPORT CRequestMessage : public CMessage, public IRemoteCommand
 {
 public:
-    CRequestMessage(const std::string& strCommand);
+    CRequestMessage(const std::string &strCommand);
     CRequestMessage();
 
     // Command Name
-    void setCommand(const std::string& strCommand);
-    virtual const std::string& getCommand() const;
+    void setCommand(const std::string &strCommand);
+    virtual const std::string &getCommand() const;
 
     // Arguments
-    virtual void addArgument(const std::string& strArgument);
+    virtual void addArgument(const std::string &strArgument);
     virtual size_t getArgumentCount() const;
-    virtual const std::string& getArgument(size_t argument) const;
-    virtual const std::vector<std::string>& getArguments() const;
+    virtual const std::string &getArgument(size_t argument) const;
+    virtual const std::vector<std::string> &getArguments() const;
     virtual const std::string packArguments(size_t startArgument, size_t nbArguments) const;
 
 private:
-
     /**
       * Constant character array.
       * This value defines the delimiters used to separate the arguments
       * in the request command.
       */
-    static const char* const gacDelimiters;
+    static const char *const gacDelimiters;
 
     // Fill data to send
     virtual void fillDataToSend();
@@ -72,11 +71,10 @@ private:
      */
     virtual size_t getDataSize() const;
     // Trim input std::string
-    static std::string trim(const std::string& strToTrim);
+    static std::string trim(const std::string &strToTrim);
 
     // Command
     std::string _strCommand;
     // Arguments
     std::vector<std::string> _argumentVector;
 };
-

--- a/skeleton-subsystem/SkeletonMappingKeys.h
+++ b/skeleton-subsystem/SkeletonMappingKeys.h
@@ -30,7 +30,8 @@
 #pragma once
 
 // Mapping item types
-enum SkeletonItemType {
+enum SkeletonItemType
+{
     ESkeletonOwner,
     EAmend1,
     EAmend2,

--- a/skeleton-subsystem/SkeletonSubsystem.cpp
+++ b/skeleton-subsystem/SkeletonSubsystem.cpp
@@ -35,7 +35,7 @@
 #define base CSubsystem
 
 // Implementation
-CSkeletonSubsystem::CSkeletonSubsystem(const std::string& strName, core::log::Logger& logger)
+CSkeletonSubsystem::CSkeletonSubsystem(const std::string &strName, core::log::Logger &logger)
     : base(strName, logger)
 {
     // Provide mapping keys to upper layer
@@ -44,5 +44,6 @@ CSkeletonSubsystem::CSkeletonSubsystem(const std::string& strName, core::log::Lo
     addContextMappingKey("Amend2");
 
     // Provide creators to upper layer
-    addSubsystemObjectFactory(new TSubsystemObjectFactory<CSkeletonSubsystemObject>("Message", 1 << ESkeletonOwner));
+    addSubsystemObjectFactory(
+        new TSubsystemObjectFactory<CSkeletonSubsystemObject>("Message", 1 << ESkeletonOwner));
 }

--- a/skeleton-subsystem/SkeletonSubsystem.h
+++ b/skeleton-subsystem/SkeletonSubsystem.h
@@ -34,7 +34,5 @@
 class CSkeletonSubsystem : public CSubsystem
 {
 public:
-    CSkeletonSubsystem(const std::string& strName, core::log::Logger& logger);
-
+    CSkeletonSubsystem(const std::string &strName, core::log::Logger &logger);
 };
-

--- a/skeleton-subsystem/SkeletonSubsystemBuilder.cpp
+++ b/skeleton-subsystem/SkeletonSubsystemBuilder.cpp
@@ -31,10 +31,9 @@
 #include "LoggingElementBuilderTemplate.h"
 #include "SkeletonSubsystem.h"
 
-
-void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary* pSubsystemLibrary, core::log::Logger& logger)
+void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary *pSubsystemLibrary,
+                                              core::log::Logger &logger)
 {
     pSubsystemLibrary->addElementBuilder(
-            "Skeleton",
-            new TLoggingElementBuilderTemplate<CSkeletonSubsystem>(logger));
+        "Skeleton", new TLoggingElementBuilderTemplate<CSkeletonSubsystem>(logger));
 }

--- a/skeleton-subsystem/SkeletonSubsystemObject.cpp
+++ b/skeleton-subsystem/SkeletonSubsystemObject.cpp
@@ -46,43 +46,36 @@
 using std::string;
 
 CSkeletonSubsystemObject::CSkeletonSubsystemObject(
-            const string& strMappingValue,
-            CInstanceConfigurableElement* pInstanceConfigurableElement,
-            const CMappingContext& context,
-            core::log::Logger& logger
-        ) :
-        base(pInstanceConfigurableElement,
-             logger,
-             strMappingValue,
-             EAmend1,
-             EAmendEnd - EAmend1 + 1,
-             context),
-        _bWrongElementTypeError(false)
+    const string &strMappingValue, CInstanceConfigurableElement *pInstanceConfigurableElement,
+    const CMappingContext &context, core::log::Logger &logger)
+    : base(pInstanceConfigurableElement, logger, strMappingValue, EAmend1, EAmendEnd - EAmend1 + 1,
+           context),
+      _bWrongElementTypeError(false)
 {
     // Get actual element type
-    const CParameterType* pParameterType = static_cast<const CParameterType*>(pInstanceConfigurableElement->getTypeElement());
+    const CParameterType *pParameterType =
+        static_cast<const CParameterType *>(pInstanceConfigurableElement->getTypeElement());
 
     // Retrieve sizes
     _scalarSize = pParameterType->getSize();
     _arraySize = pInstanceConfigurableElement->getFootPrint() / _scalarSize;
 
     // Construct message
-    _strMessage = context.getItem(ESkeletonOwner) + ":" + strMappingValue ;
+    _strMessage = context.getItem(ESkeletonOwner) + ":" + strMappingValue;
 
     // Handle types
     // Check we are able to handle elements (no exception support, defer the error)
-    switch(pInstanceConfigurableElement->getType()) {
+    switch (pInstanceConfigurableElement->getType()) {
 
-        case CInstanceConfigurableElement::EParameter:
-            break;
-        default:
-            _bWrongElementTypeError = true;
-            break;
+    case CInstanceConfigurableElement::EParameter:
+        break;
+    default:
+        _bWrongElementTypeError = true;
+        break;
     }
-
 }
 // Sync to/from HW
-bool CSkeletonSubsystemObject::accessHW(bool bReceive, string& strError)
+bool CSkeletonSubsystemObject::accessHW(bool bReceive, string &strError)
 {
     // Check parameter type is ok (deferred error, no exceptions available :-()
     if (_bWrongElementTypeError) {
@@ -95,11 +88,11 @@ bool CSkeletonSubsystemObject::accessHW(bool bReceive, string& strError)
     return base::accessHW(bReceive, strError);
 }
 
-bool CSkeletonSubsystemObject::sendToHW(string& /*strError*/)
+bool CSkeletonSubsystemObject::sendToHW(string & /*strError*/)
 {
-    void* pvValue = alloca(_scalarSize);
+    void *pvValue = alloca(_scalarSize);
 
-    for (size_t index = 0 ; index < _arraySize ; index++) {
+    for (size_t index = 0; index < _arraySize; index++) {
 
         // Read Value in BlackBoard
         blackboardRead(pvValue, _scalarSize);
@@ -111,11 +104,11 @@ bool CSkeletonSubsystemObject::sendToHW(string& /*strError*/)
     return true;
 }
 
-bool CSkeletonSubsystemObject::receiveFromHW(string& /*strError*/)
+bool CSkeletonSubsystemObject::receiveFromHW(string & /*strError*/)
 {
-    void* pvValue = alloca(_scalarSize);
+    void *pvValue = alloca(_scalarSize);
 
-    for (size_t index = 0 ; index < _arraySize ; index++) {
+    for (size_t index = 0; index < _arraySize; index++) {
 
         // Retreive here the value
         std::cout << "Retreive from HW: " << _strMessage << std::endl;

--- a/skeleton-subsystem/SkeletonSubsystemObject.h
+++ b/skeleton-subsystem/SkeletonSubsystemObject.h
@@ -36,20 +36,19 @@ class CMappingContext;
 class CSkeletonSubsystemObject : public CFormattedSubsystemObject
 {
 public:
-    CSkeletonSubsystemObject(const std::string& strMappingValue,
-                             CInstanceConfigurableElement* pInstanceConfigurableElement,
-                             const CMappingContext& context,
-                             core::log::Logger& logger);
+    CSkeletonSubsystemObject(const std::string &strMappingValue,
+                             CInstanceConfigurableElement *pInstanceConfigurableElement,
+                             const CMappingContext &context, core::log::Logger &logger);
 
 protected:
     // from CSubsystemObject
     // Sync to/from HW
-    virtual bool sendToHW(std::string& strError);
-    virtual bool receiveFromHW(std::string& strError);
+    virtual bool sendToHW(std::string &strError);
+    virtual bool receiveFromHW(std::string &strError);
 
 private:
     // Sync to/from HW
-    virtual bool accessHW(bool bReceive, std::string& strError);
+    virtual bool accessHW(bool bReceive, std::string &strError);
 
 protected:
     // Scalar parameter size for elementary access

--- a/skeleton-subsystem/test/main.cpp
+++ b/skeleton-subsystem/test/main.cpp
@@ -34,16 +34,13 @@
 class MyLogger final : public CParameterMgrFullConnector::ILogger
 {
 public:
-    void info(const std::string& log) override {
-        std::cout << "Info: " << log << std::endl;
-    }
+    void info(const std::string &log) override { std::cout << "Info: " << log << std::endl; }
 
-    void warning(const std::string& log) override {
-        std::cerr << "Warning: " << log << std::endl;
-    }
+    void warning(const std::string &log) override { std::cerr << "Warning: " << log << std::endl; }
 };
 
-int main(void) {
+int main(void)
+{
     MyLogger logger;
     CParameterMgrFullConnector instance("toplevel.xml");
     instance.setLogger(&logger);

--- a/test/functional-tests/AutoSync.cpp
+++ b/test/functional-tests/AutoSync.cpp
@@ -43,8 +43,7 @@ namespace parameterFramework
 
 struct BoolPF : public ParameterFramework
 {
-    BoolPF()
-        : ParameterFramework{ createConfig() } {}
+    BoolPF() : ParameterFramework{createConfig()} {}
 
     /** Set the boolean parameter value within the "Conf" configuration,
      * which is always applicable. */
@@ -59,7 +58,7 @@ private:
     {
         Config config;
         config.instances = R"(<BooleanParameter Name="param" Mapping="Object"/>)";
-        config.plugins = { { "", {"introspection-subsystem"} } };
+        config.plugins = {{"", {"introspection-subsystem"}}};
         config.subsystemType = "INTROSPECTION";
 
         config.domains = R"(<ConfigurableDomain Name="Domain">
@@ -86,40 +85,40 @@ private:
     }
 };
 
-SCENARIO_METHOD(BoolPF, "Auto sync") {
-    GIVEN("A Pfw that starts") {
+SCENARIO_METHOD (BoolPF, "Auto sync") {
+    GIVEN ("A Pfw that starts") {
         REQUIRE_NOTHROW(start());
 
-        THEN("Parameter value is false according to the settings") {
+        THEN ("Parameter value is false according to the settings") {
             REQUIRE_FALSE(introspectionSubsystem::getParameterValue());
 
-            AND_THEN("Tuning is off") {
+            AND_THEN ("Tuning is off") {
                 REQUIRE_FALSE(isTuningModeOn());
 
-                WHEN("Turning autosync on") {
+                WHEN ("Turning autosync on") {
                     REQUIRE_NOTHROW(setAutoSync(true));
 
-                    AND_WHEN("A parameter is set") {
+                    AND_WHEN ("A parameter is set") {
                         REQUIRE_NOTHROW(setParameterValue(true));
 
-                        THEN("Sync is done") {
+                        THEN ("Sync is done") {
                             CHECK(introspectionSubsystem::getParameterValue());
                         }
                     }
                 }
-                WHEN("Turning autosync off") {
+                WHEN ("Turning autosync off") {
                     REQUIRE_NOTHROW(setAutoSync(false));
 
-                    AND_WHEN("A parameter is set") {
+                    AND_WHEN ("A parameter is set") {
                         REQUIRE_NOTHROW(setParameterValue(true));
 
-                        THEN("Sync should not have occurred yet") {
+                        THEN ("Sync should not have occurred yet") {
                             REQUIRE_FALSE(introspectionSubsystem::getParameterValue());
 
-                            WHEN("Turning autosync on") {
+                            WHEN ("Turning autosync on") {
                                 REQUIRE_NOTHROW(setAutoSync(true));
 
-                                THEN("Sync is done") {
+                                THEN ("Sync is done") {
                                     CHECK(introspectionSubsystem::getParameterValue());
                                 }
                             }
@@ -130,5 +129,4 @@ SCENARIO_METHOD(BoolPF, "Auto sync") {
         }
     }
 }
-
 }

--- a/test/functional-tests/AutoSync.cpp
+++ b/test/functional-tests/AutoSync.cpp
@@ -85,7 +85,8 @@ private:
     }
 };
 
-SCENARIO_METHOD (BoolPF, "Auto sync") {
+SCENARIO_METHOD(BoolPF, "Auto sync")
+{
     GIVEN ("A Pfw that starts") {
         REQUIRE_NOTHROW(start());
 

--- a/test/functional-tests/Basic.cpp
+++ b/test/functional-tests/Basic.cpp
@@ -43,43 +43,44 @@
 namespace parameterFramework
 {
 
-SCENARIO_METHOD(ParameterFramework, "Default logger", "[log]") {
-    WHEN("No logger is set") {
-        THEN("Start should succeed") {
+SCENARIO_METHOD (ParameterFramework, "Default logger", "[log]") {
+    WHEN ("No logger is set") {
+        THEN ("Start should succeed") {
             CHECK_NOTHROW(start());
         }
     }
 }
 
-SCENARIO_METHOD(ParameterFramework, "No Logger", "[log]") {
-    WHEN("A nullptr logger is set") {
+SCENARIO_METHOD (ParameterFramework, "No Logger", "[log]") {
+    WHEN ("A nullptr logger is set") {
         setLogger(nullptr);
-        THEN("Start should succeed") {
+        THEN ("Start should succeed") {
             CHECK_NOTHROW(start());
         }
     }
 }
 
-SCENARIO_METHOD(WarningPF, "Logger should receive info and warnings", "[log]") {
-    GIVEN("Config files that emit warnings") {
-        GIVEN("A logger that stores logs") {
+SCENARIO_METHOD (WarningPF, "Logger should receive info and warnings", "[log]") {
+    GIVEN ("Config files that emit warnings") {
+        GIVEN ("A logger that stores logs") {
             StoreLogger logger{};
-            WHEN("The record logger is set") {
+            WHEN ("The record logger is set") {
                 setLogger(&logger);
-                THEN("Start should succeed") {
+                THEN ("Start should succeed") {
                     REQUIRE_NOTHROW(start());
-                    AND_THEN("The logger should have stored info and warning log") {
+                    AND_THEN ("The logger should have stored info and warning log") {
                         using Logs = StoreLogger::Logs;
                         using Level = StoreLogger::Log::Level;
                         CHECK(logger.filter(Level::warning) != Logs{});
                         CHECK(logger.getLogs() != Logs{});
                     }
                 }
-                AND_WHEN("A nullptr logger is set") {
+                AND_WHEN ("A nullptr logger is set") {
                     setLogger(nullptr);
-                    THEN("Start should succeed") {
+                    THEN ("Start should succeed") {
                         REQUIRE_NOTHROW(start());
-                        AND_THEN("The record logger should NOT have stored any info or warning log") {
+                        AND_THEN (
+                            "The record logger should NOT have stored any info or warning log") {
                             CHECK(logger.getLogs() == StoreLogger::Logs{});
                         }
                     }
@@ -89,23 +90,22 @@ SCENARIO_METHOD(WarningPF, "Logger should receive info and warnings", "[log]") {
     }
 }
 
-SCENARIO_METHOD(LazyPF, "Tuning OK", "[properties][remote interface]") {
+SCENARIO_METHOD (LazyPF, "Tuning OK", "[properties][remote interface]") {
 }
 
-SCENARIO_METHOD(LazyPF, "Invalid XML configuration") {
-    for (auto &xmlT : Tests<std::string>{
-            {"an unknown tag", "<unknown_tag/>" },
-            {"an unclosed tag", "<unclosed>" } }) {
+SCENARIO_METHOD (LazyPF, "Invalid XML configuration") {
+    for (auto &xmlT : Tests<std::string>{{"an unknown tag", "<unknown_tag/>"},
+                                         {"an unclosed tag", "<unclosed>"}}) {
         auto invalidXml = xmlT.payload;
-        GIVEN("An invalid xml: containing " + xmlT.title) {
+        GIVEN ("An invalid xml: containing " + xmlT.title) {
             Config::Plugins ps{};
             for (auto &&configT : Tests<Config>{
-                    {"top config", { &Config::plugins, Config::Plugins{ { "", { invalidXml } } } } },
-                    {"structure", { &Config::instances, invalidXml } },
-                    {"settings", { &Config::domains, invalidXml } } }) {
-                WHEN("Used in the " + configT.title) {
+                     {"top config", {&Config::plugins, Config::Plugins{{"", {invalidXml}}}}},
+                     {"structure", {&Config::instances, invalidXml}},
+                     {"settings", {&Config::domains, invalidXml}}}) {
+                WHEN ("Used in the " + configT.title) {
                     create(std::move(configT.payload));
-                    THEN("Start should fail") {
+                    THEN ("Start should fail") {
                         CHECK_THROWS_AS(mPf->start(), Exception);
                     }
                 }
@@ -114,28 +114,26 @@ SCENARIO_METHOD(LazyPF, "Invalid XML configuration") {
     }
 }
 
-SCENARIO_METHOD(LazyPF, "Plugin OK", "[properties][missing plugin policy]") {
-    for (auto &pluginNameT : Tests<std::string>{
-            {"an non existing plugin", "libdonetexist.so" },
-            {"an existing library but invalid (linux) PF plugin", "libc.so.6" } })
-    {
-        GIVEN("An" + pluginNameT.title)
-        {
-            create({ &Config::plugins, Config::Plugins{ { "", { pluginNameT.payload } } } });
-            WHEN("The missing subsystem policy is left to default") {
-                THEN("Start should fail") {
+SCENARIO_METHOD (LazyPF, "Plugin OK", "[properties][missing plugin policy]") {
+    for (auto &pluginNameT :
+         Tests<std::string>{{"an non existing plugin", "libdonetexist.so"},
+                            {"an existing library but invalid (linux) PF plugin", "libc.so.6"}}) {
+        GIVEN ("An" + pluginNameT.title) {
+            create({&Config::plugins, Config::Plugins{{"", {pluginNameT.payload}}}});
+            WHEN ("The missing subsystem policy is left to default") {
+                THEN ("Start should fail") {
                     CHECK_THROWS_AS(mPf->start(), Exception);
                 }
             }
-            WHEN("The missing subsystem policy is set to failure") {
+            WHEN ("The missing subsystem policy is set to failure") {
                 mPf->setFailureOnMissingSubsystem(true);
-                THEN("Start should fail") {
+                THEN ("Start should fail") {
                     CHECK_THROWS_AS(mPf->start(), Exception);
                 }
             }
-            WHEN("The missing subsystem policy is set to ignore") {
+            WHEN ("The missing subsystem policy is set to ignore") {
                 mPf->setFailureOnMissingSubsystem(false);
-                THEN("Start should success") {
+                THEN ("Start should success") {
                     CHECK_NOTHROW(mPf->start());
                 }
             }
@@ -143,26 +141,25 @@ SCENARIO_METHOD(LazyPF, "Plugin OK", "[properties][missing plugin policy]") {
     }
 }
 
-
-SCENARIO_METHOD(LazyPF, "Invalid domains", "[properties]") {
-    GIVEN("An invalid domain file") {
-        create({ &Config::domains, "<Domain name='Invalid'/>" });
-        THEN("Start should fail") {
+SCENARIO_METHOD (LazyPF, "Invalid domains", "[properties]") {
+    GIVEN ("An invalid domain file") {
+        create({&Config::domains, "<Domain name='Invalid'/>"});
+        THEN ("Start should fail") {
             CHECK_THROWS_AS(mPf->start(), Exception);
         }
-        WHEN("Changing failure setting load policy to ignore") {
+        WHEN ("Changing failure setting load policy to ignore") {
             mPf->setFailureOnFailedSettingsLoad(false);
-            THEN("Start should succeed") {
+            THEN ("Start should succeed") {
                 CHECK_NOTHROW(mPf->start());
             }
         }
     }
 }
 
-SCENARIO_METHOD(ParameterFramework, "Raw value space") {
-    WHEN("Raw value space is set") {
+SCENARIO_METHOD (ParameterFramework, "Raw value space") {
+    WHEN ("Raw value space is set") {
         setRawValueSpace(true);
-        THEN("Value space should be raw") {
+        THEN ("Value space should be raw") {
             CHECK(isValueSpaceRaw() == true);
         }
     }

--- a/test/functional-tests/Basic.cpp
+++ b/test/functional-tests/Basic.cpp
@@ -43,7 +43,8 @@
 namespace parameterFramework
 {
 
-SCENARIO_METHOD (ParameterFramework, "Default logger", "[log]") {
+SCENARIO_METHOD(ParameterFramework, "Default logger", "[log]")
+{
     WHEN ("No logger is set") {
         THEN ("Start should succeed") {
             CHECK_NOTHROW(start());
@@ -51,7 +52,8 @@ SCENARIO_METHOD (ParameterFramework, "Default logger", "[log]") {
     }
 }
 
-SCENARIO_METHOD (ParameterFramework, "No Logger", "[log]") {
+SCENARIO_METHOD(ParameterFramework, "No Logger", "[log]")
+{
     WHEN ("A nullptr logger is set") {
         setLogger(nullptr);
         THEN ("Start should succeed") {
@@ -60,7 +62,8 @@ SCENARIO_METHOD (ParameterFramework, "No Logger", "[log]") {
     }
 }
 
-SCENARIO_METHOD (WarningPF, "Logger should receive info and warnings", "[log]") {
+SCENARIO_METHOD(WarningPF, "Logger should receive info and warnings", "[log]")
+{
     GIVEN ("Config files that emit warnings") {
         GIVEN ("A logger that stores logs") {
             StoreLogger logger{};
@@ -90,10 +93,12 @@ SCENARIO_METHOD (WarningPF, "Logger should receive info and warnings", "[log]") 
     }
 }
 
-SCENARIO_METHOD (LazyPF, "Tuning OK", "[properties][remote interface]") {
+SCENARIO_METHOD(LazyPF, "Tuning OK", "[properties][remote interface]")
+{
 }
 
-SCENARIO_METHOD (LazyPF, "Invalid XML configuration") {
+SCENARIO_METHOD(LazyPF, "Invalid XML configuration")
+{
     for (auto &xmlT : Tests<std::string>{{"an unknown tag", "<unknown_tag/>"},
                                          {"an unclosed tag", "<unclosed>"}}) {
         auto invalidXml = xmlT.payload;
@@ -114,7 +119,8 @@ SCENARIO_METHOD (LazyPF, "Invalid XML configuration") {
     }
 }
 
-SCENARIO_METHOD (LazyPF, "Plugin OK", "[properties][missing plugin policy]") {
+SCENARIO_METHOD(LazyPF, "Plugin OK", "[properties][missing plugin policy]")
+{
     for (auto &pluginNameT :
          Tests<std::string>{{"an non existing plugin", "libdonetexist.so"},
                             {"an existing library but invalid (linux) PF plugin", "libc.so.6"}}) {
@@ -141,7 +147,8 @@ SCENARIO_METHOD (LazyPF, "Plugin OK", "[properties][missing plugin policy]") {
     }
 }
 
-SCENARIO_METHOD (LazyPF, "Invalid domains", "[properties]") {
+SCENARIO_METHOD(LazyPF, "Invalid domains", "[properties]")
+{
     GIVEN ("An invalid domain file") {
         create({&Config::domains, "<Domain name='Invalid'/>"});
         THEN ("Start should fail") {
@@ -156,7 +163,8 @@ SCENARIO_METHOD (LazyPF, "Invalid domains", "[properties]") {
     }
 }
 
-SCENARIO_METHOD (ParameterFramework, "Raw value space") {
+SCENARIO_METHOD(ParameterFramework, "Raw value space")
+{
     WHEN ("Raw value space is set") {
         setRawValueSpace(true);
         THEN ("Value space should be raw") {

--- a/test/functional-tests/FloatingPoint.cpp
+++ b/test/functional-tests/FloatingPoint.cpp
@@ -43,62 +43,58 @@ using std::string;
 namespace parameterFramework
 {
 
-
-const auto validInstances = Config{ &Config::instances,
-    // Size is fixed at 32 and as such is optional */
-    R"(<FloatingPointParameter Name="Empty"/>
+const auto validInstances = Config{&Config::instances,
+                                   // Size is fixed at 32 and as such is optional */
+                                   R"(<FloatingPointParameter Name="Empty"/>
     <FloatingPointParameter Name="trivial" Size="32"/>
     <FloatingPointParameter Name="nominal" Size="32" Min="-50.4" Max="12.2"/>
     <FloatingPointParameter Name="defaultMin" Size="32" Max="12.2"/>
-    <FloatingPointParameter Name="defaultMax" Size="32" Min="-50.4"/>)"
-};
-const auto &invalidParameters = Tests<string>{
-    { "invalid Size(64)", "<FloatingPointParameter Name='error' Size='64'/>" },
-    { "invalid Size(16)", "<FloatingPointParameter Name='error' Size='16'/>" },
-    { "minimum > maximum", "<FloatingPointParameter Name='error' Min='1' Max='0'/>" }
-};
+    <FloatingPointParameter Name="defaultMax" Size="32" Min="-50.4"/>)"};
+const auto &invalidParameters =
+    Tests<string>{{"invalid Size(64)", "<FloatingPointParameter Name='error' Size='64'/>"},
+                  {"invalid Size(16)", "<FloatingPointParameter Name='error' Size='16'/>"},
+                  {"minimum > maximum", "<FloatingPointParameter Name='error' Min='1' Max='0'/>"}};
 
 struct FloatsPF : public ParameterFramework
 {
-    FloatsPF()
-        : ParameterFramework{ std::move(validInstances) } {}
+    FloatsPF() : ParameterFramework{std::move(validInstances)} {}
 };
 
-SCENARIO_METHOD(LazyPF, "Invalid floating points XML structure", "[floating point]") {
+SCENARIO_METHOD (LazyPF, "Invalid floating points XML structure", "[floating point]") {
     for (auto &vec : invalidParameters) {
-        GIVEN("intentional error: " + vec.title) {
-            create(Config{ &Config::instances, vec.payload });
-            THEN("Start should fail") {
+        GIVEN ("intentional error: " + vec.title) {
+            create(Config{&Config::instances, vec.payload});
+            THEN ("Start should fail") {
                 CHECK_THROWS_AS(mPf->start(), Exception);
             }
         }
     }
 }
 
-SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
-    GIVEN("A valid XML structure file") {
-        THEN("Start should succeed") {
+SCENARIO_METHOD (FloatsPF, "Floating points", "[floating points]") {
+    GIVEN ("A valid XML structure file") {
+        THEN ("Start should succeed") {
             CHECK_NOTHROW(start());
             REQUIRE_NOTHROW(setTuningMode(true));
             string path = "/test/test/nominal";
 
-            AND_THEN("Set/Get a floating point parameter in real value space") {
+            AND_THEN ("Set/Get a floating point parameter in real value space") {
 
                 for (auto &vec : Tests<string>{
-                            { "(too high)", "12.3" },
-                            { "(too low)", "-50.5" },
-                            { "(not a number)", "foobar" },
-                        }) {
-                    GIVEN("Invalid value " + vec.title) {
+                         {"(too high)", "12.3"},
+                         {"(too low)", "-50.5"},
+                         {"(not a number)", "foobar"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
                         CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
                     }
                 }
                 for (auto &vec : Tests<string>{
-                            { "(upper limit)", "12.2" },
-                            { "(lower limit)", "-50.4" },
-                            { "(inside range)", "0" },
-                        }) {
-                    GIVEN("A valid value " + vec.title) {
+                         {"(upper limit)", "12.2"},
+                         {"(lower limit)", "-50.4"},
+                         {"(inside range)", "0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
                         CHECK_NOTHROW(setParameter(path, vec.payload));
                         string getValueBack;
                         CHECK_NOTHROW(getParameter(path, getValueBack));
@@ -107,22 +103,22 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
                 }
             }
 
-            AND_THEN("Set/Get a floating point parameter in raw value space") {
+            AND_THEN ("Set/Get a floating point parameter in raw value space") {
                 const float tooHigh = 12.3f;
                 const float tooLow = -50.5f;
                 const float nan = std::numeric_limits<float>::quiet_NaN();
                 const float inf = std::numeric_limits<float>::infinity();
                 REQUIRE_NOTHROW(setRawValueSpace(true));
                 for (auto &vec : Tests<string>{
-                            { "(too high, as decimal)",
-                                std::to_string(::utility::binaryCopy<uint32_t>(tooHigh)) },
-                            { "(too low, as decimal)",
-                                std::to_string(::utility::binaryCopy<uint32_t>(tooLow)) },
-                            { "(meaningless)", "foobar" },
-                            { "(infinity)", std::to_string(::utility::binaryCopy<uint32_t>(inf))},
-                            { "(NaN)", std::to_string(::utility::binaryCopy<uint32_t>(nan))},
-                        }) {
-                    GIVEN("Invalid value " + vec.title) {
+                         {"(too high, as decimal)",
+                          std::to_string(::utility::binaryCopy<uint32_t>(tooHigh))},
+                         {"(too low, as decimal)",
+                          std::to_string(::utility::binaryCopy<uint32_t>(tooLow))},
+                         {"(meaningless)", "foobar"},
+                         {"(infinity)", std::to_string(::utility::binaryCopy<uint32_t>(inf))},
+                         {"(NaN)", std::to_string(::utility::binaryCopy<uint32_t>(nan))},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
                         CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
                     }
                 }
@@ -130,14 +126,14 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
                 const float lower = -50.4f;
                 const float zero = 0.0f;
                 for (auto &vec : Tests<string>{
-                            { "(upper limit, as decimal)",
-                                std::to_string(::utility::binaryCopy<uint32_t>(upper)) },
-                            { "(lower limit, as decimal)",
-                                std::to_string(::utility::binaryCopy<uint32_t>(lower)) },
-                            { "(inside range, as decimal)",
-                                std::to_string(::utility::binaryCopy<uint32_t>(zero)) },
-                        }) {
-                    GIVEN("A valid value " + vec.title) {
+                         {"(upper limit, as decimal)",
+                          std::to_string(::utility::binaryCopy<uint32_t>(upper))},
+                         {"(lower limit, as decimal)",
+                          std::to_string(::utility::binaryCopy<uint32_t>(lower))},
+                         {"(inside range, as decimal)",
+                          std::to_string(::utility::binaryCopy<uint32_t>(zero))},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
                         CHECK_NOTHROW(setParameter(path, vec.payload));
                         string getValueBack;
                         CHECK_NOTHROW(getParameter(path, getValueBack));
@@ -146,7 +142,7 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
                 }
             }
 
-            AND_THEN("Set/Get floating point parameter handle") {
+            AND_THEN ("Set/Get floating point parameter handle") {
                 ElementHandle handle{*this, path};
                 /** @FIXME: 'set' operations on a ParameterHandle are silently
                  * ignored in tuning mode. Does it make sense ? */
@@ -156,11 +152,11 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
                  * argument, we need to define the test vector as floats in
                  * order to prevent rounding issues */
                 for (auto &vec : Tests<float>{
-                            { "(upper limit)", 12.2f },
-                            { "(lower limit)", -50.4f },
-                            { "(inside range)", 0.0f },
-                        }) {
-                    GIVEN("A valid value " + vec.title) {
+                         {"(upper limit)", 12.2f},
+                         {"(lower limit)", -50.4f},
+                         {"(inside range)", 0.0f},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
                         CHECK_NOTHROW(handle.setAsDouble(vec.payload));
                         double getValueBack;
                         CHECK_NOTHROW(handle.getAsDouble(getValueBack));
@@ -168,10 +164,9 @@ SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]") {
                     }
                 }
                 for (auto &vec : Tests<float>{
-                            { "(too high)", 12.3f },
-                            { "(too low)", -50.5f },
-                        }) {
-                    GIVEN("An invalid value " + vec.title) {
+                         {"(too high)", 12.3f}, {"(too low)", -50.5f},
+                     }) {
+                    GIVEN ("An invalid value " + vec.title) {
                         CHECK_THROWS_AS(handle.setAsDouble(vec.payload), Exception);
                     }
                 }

--- a/test/functional-tests/FloatingPoint.cpp
+++ b/test/functional-tests/FloatingPoint.cpp
@@ -60,7 +60,8 @@ struct FloatsPF : public ParameterFramework
     FloatsPF() : ParameterFramework{std::move(validInstances)} {}
 };
 
-SCENARIO_METHOD (LazyPF, "Invalid floating points XML structure", "[floating point]") {
+SCENARIO_METHOD(LazyPF, "Invalid floating points XML structure", "[floating point]")
+{
     for (auto &vec : invalidParameters) {
         GIVEN ("intentional error: " + vec.title) {
             create(Config{&Config::instances, vec.payload});
@@ -71,7 +72,8 @@ SCENARIO_METHOD (LazyPF, "Invalid floating points XML structure", "[floating poi
     }
 }
 
-SCENARIO_METHOD (FloatsPF, "Floating points", "[floating points]") {
+SCENARIO_METHOD(FloatsPF, "Floating points", "[floating points]")
+{
     GIVEN ("A valid XML structure file") {
         THEN ("Start should succeed") {
             CHECK_NOTHROW(start());

--- a/test/functional-tests/Handle.cpp
+++ b/test/functional-tests/Handle.cpp
@@ -51,10 +51,7 @@ namespace parameterFramework
 
 struct AllParamsPF : public ParameterFramework
 {
-    AllParamsPF() : ParameterFramework{getConfig()}
-    {
-        REQUIRE_NOTHROW(start());
-    }
+    AllParamsPF() : ParameterFramework{getConfig()} { REQUIRE_NOTHROW(start()); }
 
     string getBasicParams()
     {
@@ -97,20 +94,18 @@ struct AllParamsPF : public ParameterFramework
     {
         Config config;
         config.components = nodeDesc("ComponentType", "component_type", getBasicParams());
-        config.instances = getBasicParams() +
-                           nodeDesc("ParameterBlock", "parameter_block",getBasicParams()) +
-                           nodeDesc("ParameterBlock", "parameter_block_array",
-                                    getBasicParams(), "ArrayLength='2'") +
-                           nodeDesc("Component", "component_scalar", "", "Type='component_type'") +
-                           nodeDesc("Component", "component_array", "",
-                                    "Type='component_type' ArrayLength='2'");
+        config.instances =
+            getBasicParams() + nodeDesc("ParameterBlock", "parameter_block", getBasicParams()) +
+            nodeDesc("ParameterBlock", "parameter_block_array", getBasicParams(),
+                     "ArrayLength='2'") +
+            nodeDesc("Component", "component_scalar", "", "Type='component_type'") +
+            nodeDesc("Component", "component_array", "", "Type='component_type' ArrayLength='2'");
         return config;
-   }
+    }
 
     void checkStructure(const string &path, const string &expected)
     {
-        CHECK_NOTHROW(checkXMLEq(ElementHandle{*this, path}.getStructureAsXML(),
-                      expected));
+        CHECK_NOTHROW(checkXMLEq(ElementHandle{*this, path}.getStructureAsXML(), expected));
     }
 
     /** Use libxml2 to pretty format xml.
@@ -120,9 +115,10 @@ struct AllParamsPF : public ParameterFramework
     {
         // Parse xml
         // Might be better to specialize std::default_delete<xmlDoc>.
-        std::unique_ptr<xmlDoc, void(*)(xmlDoc *)> doc{
-                xmlReadMemory(xml.c_str(), (int)xml.length(), "structure.xml", nullptr, XML_PARSE_NOBLANKS),
-                xmlFreeDoc};
+        std::unique_ptr<xmlDoc, void (*)(xmlDoc *)> doc{
+            xmlReadMemory(xml.c_str(), (int)xml.length(), "structure.xml", nullptr,
+                          XML_PARSE_NOBLANKS),
+            xmlFreeDoc};
         if (doc == nullptr) {
             throw Exception{"Failed to parse document: " + xml};
         }
@@ -140,8 +136,8 @@ struct AllParamsPF : public ParameterFramework
         //       attributes are also ordered deterministically.
         //       That would solve the workaround in the node function with pre/post attributes.
         //       Unfortunately c14n is not available in appveyor (Windows CI) libxml2 prebuild
-        xmlDocDumpFormatMemoryEnc(doc.get(), &unsafeFormated, &size, "UTF-8",1);
-        std::unique_ptr<xmlChar, void(*)(void *)> formated{unsafeFormated, xmlFree};
+        xmlDocDumpFormatMemoryEnc(doc.get(), &unsafeFormated, &size, "UTF-8", 1);
+        std::unique_ptr<xmlChar, void (*)(void *)> formated{unsafeFormated, xmlFree};
 
         if (formated == nullptr) {
             throw Exception{"Could not dump xml: " + xml};
@@ -150,7 +146,7 @@ struct AllParamsPF : public ParameterFramework
         return string{(char *)formated.get()};
     }
 
-    static void checkEq(const string &result, const string& expected)
+    static void checkEq(const string &result, const string &expected)
     {
         CHECK(result == expected);
 
@@ -161,7 +157,8 @@ struct AllParamsPF : public ParameterFramework
             utility::TmpFile resultFile(result);
             utility::TmpFile expectedFile(expected);
             auto gitCommand = "git --no-pager diff --word-diff-regex='[^ <>]+' --color --no-index ";
-            auto diffSuccess = system((gitCommand + resultFile.getPath() + ' ' + expectedFile.getPath()).c_str());
+            auto diffSuccess =
+                system((gitCommand + resultFile.getPath() + ' ' + expectedFile.getPath()).c_str());
             if (diffSuccess != 0) {
                 WARN("Failed to pretty-print the difference between actual and expected results.");
             }
@@ -173,19 +170,18 @@ struct AllParamsPF : public ParameterFramework
         checkEq(canonicalizeXML(result), canonicalizeXML(expected));
     }
 
-    static string node(string tag, string name, string content,
-                       string attributes = "", string postAttributes = "")
+    static string node(string tag, string name, string content, string attributes = "",
+                       string postAttributes = "")
     {
         return "<" + tag + " " + attributes + " Name='" + name + "' " + postAttributes + ">" +
-                content +
-               "</" + tag +">";
+               content + "</" + tag + ">";
     }
     /** Node with a description.
      * @param[in] maybeDescription If nullptr, description will be generated from the name
      *                             Otherwise, the description.
      */
     static string nodeDesc(string tag, string name, string content, string attributes = "",
-                           const char *maybeDescription=nullptr)
+                           const char *maybeDescription = nullptr)
     {
         string description = "description_" + name;
         if (maybeDescription != nullptr) {
@@ -197,65 +193,57 @@ struct AllParamsPF : public ParameterFramework
     static string rootNode(string name, string attributes, string content)
     {
         return '<' + name + " xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
-                            " xsi:noNamespaceSchemaLocation='" + name + ".xsd'" +
-                             ' ' + attributes + '>' +
-                content + "</" + name + '>';
+                            " xsi:noNamespaceSchemaLocation='" +
+               name + ".xsd'" + ' ' + attributes + '>' + content + "</" + name + '>';
     }
 };
 
-SCENARIO_METHOD(AllParamsPF, "Export boolean", "[handler][structure][xml]")
-{
+SCENARIO_METHOD (AllParamsPF, "Export boolean", "[handler][structure][xml]") {
     string expected = rootNode("BooleanParameter", "Name='bool' Description='bool'", "");
     checkStructure("/test/test/bool", expected);
 }
 
-SCENARIO_METHOD(AllParamsPF, "Export component", "[handler][structure][xml]")
-{
+SCENARIO_METHOD (AllParamsPF, "Export component", "[handler][structure][xml]") {
     string expected = rootNode("ParameterBlock", "Name='component_scalar' "
                                                  "Description='description_component_scalar'",
                                getBasicParams());
     checkStructure("/test/test/component_scalar", expected);
 }
 
-SCENARIO_METHOD(AllParamsPF, "Export component array", "[handler][structure][xml]")
-{
-    string expected = rootNode("ParameterBlock",
-                               "Name='component_array' Description='description_component_array'",
-                               nodeDesc("ParameterBlock", "0", getBasicParams(), "",
-                                        "description_component_array") +
-                               nodeDesc("ParameterBlock", "1", getBasicParams(), "",
-                                        "description_component_array"));
+SCENARIO_METHOD (AllParamsPF, "Export component array", "[handler][structure][xml]") {
+    string expected = rootNode(
+        "ParameterBlock", "Name='component_array' Description='description_component_array'",
+        nodeDesc("ParameterBlock", "0", getBasicParams(), "", "description_component_array") +
+            nodeDesc("ParameterBlock", "1", getBasicParams(), "", "description_component_array"));
     checkStructure("/test/test/component_array", expected);
 }
 
-SCENARIO_METHOD(AllParamsPF, "Export all parameters", "[handler][structure][xml]")
-{
+SCENARIO_METHOD (AllParamsPF, "Export all parameters", "[handler][structure][xml]") {
     string paramExpected = getBasicParams() +
                            nodeDesc("ParameterBlock", "parameter_block", getBasicParams()) +
                            nodeDesc("ParameterBlock", "parameter_block_array",
-                                   nodeDesc("ParameterBlock", "0", getBasicParams(), "",
-                                        // description is inherited from array
-                                        "description_parameter_block_array") +
-                                   nodeDesc("ParameterBlock", "1", getBasicParams(), "",
-                                        "description_parameter_block_array")) +
+                                    nodeDesc("ParameterBlock", "0", getBasicParams(), "",
+                                             // description is inherited from array
+                                             "description_parameter_block_array") +
+                                        nodeDesc("ParameterBlock", "1", getBasicParams(), "",
+                                                 "description_parameter_block_array")) +
                            // Components should be exported as parameterBlock
                            nodeDesc("ParameterBlock", "component_scalar", getBasicParams()) +
                            nodeDesc("ParameterBlock", "component_array",
-                                   nodeDesc("ParameterBlock", "0", getBasicParams(), "",
-                                        // description is inherited from array
-                                        "description_component_array") +
-                                   nodeDesc("ParameterBlock", "1", getBasicParams(), "",
-                                        "description_component_array"));
+                                    nodeDesc("ParameterBlock", "0", getBasicParams(), "",
+                                             // description is inherited from array
+                                             "description_component_array") +
+                                        nodeDesc("ParameterBlock", "1", getBasicParams(), "",
+                                                 "description_component_array"));
 
-    WHEN("Exporting subsystem") {
+    WHEN ("Exporting subsystem") {
         string expected = rootNode("Subsystem", "Name='test'", paramExpected);
         checkStructure("/test/test", expected);
     }
 
-
-    WHEN("Exporting systemClass") {
+    WHEN ("Exporting systemClass") {
         string expected = rootNode("SystemClass", "Name='test'",
-                                       "<Subsystem Name='test'>" + paramExpected + "</Subsystem>");
+                                   "<Subsystem Name='test'>" + paramExpected + "</Subsystem>");
 
         // Awkwardly, the root and its first child are the same element
         checkStructure("/test", expected);
@@ -265,27 +253,27 @@ SCENARIO_METHOD(AllParamsPF, "Export all parameters", "[handler][structure][xml]
 
 struct SettingsTestPF : public AllParamsPF
 {
-    static string parameterBlockNode(string name, string settings) {
+    static string parameterBlockNode(string name, string settings)
+    {
         return node("ParameterBlock", name, settings);
     };
-    static string mkBasicSettings(string settings, string name) {
+    static string mkBasicSettings(string settings, string name)
+    {
         return rootNode("ParameterBlock", "Name='" + name + "'", settings);
     }
 
     static string fullXMLSettings(const string &basicSettings)
     {
         string settings = basicSettings;
-        settings += parameterBlockNode("parameter_block", settings) +
-                    parameterBlockNode("parameter_block_array",
-                        parameterBlockNode("0", settings) +
-                        parameterBlockNode("1", settings)) +
-                    parameterBlockNode("component_scalar", settings) +
-                    parameterBlockNode("component_array",
-                        parameterBlockNode("0", settings) +
-                        parameterBlockNode("1", settings));
+        settings +=
+            parameterBlockNode("parameter_block", settings) +
+            parameterBlockNode("parameter_block_array", parameterBlockNode("0", settings) +
+                                                            parameterBlockNode("1", settings)) +
+            parameterBlockNode("component_scalar", settings) +
+            parameterBlockNode("component_array", parameterBlockNode("0", settings) +
+                                                      parameterBlockNode("1", settings));
 
-        return rootNode("SystemClass", "Name='test'" ,
-                        node("Subsystem", "test", settings, ""));
+        return rootNode("SystemClass", "Name='test'", node("Subsystem", "test", settings, ""));
     }
 
     static string fullBytesSettings(const string &basicSettings)
@@ -300,7 +288,8 @@ struct SettingsTestPF : public AllParamsPF
     }
 
     /** Print Bytes as string separated hexadecimal number. */
-    static string showBytes(const Bytes &bytes) {
+    static string showBytes(const Bytes &bytes)
+    {
         using namespace std;
         ostringstream ss;
         ss.exceptions(ostream::badbit | ostream::failbit);
@@ -310,11 +299,12 @@ struct SettingsTestPF : public AllParamsPF
         return ss.str();
     }
 
-    static Bytes readBytes(const string &strBytes) {
+    static Bytes readBytes(const string &strBytes)
+    {
         using namespace std;
         istringstream ss{strBytes};
         ss.exceptions(istream::badbit | istream::failbit);
-        Bytes bytes(strBytes.size()/3);
+        Bytes bytes(strBytes.size() / 3);
 
         for (auto &byte : bytes) {
             uint16_t notCharByte;
@@ -324,12 +314,14 @@ struct SettingsTestPF : public AllParamsPF
         return bytes;
     }
 
-     static void checkBytesEq(const Bytes &result, const string &expect) {
-         checkEq(showBytes(result), expect);
-     }
-     static void checkBytesEq(const Bytes &result, const Bytes &expect) {
-         checkEq(showBytes(result), showBytes(expect));
-     }
+    static void checkBytesEq(const Bytes &result, const string &expect)
+    {
+        checkEq(showBytes(result), expect);
+    }
+    static void checkBytesEq(const Bytes &result, const Bytes &expect)
+    {
+        checkEq(showBytes(result), showBytes(expect));
+    }
 };
 
 static const char *defaultBasicSettingsXML = R"(
@@ -370,135 +362,127 @@ static const char *testBasicSettingsXML = R"(
       </BitParameterBlock>
 )";
 
-
-SCENARIO_METHOD(SettingsTestPF, "Export and import XML settings", "[handler][settings][xml]")
-{
-    WHEN("Exporting root XML") {
+SCENARIO_METHOD (SettingsTestPF, "Export and import XML settings", "[handler][settings][xml]") {
+    WHEN ("Exporting root XML") {
         auto getAsXML = [this](string path) { return ElementHandle(*this, path).getAsXML(); };
         CHECK(getAsXML("/") == getAsXML("/test"));
         checkXMLEq(getAsXML("/"), fullXMLSettings(defaultBasicSettingsXML));
     }
 
     ElementHandle basicParams(*this, "/test/test/parameter_block");
-    WHEN("Exporting basic parameter XML") {
+    WHEN ("Exporting basic parameter XML") {
         checkXMLEq(basicParams.getAsXML(),
                    mkBasicSettings(defaultBasicSettingsXML, "parameter_block"));
     }
-    WHEN("Importing basic parameter XML") {
+    WHEN ("Importing basic parameter XML") {
         string testSettings = mkBasicSettings(testBasicSettingsXML, "parameter_block");
         CHECK_NOTHROW(basicParams.setAsXML(testSettings));
-        THEN("Exported settings should be the ones imported") {
+        THEN ("Exported settings should be the ones imported") {
             checkXMLEq(basicParams.getAsXML(), testSettings);
         }
     }
 }
 
 static const string defaultBasicSettingsBytes =
- "00 00 00 21 00 f6 ff ff ff f6 ff ff ff f6 ff ff ff f6 ff ff ff 00 00 00 00 "
- "00 00 00 00 00 00 00 00 00 00 00 00 80 08 00 08 00 08 00 08 00 00 00 00 00 00 "
- "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
- "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
- "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ";
+    "00 00 00 21 00 f6 ff ff ff f6 ff ff ff f6 ff ff ff f6 ff ff ff 00 00 00 00 "
+    "00 00 00 00 00 00 00 00 00 00 00 00 80 08 00 08 00 08 00 08 00 00 00 00 00 00 "
+    "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+    "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+    "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ";
 
 static const string testBasicSettingsBytes =
-  "01 00 01 64 00 f6 ff ff ff 00 00 00 00 08 00 00 00 0a 00 00 00 00 00 00 24 "
-  "00 00 00 72 00 00 00 0b 00 00 00 f0 05 08 00 01 80 08 00 01 80 41 20 73 74 72 "
-  "69 6e 67 20 6f 66 20 33 32 20 63 68 61 72 61 63 74 65 72 2e 40 40 40 40 40 40 "
-  "40 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
-  "00 00 00 00 00 00 00 8a 02 48 00 ff ff ff ff ";
+    "01 00 01 64 00 f6 ff ff ff 00 00 00 00 08 00 00 00 0a 00 00 00 00 00 00 24 "
+    "00 00 00 72 00 00 00 0b 00 00 00 f0 05 08 00 01 80 08 00 01 80 41 20 73 74 72 "
+    "69 6e 67 20 6f 66 20 33 32 20 63 68 61 72 61 63 74 65 72 2e 40 40 40 40 40 40 "
+    "40 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+    "00 00 00 00 00 00 00 8a 02 48 00 ff ff ff ff ";
 
-SCENARIO_METHOD(SettingsTestPF, "Bijection of binary show and read", "[identity][test]")
-{
+SCENARIO_METHOD (SettingsTestPF, "Bijection of binary show and read", "[identity][test]") {
     CHECK(showBytes(readBytes(testBasicSettingsBytes)) == testBasicSettingsBytes);
 }
 
-SCENARIO_METHOD(SettingsTestPF, "Export and import root binary settings",
-                "[handler][settings][bytes]")
-{
+SCENARIO_METHOD (SettingsTestPF, "Export and import root binary settings",
+                 "[handler][settings][bytes]") {
     ElementHandle root(*this, "/");
     ElementHandle systemClass(*this, "/");
 
-    THEN("Root and system class should export the same binary") {
+    THEN ("Root and system class should export the same binary") {
         checkBytesEq(root.getAsBytes(), systemClass.getAsBytes());
     }
-    WHEN("Exporting root binary") {
+    WHEN ("Exporting root binary") {
         checkBytesEq(root.getAsBytes(), fullBytesSettings(defaultBasicSettingsBytes));
     }
-    WHEN("Importing root binary") {
+    WHEN ("Importing root binary") {
         string rootTestSettings = fullBytesSettings(testBasicSettingsBytes);
         REQUIRE_NOTHROW(root.setAsBytes(readBytes(rootTestSettings)));
-        THEN("Exported settings should be the ones imported") {
+        THEN ("Exported settings should be the ones imported") {
             checkBytesEq(root.getAsBytes(), rootTestSettings);
         }
     }
 }
 
-SCENARIO_METHOD(SettingsTestPF, "Export and import basic binary settings",
-                "[handler][settings][bytes]")
-{
+SCENARIO_METHOD (SettingsTestPF, "Export and import basic binary settings",
+                 "[handler][settings][bytes]") {
     ElementHandle basicParams(*this, "/test/test/parameter_block");
-    WHEN("Exporting basic parameter binary") {
+    WHEN ("Exporting basic parameter binary") {
         checkBytesEq(basicParams.getAsBytes(), defaultBasicSettingsBytes);
     }
-    WHEN("Importing basic parameter binary") {
+    WHEN ("Importing basic parameter binary") {
         REQUIRE_NOTHROW(basicParams.setAsBytes(readBytes(testBasicSettingsBytes)));
-        THEN("Exported settings should be the ones imported") {
+        THEN ("Exported settings should be the ones imported") {
             checkBytesEq(basicParams.getAsBytes(), testBasicSettingsBytes);
         }
     }
 }
 
-SCENARIO_METHOD(SettingsTestPF, "Export and import array binary settings",
-                "[handler][settings][bytes]")
-{
+SCENARIO_METHOD (SettingsTestPF, "Export and import array binary settings",
+                 "[handler][settings][bytes]") {
     ElementHandle array(*this, "/test/test/parameter_block_array");
     ElementHandle elem0(*this, "/test/test/parameter_block_array/0");
-    WHEN("Importing one array element") {
+    WHEN ("Importing one array element") {
         REQUIRE_NOTHROW(elem0.setAsBytes(readBytes(testBasicSettingsBytes)));
-        THEN("The other element should not have changed") {
+        THEN ("The other element should not have changed") {
             checkBytesEq(array.getAsBytes(), testBasicSettingsBytes + defaultBasicSettingsBytes);
         }
     }
 }
 
-SCENARIO_METHOD(SettingsTestPF, "Import root in one format, export in an other",
-                "[handler][settings][bytes][xml]")
-{
+SCENARIO_METHOD (SettingsTestPF, "Import root in one format, export in an other",
+                 "[handler][settings][bytes][xml]") {
     ElementHandle root(*this, "/test");
     string rootBytesSettings = fullBytesSettings(testBasicSettingsBytes);
     string rootXMLSettings = fullXMLSettings(testBasicSettingsXML);
 
-    WHEN("Importing root binary") {
+    WHEN ("Importing root binary") {
         REQUIRE_NOTHROW(root.setAsBytes(readBytes(rootBytesSettings)));
-        THEN("Exported XML settings should be the ones imported") {
+        THEN ("Exported XML settings should be the ones imported") {
             checkXMLEq(root.getAsXML(), rootXMLSettings);
         }
     }
 
-    WHEN("Importing root XML") {
+    WHEN ("Importing root XML") {
         REQUIRE_NOTHROW(root.setAsXML(rootXMLSettings));
-        THEN("Exported bytes settings should be the ones imported") {
+        THEN ("Exported bytes settings should be the ones imported") {
             checkBytesEq(root.getAsBytes(), rootBytesSettings);
         }
     }
 }
 
-SCENARIO_METHOD(SettingsTestPF, "Import basic params in one format, export in an other",
-                "[handler][settings][bytes][xml]")
-{
+SCENARIO_METHOD (SettingsTestPF, "Import basic params in one format, export in an other",
+                 "[handler][settings][bytes][xml]") {
     ElementHandle basicParams(*this, "/test/test/parameter_block_array/0");
     string basicXMLSettings = mkBasicSettings(testBasicSettingsXML, "0");
 
-    WHEN("Importing basic parameters binary") {
+    WHEN ("Importing basic parameters binary") {
         REQUIRE_NOTHROW(basicParams.setAsBytes(readBytes(testBasicSettingsBytes)));
-        THEN("Exported XML settings should be the ones imported") {
+        THEN ("Exported XML settings should be the ones imported") {
             checkXMLEq(basicParams.getAsXML(), basicXMLSettings);
         }
     }
 
-    WHEN("Importing basic parameters XML") {
+    WHEN ("Importing basic parameters XML") {
         REQUIRE_NOTHROW(basicParams.setAsXML(basicXMLSettings));
-        THEN("Exported bytes settings should be the ones imported") {
+        THEN ("Exported bytes settings should be the ones imported") {
             checkBytesEq(basicParams.getAsBytes(), testBasicSettingsBytes);
         }
     }

--- a/test/functional-tests/Handle.cpp
+++ b/test/functional-tests/Handle.cpp
@@ -198,19 +198,22 @@ struct AllParamsPF : public ParameterFramework
     }
 };
 
-SCENARIO_METHOD (AllParamsPF, "Export boolean", "[handler][structure][xml]") {
+SCENARIO_METHOD(AllParamsPF, "Export boolean", "[handler][structure][xml]")
+{
     string expected = rootNode("BooleanParameter", "Name='bool' Description='bool'", "");
     checkStructure("/test/test/bool", expected);
 }
 
-SCENARIO_METHOD (AllParamsPF, "Export component", "[handler][structure][xml]") {
+SCENARIO_METHOD(AllParamsPF, "Export component", "[handler][structure][xml]")
+{
     string expected = rootNode("ParameterBlock", "Name='component_scalar' "
                                                  "Description='description_component_scalar'",
                                getBasicParams());
     checkStructure("/test/test/component_scalar", expected);
 }
 
-SCENARIO_METHOD (AllParamsPF, "Export component array", "[handler][structure][xml]") {
+SCENARIO_METHOD(AllParamsPF, "Export component array", "[handler][structure][xml]")
+{
     string expected = rootNode(
         "ParameterBlock", "Name='component_array' Description='description_component_array'",
         nodeDesc("ParameterBlock", "0", getBasicParams(), "", "description_component_array") +
@@ -218,7 +221,8 @@ SCENARIO_METHOD (AllParamsPF, "Export component array", "[handler][structure][xm
     checkStructure("/test/test/component_array", expected);
 }
 
-SCENARIO_METHOD (AllParamsPF, "Export all parameters", "[handler][structure][xml]") {
+SCENARIO_METHOD(AllParamsPF, "Export all parameters", "[handler][structure][xml]")
+{
     string paramExpected = getBasicParams() +
                            nodeDesc("ParameterBlock", "parameter_block", getBasicParams()) +
                            nodeDesc("ParameterBlock", "parameter_block_array",
@@ -362,7 +366,8 @@ static const char *testBasicSettingsXML = R"(
       </BitParameterBlock>
 )";
 
-SCENARIO_METHOD (SettingsTestPF, "Export and import XML settings", "[handler][settings][xml]") {
+SCENARIO_METHOD(SettingsTestPF, "Export and import XML settings", "[handler][settings][xml]")
+{
     WHEN ("Exporting root XML") {
         auto getAsXML = [this](string path) { return ElementHandle(*this, path).getAsXML(); };
         CHECK(getAsXML("/") == getAsXML("/test"));
@@ -397,12 +402,14 @@ static const string testBasicSettingsBytes =
     "40 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
     "00 00 00 00 00 00 00 8a 02 48 00 ff ff ff ff ";
 
-SCENARIO_METHOD (SettingsTestPF, "Bijection of binary show and read", "[identity][test]") {
+SCENARIO_METHOD(SettingsTestPF, "Bijection of binary show and read", "[identity][test]")
+{
     CHECK(showBytes(readBytes(testBasicSettingsBytes)) == testBasicSettingsBytes);
 }
 
-SCENARIO_METHOD (SettingsTestPF, "Export and import root binary settings",
-                 "[handler][settings][bytes]") {
+SCENARIO_METHOD(SettingsTestPF, "Export and import root binary settings",
+                "[handler][settings][bytes]")
+{
     ElementHandle root(*this, "/");
     ElementHandle systemClass(*this, "/");
 
@@ -421,8 +428,9 @@ SCENARIO_METHOD (SettingsTestPF, "Export and import root binary settings",
     }
 }
 
-SCENARIO_METHOD (SettingsTestPF, "Export and import basic binary settings",
-                 "[handler][settings][bytes]") {
+SCENARIO_METHOD(SettingsTestPF, "Export and import basic binary settings",
+                "[handler][settings][bytes]")
+{
     ElementHandle basicParams(*this, "/test/test/parameter_block");
     WHEN ("Exporting basic parameter binary") {
         checkBytesEq(basicParams.getAsBytes(), defaultBasicSettingsBytes);
@@ -435,8 +443,9 @@ SCENARIO_METHOD (SettingsTestPF, "Export and import basic binary settings",
     }
 }
 
-SCENARIO_METHOD (SettingsTestPF, "Export and import array binary settings",
-                 "[handler][settings][bytes]") {
+SCENARIO_METHOD(SettingsTestPF, "Export and import array binary settings",
+                "[handler][settings][bytes]")
+{
     ElementHandle array(*this, "/test/test/parameter_block_array");
     ElementHandle elem0(*this, "/test/test/parameter_block_array/0");
     WHEN ("Importing one array element") {
@@ -447,8 +456,9 @@ SCENARIO_METHOD (SettingsTestPF, "Export and import array binary settings",
     }
 }
 
-SCENARIO_METHOD (SettingsTestPF, "Import root in one format, export in an other",
-                 "[handler][settings][bytes][xml]") {
+SCENARIO_METHOD(SettingsTestPF, "Import root in one format, export in an other",
+                "[handler][settings][bytes][xml]")
+{
     ElementHandle root(*this, "/test");
     string rootBytesSettings = fullBytesSettings(testBasicSettingsBytes);
     string rootXMLSettings = fullXMLSettings(testBasicSettingsXML);
@@ -468,8 +478,9 @@ SCENARIO_METHOD (SettingsTestPF, "Import root in one format, export in an other"
     }
 }
 
-SCENARIO_METHOD (SettingsTestPF, "Import basic params in one format, export in an other",
-                 "[handler][settings][bytes][xml]") {
+SCENARIO_METHOD(SettingsTestPF, "Import basic params in one format, export in an other",
+                "[handler][settings][bytes][xml]")
+{
     ElementHandle basicParams(*this, "/test/test/parameter_block_array/0");
     string basicXMLSettings = mkBasicSettings(testBasicSettingsXML, "0");
 

--- a/test/functional-tests/include/Config.hpp
+++ b/test/functional-tests/include/Config.hpp
@@ -37,14 +37,18 @@ namespace parameterFramework
 {
 
 /** Parameter Framework configuration. */
-struct Config {
+struct Config
+{
     Config() = default;
 
     /** Emulate C named parameter.
      * { .instances = "fuu" } <=> { &Config::instances, "fuu" }
      * Passing multiple named parameters is not implemented. */
     template <class M, class T = M>
-    Config(M (Config::*member), T &&value) { (this->*member) = std::forward<T>(value); }
+    Config(M(Config::*member), T &&value)
+    {
+        (this->*member) = std::forward<T>(value);
+    }
 
     /** Instances of the test subsystem.
      *

--- a/test/functional-tests/include/ConfigFiles.hpp
+++ b/test/functional-tests/include/ConfigFiles.hpp
@@ -42,17 +42,16 @@ namespace parameterFramework
 class ConfigFiles
 {
 public:
-    ConfigFiles(const Config &config) :
-        mStructureFile(format(mStructureTemplate,
-                                { { "type", config.subsystemType },
-                                  { "instances", config.instances },
-                                  { "components", config.components } })),
-        mDomainsFile(format(mDomainsTemplate, { { "domains", config.domains } })),
-        mConfigFile(format(mConfigTemplate,
-                           { { "structurePath", mStructureFile.getPath() },
-                             { "domainsPath", mDomainsFile.getPath() },
-                             { "plugins", toXml(config.plugins) } }))
-    {}
+    ConfigFiles(const Config &config)
+        : mStructureFile(format(mStructureTemplate, {{"type", config.subsystemType},
+                                                     {"instances", config.instances},
+                                                     {"components", config.components}})),
+          mDomainsFile(format(mDomainsTemplate, {{"domains", config.domains}})),
+          mConfigFile(format(mConfigTemplate, {{"structurePath", mStructureFile.getPath()},
+                                               {"domainsPath", mDomainsFile.getPath()},
+                                               {"plugins", toXml(config.plugins)}}))
+    {
+    }
 
     std::string getPath() { return mConfigFile.getPath(); }
 
@@ -67,8 +66,8 @@ private:
             for (auto &path : paths) {
                 pluginsLocationXml += "<Plugin Name='" + path + "'/>\n";
             }
-            pluginsXml += "<Location Folder='" + location + "'>\n" +
-                          pluginsLocationXml + "\n</Location>\n";
+            pluginsXml +=
+                "<Location Folder='" + location + "'>\n" + pluginsLocationXml + "\n</Location>\n";
         }
         return pluginsXml;
     }
@@ -81,13 +80,13 @@ private:
         return format;
     }
 
-    void replace(std::string& on, const std::string& from, const std::string& to) {
+    void replace(std::string &on, const std::string &from, const std::string &to)
+    {
         auto from_pos = on.find(from);
         if (from_pos != std::string::npos) {
             on.replace(from_pos, from.length(), to);
         }
     }
-
 
     const char *mConfigTemplate = R"(<?xml version='1.0' encoding='UTF-8'?>
         <ParameterFrameworkConfiguration SystemClassName='test' TuningAllowed='true'>

--- a/test/functional-tests/include/ElementHandle.hpp
+++ b/test/functional-tests/include/ElementHandle.hpp
@@ -45,13 +45,16 @@ namespace parameterFramework
 class ElementHandle : private FailureWrapper<::ElementHandle>
 {
     ElementHandle(const ElementHandle &other) = delete;
-    ElementHandle& operator=(const ElementHandle& other) = delete;
+    ElementHandle &operator=(const ElementHandle &other) = delete;
+
 private:
     using EH = ::ElementHandle;
 
 public:
-    ElementHandle(ParameterFramework &pf, const std::string& path) :
-        FailureWrapper(pf.createElementHandle(path)) {}
+    ElementHandle(ParameterFramework &pf, const std::string &path)
+        : FailureWrapper(pf.createElementHandle(path))
+    {
+    }
 
     /** Wrap EH::getSize.
      *
@@ -64,25 +67,18 @@ public:
     /** Wrap EH::getAsDouble to throw an exception on failure. */
     void getAsDouble(double &value) const { mayFailCall(&EH::getAsDouble, value); }
 
-    std::string getStructureAsXML() const {
-        return mayFailGet(&EH::getStructureAsXML);
-    }
+    std::string getStructureAsXML() const { return mayFailGet(&EH::getStructureAsXML); }
 
-    std::string getAsXML() const {
-        return mayFailGet(&EH::getAsXML);
-    }
-    void setAsXML(const std::string &settings) {
-        mayFailSet(&EH::setAsXML, settings);
-    }
+    std::string getAsXML() const { return mayFailGet(&EH::getAsXML); }
+    void setAsXML(const std::string &settings) { mayFailSet(&EH::setAsXML, settings); }
 
-    std::vector<uint8_t> getAsBytes() const {
+    std::vector<uint8_t> getAsBytes() const
+    {
         std::vector<uint8_t> settings(getSize());
         mayFailCall(&EH::getAsBytes, settings);
         return settings;
     }
-    void setAsBytes(const std::vector<uint8_t> &settings) {
-        mayFailSet(&EH::setAsBytes, settings);
-    }
+    void setAsBytes(const std::vector<uint8_t> &settings) { mayFailSet(&EH::setAsBytes, settings); }
 };
 
 } // parameterFramework

--- a/test/functional-tests/include/FailureWrapper.hpp
+++ b/test/functional-tests/include/FailureWrapper.hpp
@@ -38,10 +38,16 @@ namespace parameterFramework
 namespace detail
 {
 
-static inline bool successTest(bool res) { return res; }
+static inline bool successTest(bool res)
+{
+    return res;
+}
 
 template <class T>
-static inline bool successTest(T *res) { return res != nullptr; }
+static inline bool successTest(T *res)
+{
+    return res != nullptr;
+}
 
 } // namespace detail
 
@@ -54,7 +60,9 @@ public:
      * using Base::Base would be equivalent, but is not supported by VS 2013.
      */
     template <class... Args>
-    FailureWrapper(Args &&... args) : Base(std::forward<Args>(args)...) {}
+    FailureWrapper(Args &&... args) : Base(std::forward<Args>(args)...)
+    {
+    }
 
     /** Wrap a const method that may fail to throw an Exception instead of
      * retuning a boolean.
@@ -62,7 +70,8 @@ public:
      * @param[in] method (const) that return a boolean to indicate failure.
      * @param[in] args parameters to call method call with. */
     template <class K, class... MArgs, class... Args>
-    void mayFailCall(bool (K::*method)(MArgs...) const, Args&&... args) const {
+    void mayFailCall(bool (K::*method)(MArgs...) const, Args &&... args) const
+    {
         wrapCall<bool>(*this, method, std::forward<Args>(args)...);
     }
 
@@ -72,7 +81,8 @@ public:
      * @param[in] method that return a boolean to indicate failure.
      * @param[in] args parameters to call method call with. */
     template <class K, class... MArgs, class... Args>
-    void mayFailCall(bool (K::*method)(MArgs...), Args&&... args) {
+    void mayFailCall(bool (K::*method)(MArgs...), Args &&... args)
+    {
         wrapCall<bool>(*this, method, std::forward<Args>(args)...);
     }
 
@@ -82,7 +92,8 @@ public:
      * @param[in] method that return a nullprt to indicate failure.
      * @param[in] args parameters to call method call with. */
     template <class K, class ReturnType, class... MArgs, class... Args>
-    ReturnType *mayFailCall(ReturnType *(K::*method)(MArgs...), Args&&... args) {
+    ReturnType *mayFailCall(ReturnType *(K::*method)(MArgs...), Args &&... args)
+    {
         return wrapCall<ReturnType *>(*this, method, std::forward<Args>(args)...);
     }
 
@@ -92,7 +103,8 @@ public:
      * @param[in] method that return a nullprt to indicate failure.
      * @param[in] args parameters to call method call with. */
     template <class K, class ReturnType, class... MArgs, class... Args>
-    ReturnType *mayFailCall(ReturnType *(K::*method)(MArgs...) const, Args&&... args) const {
+    ReturnType *mayFailCall(ReturnType *(K::*method)(MArgs...) const, Args &&... args) const
+    {
         return wrapCall<ReturnType *>(*this, method, std::forward<Args>(args)...);
     }
 
@@ -114,7 +126,7 @@ public:
 
 private:
     template <class Ret, class I, class M, class... Args>
-    static Ret wrapCall(I &instance, M method, Args&&... args)
+    static Ret wrapCall(I &instance, M method, Args &&... args)
     {
         std::string error;
         auto res = (instance.*method)(std::forward<Args>(args)..., error);

--- a/test/functional-tests/include/ParameterFramework.hpp
+++ b/test/functional-tests/include/ParameterFramework.hpp
@@ -62,16 +62,13 @@ protected:
     using EH = ::ElementHandle;
 
 public:
-    ParameterFramework(const Config &config = Config()) :
-        ConfigFiles(config),
-        FailureWrapper(getPath())
+    ParameterFramework(const Config &config = Config())
+        : ConfigFiles(config), FailureWrapper(getPath())
     {
         setForceNoRemoteInterface(true);
     }
 
-    void start() {
-        mayFailCall(&PF::start);
-    }
+    void start() { mayFailCall(&PF::start); }
 
     /** @name Forwarded methods
      * Forward those methods without modification as there are ergonomic and
@@ -94,17 +91,20 @@ public:
     /** @} */
 
     /** Wrap PF::setValidateSchemasOnStart to throw an exception on failure. */
-    void setValidateSchemasOnStart(bool validate) {
+    void setValidateSchemasOnStart(bool validate)
+    {
         mayFailCall(&PPF::setValidateSchemasOnStart, validate);
     }
 
     /** Wrap PF::setFailureOnFailedSettingsLoad to throw an exception on failure. */
-    void setFailureOnFailedSettingsLoad(bool fail) {
+    void setFailureOnFailedSettingsLoad(bool fail)
+    {
         mayFailCall(&PPF::setFailureOnFailedSettingsLoad, fail);
     }
 
     /** Wrap PF::setFailureOnMissingSubsystem to throw an exception on failure. */
-    void setFailureOnMissingSubsystem(bool fail) {
+    void setFailureOnMissingSubsystem(bool fail)
+    {
         mayFailCall(&PPF::setFailureOnMissingSubsystem, fail);
     }
 
@@ -121,14 +121,14 @@ public:
     /** Wrap PF::accessParameterValue in "set" mode (and rename it) to throw an
      * exception on failure
      */
-    void setParameter(const std::string& path, std::string& value)
+    void setParameter(const std::string &path, std::string &value)
     {
         mayFailCall(&PF::accessParameterValue, path, value, true);
     }
     /** Wrap PF::accessParameterValue in "get" mode (and rename it) to throw an
      * exception on failure
      */
-    void getParameter(const std::string& path, std::string& value)
+    void getParameter(const std::string &path, std::string &value)
     {
         mayFailCall(&PF::accessParameterValue, path, value, false);
     }
@@ -136,8 +136,8 @@ public:
     /** Wrap PF::accessConfigurationValue in "set" mode (and rename it) to throw an
      * exception on failure
      */
-    void setConfigurationParameter(const std::string domain,
-        const std::string &configuration, const std::string& path, std::string& value)
+    void setConfigurationParameter(const std::string domain, const std::string &configuration,
+                                   const std::string &path, std::string &value)
     {
         mayFailCall(&PF::accessConfigurationValue, domain, configuration, path, value, true);
     }
@@ -145,19 +145,18 @@ public:
     /** Wrap PF::accessConfigurationValue in "get" mode (and rename it) to throw an
      * exception on failure
      */
-    void getConfigurationParameter(const std::string &domain,
-        const std::string &configuration, const std::string& path, std::string& value)
+    void getConfigurationParameter(const std::string &domain, const std::string &configuration,
+                                   const std::string &path, std::string &value)
     {
-        mayFailCall(&PF::accessConfigurationValue, domain, configuration, path, value,
-            false);
+        mayFailCall(&PF::accessConfigurationValue, domain, configuration, path, value, false);
     }
-private:
 
+private:
     /** Create an unwrapped element handle.
      *
      * Is not public as this method is intended to be used by ElementHandle facade.
      */
-    EH createElementHandle(const std::string& path)
+    EH createElementHandle(const std::string &path)
     {
         // PF::createElementHandle takes it's handler in the free store
         std::unique_ptr<EH> newedHandle{mayFailCall(&PF::createElementHandle, path)};

--- a/test/functional-tests/include/StoreLogger.hpp
+++ b/test/functional-tests/include/StoreLogger.hpp
@@ -55,30 +55,30 @@ public:
         };
         Level level;
         std::string msg;
-        bool operator == (const Log &other) const {
+        bool operator==(const Log &other) const
+        {
             return level == other.level and msg == other.msg;
         }
     };
     using Logs = std::vector<Log>;
 
-    void warning(const std::string& strLog) override
+    void warning(const std::string &strLog) override
     {
-        logs.push_back({ Log::Level::warning, strLog });
+        logs.push_back({Log::Level::warning, strLog});
     }
-    void info(const std::string& strLog) override
-    {
-        logs.push_back({ Log::Level::info, strLog });
-    }
+    void info(const std::string &strLog) override { logs.push_back({Log::Level::info, strLog}); }
 
     const Logs &getLogs() const { return logs; }
 
-    const Logs filter(Log::Level level) const {
+    const Logs filter(Log::Level level) const
+    {
         return filter([&level](const Log &log) { return log.level == level; });
     };
 
-    Logs match(const std::string& pattern) const {
-        return filter([&pattern](const Log &log) {
-                return log.msg.find(pattern) == std::string::npos; });
+    Logs match(const std::string &pattern) const
+    {
+        return filter(
+            [&pattern](const Log &log) { return log.msg.find(pattern) == std::string::npos; });
     }
 
 private:
@@ -94,10 +94,11 @@ private:
 };
 
 /** Overload input stream operator to pretty print a StoreLogger::Log::Level. */
-std::ostream& operator<<(std::ostream& os, const StoreLogger::Log::Level& level) {
+std::ostream &operator<<(std::ostream &os, const StoreLogger::Log::Level &level)
+{
     auto levelStr = "UNREACHABLE";
     using L = StoreLogger::Log::Level;
-    switch(level) {
+    switch (level) {
     case L::info:
         levelStr = "Info";
         break;
@@ -109,7 +110,8 @@ std::ostream& operator<<(std::ostream& os, const StoreLogger::Log::Level& level)
 }
 
 /** Overload input stream operator to pretty print a StoreLogger::Log. */
-std::ostream& operator<< ( std::ostream& os, const StoreLogger::Log& log) {
+std::ostream &operator<<(std::ostream &os, const StoreLogger::Log &log)
+{
     return os << log.level << log.msg << std::endl;
 }
 

--- a/test/functional-tests/include/Test.hpp
+++ b/test/functional-tests/include/Test.hpp
@@ -38,9 +38,8 @@
 #include <string>
 
 #ifndef SCENARIO_METHOD
-    /** SCENARIO_METHOD is not available in catch on ubuntu 12.04 */
-#   define SCENARIO_METHOD(className, ...) \
-        TEST_CASE_METHOD(className, "Scenario: " __VA_ARGS__)
+/** SCENARIO_METHOD is not available in catch on ubuntu 12.04 */
+#define SCENARIO_METHOD(className, ...) TEST_CASE_METHOD (className, "Scenario: " __VA_ARGS__)
 #endif
 
 namespace parameterFramework
@@ -117,21 +116,16 @@ class LazyPF
 public:
     using PF = ParameterFramework;
 
-    void create(Config &&configFile)
-    {
-        mPf.reset(new PF{ std::move(configFile) });
-    }
+    void create(Config &&configFile) { mPf.reset(new PF{std::move(configFile)}); }
     std::unique_ptr<PF> mPf;
 };
 
 /** PF that will log a warning at start. */
 struct WarningPF : public ParameterFramework
 {
-    WarningPF() :
-        ParameterFramework{ { &Config::domains, "<InvalidDomain/>" } }
+    WarningPF() : ParameterFramework{{&Config::domains, "<InvalidDomain/>"}}
     {
         setFailureOnFailedSettingsLoad(false);
     }
 };
-
 }

--- a/test/functional-tests/include/Test.hpp
+++ b/test/functional-tests/include/Test.hpp
@@ -39,7 +39,7 @@
 
 #ifndef SCENARIO_METHOD
 /** SCENARIO_METHOD is not available in catch on ubuntu 12.04 */
-#define SCENARIO_METHOD(className, ...) TEST_CASE_METHOD (className, "Scenario: " __VA_ARGS__)
+#define SCENARIO_METHOD(className, ...) TEST_CASE_METHOD(className, "Scenario: " __VA_ARGS__)
 #endif
 
 namespace parameterFramework

--- a/test/introspection-subsystem/IntrospectionEntryPoint.cpp
+++ b/test/introspection-subsystem/IntrospectionEntryPoint.cpp
@@ -40,6 +40,5 @@ bool getParameterValue()
 {
     return SubsystemObject::getSingletonInstanceValue();
 }
-
 }
 }

--- a/test/introspection-subsystem/IntrospectionSubsystem.cpp
+++ b/test/introspection-subsystem/IntrospectionSubsystem.cpp
@@ -37,11 +37,9 @@ namespace parameterFramework
 namespace introspectionSubsystem
 {
 
-Subsystem::Subsystem(const std::string& name, core::log::Logger& logger)
-    : base(name, logger)
+Subsystem::Subsystem(const std::string &name, core::log::Logger &logger) : base(name, logger)
 {
     addSubsystemObjectFactory(new TSubsystemObjectFactory<SubsystemObject>("Object", 0));
 }
-
 }
 }

--- a/test/introspection-subsystem/IntrospectionSubsystem.h
+++ b/test/introspection-subsystem/IntrospectionSubsystem.h
@@ -41,11 +41,10 @@ namespace introspectionSubsystem
 class Subsystem : public CSubsystem
 {
 public:
-   Subsystem(const std::string& name, core::log::Logger& logger);
+    Subsystem(const std::string &name, core::log::Logger &logger);
 
 private:
     using base = CSubsystem;
 };
-
 }
 }

--- a/test/introspection-subsystem/IntrospectionSubsystemBuilder.cpp
+++ b/test/introspection-subsystem/IntrospectionSubsystemBuilder.cpp
@@ -31,12 +31,10 @@
 #include <LoggingElementBuilderTemplate.h>
 #include "IntrospectionSubsystem.h"
 
-
-void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary* subsystemLibrary,
-    core::log::Logger& logger)
+void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary *subsystemLibrary,
+                                              core::log::Logger &logger)
 {
     using Subsystem = parameterFramework::introspectionSubsystem::Subsystem;
     subsystemLibrary->addElementBuilder("INTROSPECTION",
-                                         new TLoggingElementBuilderTemplate<Subsystem>(
-                                             logger));
+                                        new TLoggingElementBuilderTemplate<Subsystem>(logger));
 }

--- a/test/introspection-subsystem/IntrospectionSubsystemObject.cpp
+++ b/test/introspection-subsystem/IntrospectionSubsystemObject.cpp
@@ -45,20 +45,18 @@ const CParameterType *geParameterType(CInstanceConfigurableElement *element)
     return static_cast<const CParameterType *>(element->getTypeElement());
 }
 
-SubsystemObject::SubsystemObject(const std::string& /*mappingValue*/,
-                                 CInstanceConfigurableElement* instanceConfigurableElement,
-                                 const CMappingContext& /*context*/,
-                                 core::log::Logger& logger) :
-    base(instanceConfigurableElement, logger),
-    mParameter(false)
+SubsystemObject::SubsystemObject(const std::string & /*mappingValue*/,
+                                 CInstanceConfigurableElement *instanceConfigurableElement,
+                                 const CMappingContext & /*context*/, core::log::Logger &logger)
+    : base(instanceConfigurableElement, logger), mParameter(false)
 {
     /* Checking that structure matches the internal parameter */
     ALWAYS_ASSERT(geParameterType(instanceConfigurableElement)->getSize() == parameterSize,
-        "Wrong parameter size");
+                  "Wrong parameter size");
     ALWAYS_ASSERT((instanceConfigurableElement->getFootPrint() / parameterSize) == 1,
-        "Parameter shall not be an array");
+                  "Parameter shall not be an array");
     ALWAYS_ASSERT(geParameterType(instanceConfigurableElement)->isScalar(),
-        "Parameter shall be scalar");
+                  "Parameter shall be scalar");
 
     /* Registering the instance into a singleton */
     registerInstance(*this);
@@ -70,18 +68,16 @@ SubsystemObject::~SubsystemObject()
     unregisterInstance(*this);
 }
 
-bool SubsystemObject::sendToHW(std::string& /*error*/)
+bool SubsystemObject::sendToHW(std::string & /*error*/)
 {
     blackboardRead(&mParameter, parameterSize);
     return true;
 }
 
-
-bool SubsystemObject::receiveFromHW(std::string& /*error*/)
+bool SubsystemObject::receiveFromHW(std::string & /*error*/)
 {
     blackboardRead(&mParameter, parameterSize);
     return true;
 }
-
 }
 }

--- a/test/introspection-subsystem/IntrospectionSubsystemObject.h
+++ b/test/introspection-subsystem/IntrospectionSubsystemObject.h
@@ -47,10 +47,9 @@ namespace introspectionSubsystem
 class SubsystemObject final : public CSubsystemObject
 {
 public:
-    SubsystemObject(const std::string& mappingValue,
-                         CInstanceConfigurableElement* instanceConfigurableElement,
-                         const CMappingContext& context,
-                         core::log::Logger& logger);
+    SubsystemObject(const std::string &mappingValue,
+                    CInstanceConfigurableElement *instanceConfigurableElement,
+                    const CMappingContext &context, core::log::Logger &logger);
     ~SubsystemObject();
 
     static bool getSingletonInstanceValue()
@@ -62,8 +61,8 @@ public:
 private:
     using base = CSubsystemObject;
 
-    virtual bool sendToHW(std::string& error) override;
-    virtual bool receiveFromHW(std::string& error) override;
+    virtual bool sendToHW(std::string &error) override;
+    virtual bool receiveFromHW(std::string &error) override;
 
     static void registerInstance(const SubsystemObject &instance)
     {
@@ -73,7 +72,7 @@ private:
 
     static void unregisterInstance(const SubsystemObject &instance)
     {
-        //instance parameter is only used by assertion, so unused in release mode
+        // instance parameter is only used by assertion, so unused in release mode
         (void)instance;
 
         ALWAYS_ASSERT(mSingletonInstance == &instance, "This instance was not registered.");
@@ -86,6 +85,5 @@ private:
 
     bool mParameter;
 };
-
 }
 }

--- a/test/introspection-subsystem/include/IntrospectionEntryPoint.h
+++ b/test/introspection-subsystem/include/IntrospectionEntryPoint.h
@@ -37,6 +37,5 @@ namespace introspectionSubsystem
 {
 
 INTROSPECTION_SUBSYSTEM_EXPORT bool getParameterValue();
-
 }
 }

--- a/test/test-platform/TestPlatform.cpp
+++ b/test/test-platform/TestPlatform.cpp
@@ -38,10 +38,8 @@
 
 using std::string;
 
-CTestPlatform::CTestPlatform(const string& strClass, uint16_t iPortNumber) :
-    mParameterMgrPlatformConnector(strClass),
-    mLogger(),
-    mRemoteProcessorServer(iPortNumber)
+CTestPlatform::CTestPlatform(const string &strClass, uint16_t iPortNumber)
+    : mParameterMgrPlatformConnector(strClass), mLogger(), mRemoteProcessorServer(iPortNumber)
 {
     mParameterMgrPlatformConnector.setLogger(&mLogger);
 }
@@ -50,15 +48,15 @@ CTestPlatform::~CTestPlatform()
 {
 }
 
-CTestPlatform::CommandReturn CTestPlatform::exit(
-    const IRemoteCommand& /*command*/, string& /*strResult*/)
+CTestPlatform::CommandReturn CTestPlatform::exit(const IRemoteCommand & /*command*/,
+                                                 string & /*strResult*/)
 {
     mRemoteProcessorServer.stop();
 
     return CTestPlatform::CCommandHandler::EDone;
 }
 
-bool CTestPlatform::run(std::string& strError)
+bool CTestPlatform::run(std::string &strError)
 {
     // Start remote processor server
     if (!mRemoteProcessorServer.start(strError)) {
@@ -70,70 +68,61 @@ bool CTestPlatform::run(std::string& strError)
     CCommandHandler commandHandler(this);
 
     // Add command parsers
-    commandHandler.addCommandParser("exit", &CTestPlatform::exit,
-                                       0, "", "Exit TestPlatform");
-    commandHandler.addCommandParser(
-        "createExclusiveSelectionCriterionFromStateList",
-        &CTestPlatform::createExclusiveSelectionCriterionFromStateList,
-        2, "<name> <stateList>",
-        "Create inclusive selection criterion from state name list");
-    commandHandler.addCommandParser(
-        "createInclusiveSelectionCriterionFromStateList",
-        &CTestPlatform::createInclusiveSelectionCriterionFromStateList,
-        2, "<name> <stateList>",
-        "Create exclusive selection criterion from state name list");
+    commandHandler.addCommandParser("exit", &CTestPlatform::exit, 0, "", "Exit TestPlatform");
+    commandHandler.addCommandParser("createExclusiveSelectionCriterionFromStateList",
+                                    &CTestPlatform::createExclusiveSelectionCriterionFromStateList,
+                                    2, "<name> <stateList>",
+                                    "Create inclusive selection criterion from state name list");
+    commandHandler.addCommandParser("createInclusiveSelectionCriterionFromStateList",
+                                    &CTestPlatform::createInclusiveSelectionCriterionFromStateList,
+                                    2, "<name> <stateList>",
+                                    "Create exclusive selection criterion from state name list");
 
-    commandHandler.addCommandParser(
-        "createExclusiveSelectionCriterion",
-        &CTestPlatform::createExclusiveSelectionCriterion,
-        2, "<name> <nbStates>", "Create inclusive selection criterion");
-    commandHandler.addCommandParser(
-        "createInclusiveSelectionCriterion",
-        &CTestPlatform::createInclusiveSelectionCriterion,
-        2, "<name> <nbStates>", "Create exclusive selection criterion");
+    commandHandler.addCommandParser("createExclusiveSelectionCriterion",
+                                    &CTestPlatform::createExclusiveSelectionCriterion, 2,
+                                    "<name> <nbStates>", "Create inclusive selection criterion");
+    commandHandler.addCommandParser("createInclusiveSelectionCriterion",
+                                    &CTestPlatform::createInclusiveSelectionCriterion, 2,
+                                    "<name> <nbStates>", "Create exclusive selection criterion");
 
-    commandHandler.addCommandParser("start", &CTestPlatform::startParameterMgr,
-                                       0, "", "Start ParameterMgr");
+    commandHandler.addCommandParser("start", &CTestPlatform::startParameterMgr, 0, "",
+                                    "Start ParameterMgr");
 
-    commandHandler.addCommandParser("setCriterionState", &CTestPlatform::setCriterionState,
-                                       2, "<name> <state>",
-                                       "Set the current state of a selection criterion");
+    commandHandler.addCommandParser("setCriterionState", &CTestPlatform::setCriterionState, 2,
+                                    "<name> <state>",
+                                    "Set the current state of a selection criterion");
     commandHandler.addCommandParser(
-        "applyConfigurations",
-        &CTestPlatform::applyConfigurations,
-        0, "", "Apply configurations selected by current selection criteria states");
+        "applyConfigurations", &CTestPlatform::applyConfigurations, 0, "",
+        "Apply configurations selected by current selection criteria states");
 
     commandHandler.addCommandParser(
         "setFailureOnMissingSubsystem",
-        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setFailureOnMissingSubsystem>,
-        1, "true|false", "Set policy for missing subsystems, "
-                         "either abort start or fallback on virtual subsystem.");
+        &CTestPlatform::setter<&CParameterMgrPlatformConnector::setFailureOnMissingSubsystem>, 1,
+        "true|false", "Set policy for missing subsystems, "
+                      "either abort start or fallback on virtual subsystem.");
     commandHandler.addCommandParser(
         "getMissingSubsystemPolicy",
-        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getFailureOnMissingSubsystem>,
-        0, "", "Get policy for missing subsystems, "
-               "either abort start or fallback on virtual subsystem.");
+        &CTestPlatform::getter<&CParameterMgrPlatformConnector::getFailureOnMissingSubsystem>, 0,
+        "", "Get policy for missing subsystems, "
+            "either abort start or fallback on virtual subsystem.");
 
     commandHandler.addCommandParser(
         "setFailureOnFailedSettingsLoad",
-        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setFailureOnFailedSettingsLoad>,
-        1, "true|false",
+        &CTestPlatform::setter<&CParameterMgrPlatformConnector::setFailureOnFailedSettingsLoad>, 1,
+        "true|false",
         "Set policy for failed settings load, either abort start or continue without domains.");
     commandHandler.addCommandParser(
         "getFailedSettingsLoadPolicy",
-        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getFailureOnFailedSettingsLoad>,
-        0, "",
-        "Get policy for failed settings load, either abort start or continue without domains.");
+        &CTestPlatform::getter<&CParameterMgrPlatformConnector::getFailureOnFailedSettingsLoad>, 0,
+        "", "Get policy for failed settings load, either abort start or continue without domains.");
 
     commandHandler.addCommandParser(
         "setValidateSchemasOnStart",
-        &CTestPlatform::setter<& CParameterMgrPlatformConnector::setValidateSchemasOnStart>,
-        1, "true|false",
-        "Set policy for schema validation based on .xsd files (false by default).");
+        &CTestPlatform::setter<&CParameterMgrPlatformConnector::setValidateSchemasOnStart>, 1,
+        "true|false", "Set policy for schema validation based on .xsd files (false by default).");
     commandHandler.addCommandParser(
         "getValidateSchemasOnStart",
-        &CTestPlatform::getter<& CParameterMgrPlatformConnector::getValidateSchemasOnStart>,
-        0, "",
+        &CTestPlatform::getter<&CParameterMgrPlatformConnector::getValidateSchemasOnStart>, 0, "",
         "Get policy for schema validation based on .xsd files.");
 
     return mRemoteProcessorServer.process(commandHandler);
@@ -142,75 +131,79 @@ bool CTestPlatform::run(std::string& strError)
 //////////////// Remote command parsers
 /// Selection Criterion
 CTestPlatform::CommandReturn CTestPlatform::createExclusiveSelectionCriterionFromStateList(
-    const IRemoteCommand& remoteCommand, string& strResult)
+    const IRemoteCommand &remoteCommand, string &strResult)
 {
-    return createExclusiveSelectionCriterionFromStateList(
-        remoteCommand.getArgument(0), remoteCommand, strResult) ?
-           CTestPlatform::CCommandHandler::EDone : CTestPlatform::CCommandHandler::EFailed;
+    return createExclusiveSelectionCriterionFromStateList(remoteCommand.getArgument(0),
+                                                          remoteCommand, strResult)
+               ? CTestPlatform::CCommandHandler::EDone
+               : CTestPlatform::CCommandHandler::EFailed;
 }
 
 CTestPlatform::CommandReturn CTestPlatform::createInclusiveSelectionCriterionFromStateList(
-    const IRemoteCommand& remoteCommand, string& strResult)
+    const IRemoteCommand &remoteCommand, string &strResult)
 {
-    return createInclusiveSelectionCriterionFromStateList(
-        remoteCommand.getArgument(0), remoteCommand, strResult) ?
-           CTestPlatform::CCommandHandler::EDone : CTestPlatform::CCommandHandler::EFailed;
+    return createInclusiveSelectionCriterionFromStateList(remoteCommand.getArgument(0),
+                                                          remoteCommand, strResult)
+               ? CTestPlatform::CCommandHandler::EDone
+               : CTestPlatform::CCommandHandler::EFailed;
 }
 
 CTestPlatform::CommandReturn CTestPlatform::createExclusiveSelectionCriterion(
-    const IRemoteCommand& remoteCommand, string& strResult)
+    const IRemoteCommand &remoteCommand, string &strResult)
 {
-    return createExclusiveSelectionCriterion(
-        remoteCommand.getArgument(0),
-        strtoul(remoteCommand.getArgument(1).c_str(), NULL, 0),
-        strResult) ?
-           CTestPlatform::CCommandHandler::EDone : CTestPlatform::CCommandHandler::EFailed;
+    return createExclusiveSelectionCriterion(remoteCommand.getArgument(0),
+                                             strtoul(remoteCommand.getArgument(1).c_str(), NULL, 0),
+                                             strResult)
+               ? CTestPlatform::CCommandHandler::EDone
+               : CTestPlatform::CCommandHandler::EFailed;
 }
 
 CTestPlatform::CommandReturn CTestPlatform::createInclusiveSelectionCriterion(
-    const IRemoteCommand& remoteCommand, string& strResult)
+    const IRemoteCommand &remoteCommand, string &strResult)
 {
-    return createInclusiveSelectionCriterion(
-        remoteCommand.getArgument(0),
-        strtoul(remoteCommand.getArgument(1).c_str(), NULL, 0),
-        strResult) ?
-           CTestPlatform::CCommandHandler::EDone : CTestPlatform::CCommandHandler::EFailed;
+    return createInclusiveSelectionCriterion(remoteCommand.getArgument(0),
+                                             strtoul(remoteCommand.getArgument(1).c_str(), NULL, 0),
+                                             strResult)
+               ? CTestPlatform::CCommandHandler::EDone
+               : CTestPlatform::CCommandHandler::EFailed;
 }
 
 CTestPlatform::CommandReturn CTestPlatform::startParameterMgr(
-    const IRemoteCommand& /*remoteCommand*/, string& strResult)
+    const IRemoteCommand & /*remoteCommand*/, string &strResult)
 {
-    return mParameterMgrPlatformConnector.start(strResult) ?
-           CTestPlatform::CCommandHandler::EDone : CTestPlatform::CCommandHandler::EFailed;
+    return mParameterMgrPlatformConnector.start(strResult)
+               ? CTestPlatform::CCommandHandler::EDone
+               : CTestPlatform::CCommandHandler::EFailed;
 }
 
 template <CTestPlatform::setter_t setFunction>
-CTestPlatform::CommandReturn CTestPlatform::setter(
-    const IRemoteCommand& remoteCommand, string& strResult)
+CTestPlatform::CommandReturn CTestPlatform::setter(const IRemoteCommand &remoteCommand,
+                                                   string &strResult)
 {
-    const string& strAbort = remoteCommand.getArgument(0);
+    const string &strAbort = remoteCommand.getArgument(0);
 
     bool bFail;
 
-    if(!convertTo(strAbort, bFail)) {
+    if (!convertTo(strAbort, bFail)) {
         return CTestPlatform::CCommandHandler::EShowUsage;
     }
 
-    return (mParameterMgrPlatformConnector.*setFunction)(bFail, strResult) ?
-           CTestPlatform::CCommandHandler::EDone : CTestPlatform::CCommandHandler::EFailed;
+    return (mParameterMgrPlatformConnector.*setFunction)(bFail, strResult)
+               ? CTestPlatform::CCommandHandler::EDone
+               : CTestPlatform::CCommandHandler::EFailed;
 }
 
 template <CTestPlatform::getter_t getFunction>
-CTestPlatform::CommandReturn CTestPlatform::getter(
-    const IRemoteCommand& /*command*/, string& strResult)
+CTestPlatform::CommandReturn CTestPlatform::getter(const IRemoteCommand & /*command*/,
+                                                   string &strResult)
 {
     strResult = (mParameterMgrPlatformConnector.*getFunction)() ? "true" : "false";
 
     return CTestPlatform::CCommandHandler::ESucceeded;
 }
 
-CTestPlatform::CommandReturn CTestPlatform::setCriterionState(
-    const IRemoteCommand& remoteCommand, string& strResult)
+CTestPlatform::CommandReturn CTestPlatform::setCriterionState(const IRemoteCommand &remoteCommand,
+                                                              string &strResult)
 {
 
     bool bSuccess;
@@ -226,13 +219,12 @@ CTestPlatform::CommandReturn CTestPlatform::setCriterionState(
         bSuccess = setCriterionStateByLexicalSpace(remoteCommand, strResult);
     }
 
-    return bSuccess ? CTestPlatform::CCommandHandler::EDone : CTestPlatform::CCommandHandler::
-           EFailed;
-
+    return bSuccess ? CTestPlatform::CCommandHandler::EDone
+                    : CTestPlatform::CCommandHandler::EFailed;
 }
 
-CTestPlatform::CommandReturn CTestPlatform::applyConfigurations(const IRemoteCommand& /*command*/,
-                                                                string& /*strResult*/)
+CTestPlatform::CommandReturn CTestPlatform::applyConfigurations(const IRemoteCommand & /*command*/,
+                                                                string & /*strResult*/)
 {
     mParameterMgrPlatformConnector.applyConfigurations();
 
@@ -242,11 +234,9 @@ CTestPlatform::CommandReturn CTestPlatform::applyConfigurations(const IRemoteCom
 //////////////// Remote command handlers
 
 bool CTestPlatform::createExclusiveSelectionCriterionFromStateList(
-                                                                const string& strName,
-                                                                const IRemoteCommand& remoteCommand,
-                                                                string& strResult)
+    const string &strName, const IRemoteCommand &remoteCommand, string &strResult)
 {
-    ISelectionCriterionTypeInterface* pCriterionType =
+    ISelectionCriterionTypeInterface *pCriterionType =
         mParameterMgrPlatformConnector.createSelectionCriterionType(false);
 
     assert(pCriterionType != NULL);
@@ -255,7 +245,7 @@ bool CTestPlatform::createExclusiveSelectionCriterionFromStateList(
 
     for (size_t state = 0; state < nbStates; state++) {
 
-        const std::string& strValue = remoteCommand.getArgument(state + 1);
+        const std::string &strValue = remoteCommand.getArgument(state + 1);
 
         // FIXME state type vs addValuePair params
         if (!pCriterionType->addValuePair(int(state), strValue, strResult)) {
@@ -272,11 +262,9 @@ bool CTestPlatform::createExclusiveSelectionCriterionFromStateList(
 }
 
 bool CTestPlatform::createInclusiveSelectionCriterionFromStateList(
-                                                                const string& strName,
-                                                                const IRemoteCommand& remoteCommand,
-                                                                string& strResult)
+    const string &strName, const IRemoteCommand &remoteCommand, string &strResult)
 {
-    ISelectionCriterionTypeInterface* pCriterionType =
+    ISelectionCriterionTypeInterface *pCriterionType =
         mParameterMgrPlatformConnector.createSelectionCriterionType(true);
 
     assert(pCriterionType != NULL);
@@ -285,10 +273,9 @@ bool CTestPlatform::createInclusiveSelectionCriterionFromStateList(
 
     for (size_t state = 0; state < nbStates; state++) {
 
-        const std::string& strValue = remoteCommand.getArgument(state + 1);
+        const std::string &strValue = remoteCommand.getArgument(state + 1);
 
-        if (!pCriterionType->addValuePair(
-                    0x1 << state, strValue, strResult)) {
+        if (!pCriterionType->addValuePair(0x1 << state, strValue, strResult)) {
 
             strResult = "Unable to add value: " + strValue + ": " + strResult;
 
@@ -301,27 +288,23 @@ bool CTestPlatform::createInclusiveSelectionCriterionFromStateList(
     return true;
 }
 
-
-bool CTestPlatform::createExclusiveSelectionCriterion(const string& strName,
-                                                      size_t nbStates,
-                                                      string& strResult)
+bool CTestPlatform::createExclusiveSelectionCriterion(const string &strName, size_t nbStates,
+                                                      string &strResult)
 {
-    ISelectionCriterionTypeInterface* pCriterionType =
+    ISelectionCriterionTypeInterface *pCriterionType =
         mParameterMgrPlatformConnector.createSelectionCriterionType(false);
 
     for (size_t state = 0; state < nbStates; state++) {
 
-	std::ostringstream ostrValue;
+        std::ostringstream ostrValue;
 
         ostrValue << "State_";
         ostrValue << state;
 
         // FIXME state type vs addValuePair params
-        if (!pCriterionType->addValuePair(
-                    int(state), ostrValue.str(), strResult)) {
+        if (!pCriterionType->addValuePair(int(state), ostrValue.str(), strResult)) {
 
-            strResult = "Unable to add value: "
-                + ostrValue.str() + ": " + strResult;
+            strResult = "Unable to add value: " + ostrValue.str() + ": " + strResult;
 
             return false;
         }
@@ -332,25 +315,22 @@ bool CTestPlatform::createExclusiveSelectionCriterion(const string& strName,
     return true;
 }
 
-bool CTestPlatform::createInclusiveSelectionCriterion(const string& strName,
-                                                      size_t nbStates,
-                                                      string& strResult)
+bool CTestPlatform::createInclusiveSelectionCriterion(const string &strName, size_t nbStates,
+                                                      string &strResult)
 {
-    ISelectionCriterionTypeInterface* pCriterionType =
+    ISelectionCriterionTypeInterface *pCriterionType =
         mParameterMgrPlatformConnector.createSelectionCriterionType(true);
 
     for (size_t state = 0; state < nbStates; state++) {
 
-	std::ostringstream ostrValue;
+        std::ostringstream ostrValue;
 
         ostrValue << "State_0x";
         ostrValue << (0x1 << state);
 
-        if (!pCriterionType->addValuePair(
-                    0x1 << state, ostrValue.str(), strResult)) {
+        if (!pCriterionType->addValuePair(0x1 << state, ostrValue.str(), strResult)) {
 
-            strResult = "Unable to add value: "
-                + ostrValue.str() + ": " + strResult;
+            strResult = "Unable to add value: " + ostrValue.str() + ": " + strResult;
 
             return false;
         }
@@ -361,9 +341,9 @@ bool CTestPlatform::createInclusiveSelectionCriterion(const string& strName,
     return true;
 }
 
-bool CTestPlatform::setCriterionState(const string& strName, uint32_t uiState, string& strResult)
+bool CTestPlatform::setCriterionState(const string &strName, uint32_t uiState, string &strResult)
 {
-    ISelectionCriterionInterface* pCriterion =
+    ISelectionCriterionInterface *pCriterion =
         mParameterMgrPlatformConnector.getSelectionCriterion(strName);
 
     if (!pCriterion) {
@@ -378,14 +358,14 @@ bool CTestPlatform::setCriterionState(const string& strName, uint32_t uiState, s
     return true;
 }
 
-bool CTestPlatform::setCriterionStateByLexicalSpace(const IRemoteCommand& remoteCommand,
-                                                    string& strResult)
+bool CTestPlatform::setCriterionStateByLexicalSpace(const IRemoteCommand &remoteCommand,
+                                                    string &strResult)
 {
 
     // Get criterion name
     std::string strCriterionName = remoteCommand.getArgument(0);
 
-    ISelectionCriterionInterface* pCriterion =
+    ISelectionCriterionInterface *pCriterion =
         mParameterMgrPlatformConnector.getSelectionCriterion(strCriterionName);
 
     if (!pCriterion) {
@@ -396,7 +376,7 @@ bool CTestPlatform::setCriterionStateByLexicalSpace(const IRemoteCommand& remote
     }
 
     // Get criterion type
-    const ISelectionCriterionTypeInterface* pCriterionType = pCriterion->getCriterionType();
+    const ISelectionCriterionTypeInterface *pCriterionType = pCriterion->getCriterionType();
 
     // Get substate number, the first argument (index 0) is the criterion name
     size_t nbSubStates = remoteCommand.getArgumentCount() - 1;
@@ -416,9 +396,7 @@ bool CTestPlatform::setCriterionStateByLexicalSpace(const IRemoteCommand& remote
     // Parse lexical substates
     std::string strLexicalState = "";
 
-    for (lexicalSubStateIndex = 1;
-         lexicalSubStateIndex <= nbSubStates;
-         lexicalSubStateIndex++) {
+    for (lexicalSubStateIndex = 1; lexicalSubStateIndex <= nbSubStates; lexicalSubStateIndex++) {
         /*
          * getNumericalValue method from ISelectionCriterionTypeInterface strip his parameter
          * first parameter based on | sign. In case that the user uses multiple parameters
@@ -434,8 +412,8 @@ bool CTestPlatform::setCriterionStateByLexicalSpace(const IRemoteCommand& remote
     // Translate lexical to numerical substate
     if (!pCriterionType->getNumericalValue(strLexicalState, iNumericalState)) {
 
-        strResult = "Unable to find lexical state \""
-            + strLexicalState + "\" in criteria " + strCriterionName;
+        strResult = "Unable to find lexical state \"" + strLexicalState + "\" in criteria " +
+                    strCriterionName;
 
         return false;
     }

--- a/test/test-platform/TestPlatform.h
+++ b/test/test-platform/TestPlatform.h
@@ -43,25 +43,26 @@ class CTestPlatform
 {
     typedef TRemoteCommandHandlerTemplate<CTestPlatform> CCommandHandler;
     typedef CCommandHandler::CommandStatus CommandReturn;
+
 public:
     CTestPlatform(const std::string &strclass, uint16_t iPortNumber);
     virtual ~CTestPlatform();
 
     // Init
-    bool run(std::string& strError);
+    bool run(std::string &strError);
 
 private:
     //////////////// Remote command parsers
     /// Selection Criterion
     CommandReturn createExclusiveSelectionCriterionFromStateList(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+        const IRemoteCommand &remoteCommand, std::string &strResult);
     CommandReturn createInclusiveSelectionCriterionFromStateList(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+        const IRemoteCommand &remoteCommand, std::string &strResult);
 
-    CommandReturn createExclusiveSelectionCriterion(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
-    CommandReturn createInclusiveSelectionCriterion(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+    CommandReturn createExclusiveSelectionCriterion(const IRemoteCommand &remoteCommand,
+                                                    std::string &strResult);
+    CommandReturn createInclusiveSelectionCriterion(const IRemoteCommand &remoteCommand,
+                                                    std::string &strResult);
 
     /** Callback to set a criterion's value, see ISelectionCriterionInterface::setCriterionState.
      * @see CCommandHandler::RemoteCommandParser for detail on each arguments and return
@@ -72,16 +73,14 @@ private:
      *                          if the criterion is provided in numerical space,
      *                              the second argument should be the criterion new value
      */
-    CommandReturn setCriterionState(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+    CommandReturn setCriterionState(const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /** Callback to start the PFW, see CParameterMgrPlatformConnector::start.
      * @see CCommandHandler::RemoteCommandParser for detail on each arguments and return
      *
      * @param[in] remoteCommand is ignored
      */
-    CommandReturn startParameterMgr(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+    CommandReturn startParameterMgr(const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /** Callback to apply PFW configuration, see CParameterMgrPlatformConnector::applyConfiguration.
      * @see CCommandHandler::RemoteCommandParser for detail on each arguments and return
@@ -90,8 +89,7 @@ private:
      *
      * @return EDone (never fails)
      */
-    CommandReturn applyConfigurations(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+    CommandReturn applyConfigurations(const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /** Callback to exit the test-platform.
      *
@@ -99,10 +97,10 @@ private:
      *
      * @return EDone (never fails)
      */
-    CommandReturn exit(const IRemoteCommand& remoteCommand, std::string& strResult);
+    CommandReturn exit(const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /** The type of a CParameterMgrPlatformConnector boolean setter. */
-    typedef bool (CParameterMgrPlatformConnector::*setter_t)(bool, std::string&);
+    typedef bool (CParameterMgrPlatformConnector::*setter_t)(bool, std::string &);
     /** Template callback to create a _pParameterMgrPlatformConnector boolean setter callback.
      * @see CCommandHandler::RemoteCommandParser for detail on each arguments and return
      *
@@ -112,9 +110,8 @@ private:
      * @tparam the boolean setter method.
      * @param[in] remoteCommand the first argument should be ether "on" or "off".
      */
-    template<setter_t setFunction>
-    CommandReturn setter(
-            const IRemoteCommand& remoteCommand, std::string& strResult);
+    template <setter_t setFunction>
+    CommandReturn setter(const IRemoteCommand &remoteCommand, std::string &strResult);
 
     /** The type of a CParameterMgrPlatformConnector boolean getter. */
     typedef bool (CParameterMgrPlatformConnector::*getter_t)() const;
@@ -129,36 +126,36 @@ private:
      *
      * @return EDone (never fails)
      */
-    template<getter_t getFunction>
-    CommandReturn getter(const IRemoteCommand& remoteCommand, std::string& strResult);
+    template <getter_t getFunction>
+    CommandReturn getter(const IRemoteCommand &remoteCommand, std::string &strResult);
 
     // Commands
-    bool createExclusiveSelectionCriterionFromStateList(const std::string& strName, const IRemoteCommand& remoteCommand, std::string& strResult);
-    bool createInclusiveSelectionCriterionFromStateList(const std::string& strName, const IRemoteCommand& remoteCommand, std::string& strResult);
+    bool createExclusiveSelectionCriterionFromStateList(const std::string &strName,
+                                                        const IRemoteCommand &remoteCommand,
+                                                        std::string &strResult);
+    bool createInclusiveSelectionCriterionFromStateList(const std::string &strName,
+                                                        const IRemoteCommand &remoteCommand,
+                                                        std::string &strResult);
 
-    bool createExclusiveSelectionCriterion(const std::string& strName, size_t nbValues, std::string& strResult);
-    bool createInclusiveSelectionCriterion(const std::string& strName, size_t nbValues, std::string& strResult);
-    bool setCriterionState(const std::string& strName, uint32_t uiState, std::string& strResult);
-    bool setCriterionStateByLexicalSpace(const IRemoteCommand& remoteCommand, std::string& strResult);
+    bool createExclusiveSelectionCriterion(const std::string &strName, size_t nbValues,
+                                           std::string &strResult);
+    bool createInclusiveSelectionCriterion(const std::string &strName, size_t nbValues,
+                                           std::string &strResult);
+    bool setCriterionState(const std::string &strName, uint32_t uiState, std::string &strResult);
+    bool setCriterionStateByLexicalSpace(const IRemoteCommand &remoteCommand,
+                                         std::string &strResult);
 
     // Connector
     CParameterMgrPlatformConnector mParameterMgrPlatformConnector;
 
     class : public CParameterMgrPlatformConnector::ILogger
     {
-        public:
-            virtual void info(const std::string& log)
-            {
-                std::cout << log << std::endl;
-            }
+    public:
+        virtual void info(const std::string &log) { std::cout << log << std::endl; }
 
-            virtual void warning(const std::string& log)
-            {
-                std::cerr << log << std::endl;
-            }
+        virtual void warning(const std::string &log) { std::cerr << log << std::endl; }
     } mLogger;
 
     // Remote Processor Server
     CRemoteProcessorServer mRemoteProcessorServer;
 };
-

--- a/test/test-platform/main.cpp
+++ b/test/test-platform/main.cpp
@@ -45,8 +45,8 @@ static const uint16_t defaultPortNumber = 5001;
 
 static void showUsage()
 {
-    cerr << "test-platform [-h|--help] <file path> [port number, default "
-         << defaultPortNumber << "]" << endl;
+    cerr << "test-platform [-h|--help] <file path> [port number, default " << defaultPortNumber
+         << "]" << endl;
 }
 
 static void showInvalidUsage(const string &error)
@@ -64,7 +64,6 @@ static void showHelp()
          << "    -h|--help  display this help and exit" << endl;
 }
 
-
 int main(int argc, char *argv[])
 {
     using Options = std::list<string>;
@@ -72,9 +71,8 @@ int main(int argc, char *argv[])
     Options options(argv + 1, argv + argc);
 
     // Handle help option
-    auto helpOpts = { "-h", "--help" };
-    auto match = std::find_first_of(begin(options), end(options),
-                                    begin(helpOpts), end(helpOpts));
+    auto helpOpts = {"-h", "--help"};
+    auto match = std::find_first_of(begin(options), end(options), begin(helpOpts), end(helpOpts));
     if (match != end(options)) {
         showHelp();
         return 0;

--- a/test/test-subsystem/TESTMappingKeys.h
+++ b/test/test-subsystem/TESTMappingKeys.h
@@ -30,7 +30,8 @@
 #pragma once
 
 // Mapping item types
-enum TESTItemType {
+enum TESTItemType
+{
     ETESTDirectory,
     ETESTLog
 };

--- a/test/test-subsystem/TESTSubsystem.cpp
+++ b/test/test-subsystem/TESTSubsystem.cpp
@@ -40,10 +40,10 @@
 #define base CSubsystem
 
 // Directory for isAlive and NeedResync files
-const char* gacFwNamePropName = getenv("PFW_RESULT");
+const char *gacFwNamePropName = getenv("PFW_RESULT");
 
 // Implementation
-CTESTSubsystem::CTESTSubsystem(const std::string& strName, core::log::Logger& logger)
+CTESTSubsystem::CTESTSubsystem(const std::string &strName, core::log::Logger &logger)
     : base(strName, logger)
 {
     // Provide mapping keys to upper layer
@@ -51,8 +51,10 @@ CTESTSubsystem::CTESTSubsystem(const std::string& strName, core::log::Logger& lo
     addContextMappingKey("Log");
 
     // Provide creators to upper layer
-    addSubsystemObjectFactory(new TSubsystemObjectFactory<CTESTSubsystemBinary>("Binary", 1 << ETESTDirectory));
-    addSubsystemObjectFactory(new TSubsystemObjectFactory<CTESTSubsystemString>("String", 1 << ETESTDirectory));
+    addSubsystemObjectFactory(
+        new TSubsystemObjectFactory<CTESTSubsystemBinary>("Binary", 1 << ETESTDirectory));
+    addSubsystemObjectFactory(
+        new TSubsystemObjectFactory<CTESTSubsystemString>("String", 1 << ETESTDirectory));
 }
 
 // Susbsystem sanity health
@@ -88,7 +90,7 @@ bool CTESTSubsystem::needResync(bool bClear)
 }
 
 // Read boolean from file
-std::string CTESTSubsystem::read(const std::string& strFileName)
+std::string CTESTSubsystem::read(const std::string &strFileName)
 {
     std::ifstream file;
     std::string strContent;
@@ -101,7 +103,7 @@ std::string CTESTSubsystem::read(const std::string& strFileName)
 }
 
 // Write boolean to file
-void CTESTSubsystem::write(const std::string& strFileName, const std::string& strContent)
+void CTESTSubsystem::write(const std::string &strFileName, const std::string &strContent)
 {
     std::ofstream file;
 

--- a/test/test-subsystem/TESTSubsystem.h
+++ b/test/test-subsystem/TESTSubsystem.h
@@ -34,16 +34,16 @@
 class CTESTSubsystem : public CSubsystem
 {
 public:
-   CTESTSubsystem(const std::string& strName, core::log::Logger& logger);
+    CTESTSubsystem(const std::string &strName, core::log::Logger &logger);
 
-   // Susbsystem sanity
-   virtual bool isAlive() const;
-   // Resynchronization after subsystem restart needed
-   virtual bool needResync(bool bClear);
+    // Susbsystem sanity
+    virtual bool isAlive() const;
+    // Resynchronization after subsystem restart needed
+    virtual bool needResync(bool bClear);
 
 private:
     // Read boolean from file
-    static std::string read(const std::string& strFileName);
+    static std::string read(const std::string &strFileName);
     // Write boolean to file
-    static void write(const std::string& strFileName, const std::string& strContent);
+    static void write(const std::string &strFileName, const std::string &strContent);
 };

--- a/test/test-subsystem/TESTSubsystemBinary.cpp
+++ b/test/test-subsystem/TESTSubsystemBinary.cpp
@@ -39,15 +39,14 @@
 
 #define base CTESTSubsystemObject
 
-CTESTSubsystemBinary::CTESTSubsystemBinary(const std::string& strMappingValue,
-                                           CInstanceConfigurableElement* pInstanceConfigurableElement,
-                                           const CMappingContext& context,
-                                           core::log::Logger& logger)
+CTESTSubsystemBinary::CTESTSubsystemBinary(
+    const std::string &strMappingValue, CInstanceConfigurableElement *pInstanceConfigurableElement,
+    const CMappingContext &context, core::log::Logger &logger)
     : base(strMappingValue, pInstanceConfigurableElement, context, logger)
 {
 }
 
-std::string CTESTSubsystemBinary::toString(const void* pvValue, size_t size) const
+std::string CTESTSubsystemBinary::toString(const void *pvValue, size_t size) const
 {
     std::ostringstream strStream;
     uint32_t uiValue = 0;
@@ -61,7 +60,7 @@ std::string CTESTSubsystemBinary::toString(const void* pvValue, size_t size) con
     return strStream.str();
 }
 
-void CTESTSubsystemBinary::fromString(const std::string& strValue, void* pvValue, size_t size)
+void CTESTSubsystemBinary::fromString(const std::string &strValue, void *pvValue, size_t size)
 {
     uint32_t uiValue;
 

--- a/test/test-subsystem/TESTSubsystemBinary.h
+++ b/test/test-subsystem/TESTSubsystemBinary.h
@@ -34,15 +34,13 @@
 class CTESTSubsystemBinary : public CTESTSubsystemObject
 {
 public:
-    CTESTSubsystemBinary(const std::string& strMappingValue,
-                         CInstanceConfigurableElement* configurableElement,
-                         const CMappingContext& context,
-                         core::log::Logger& logger);
+    CTESTSubsystemBinary(const std::string &strMappingValue,
+                         CInstanceConfigurableElement *configurableElement,
+                         const CMappingContext &context, core::log::Logger &logger);
 
 private:
     // from CTESTSubsystemObject
     // Format Data
-    virtual std::string toString(const void* pvValue, size_t size) const;
-    virtual void fromString(const std::string& strValue, void* pvValue, size_t size);
-
+    virtual std::string toString(const void *pvValue, size_t size) const;
+    virtual void fromString(const std::string &strValue, void *pvValue, size_t size);
 };

--- a/test/test-subsystem/TESTSubsystemBuilder.cpp
+++ b/test/test-subsystem/TESTSubsystemBuilder.cpp
@@ -31,10 +31,9 @@
 #include "LoggingElementBuilderTemplate.h"
 #include "TESTSubsystem.h"
 
-
-void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary* pSubsystemLibrary, core::log::Logger& logger)
+void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary *pSubsystemLibrary,
+                                              core::log::Logger &logger)
 {
-    pSubsystemLibrary->addElementBuilder("TEST",
-                                         new TLoggingElementBuilderTemplate<CTESTSubsystem>(
-                                             logger));
+    pSubsystemLibrary->addElementBuilder(
+        "TEST", new TLoggingElementBuilderTemplate<CTESTSubsystem>(logger));
 }

--- a/test/test-subsystem/TESTSubsystemObject.cpp
+++ b/test/test-subsystem/TESTSubsystemObject.cpp
@@ -39,14 +39,15 @@
 
 #define base CSubsystemObject
 
-CTESTSubsystemObject::CTESTSubsystemObject(const std::string& /*strMappingValue*/,
-                                           CInstanceConfigurableElement* pInstanceConfigurableElement,
-                                           const CMappingContext& context,
-                                           core::log::Logger& logger)
+CTESTSubsystemObject::CTESTSubsystemObject(
+    const std::string & /*strMappingValue*/,
+    CInstanceConfigurableElement *pInstanceConfigurableElement, const CMappingContext &context,
+    core::log::Logger &logger)
     : base(pInstanceConfigurableElement, logger)
 {
     // Get actual element type
-    const CParameterType* pParameterType = static_cast<const CParameterType*>(pInstanceConfigurableElement->getTypeElement());
+    const CParameterType *pParameterType =
+        static_cast<const CParameterType *>(pInstanceConfigurableElement->getTypeElement());
 
     _scalarSize = pParameterType->getSize();
     _arraySize = pInstanceConfigurableElement->getFootPrint() / _scalarSize;
@@ -56,7 +57,7 @@ CTESTSubsystemObject::CTESTSubsystemObject(const std::string& /*strMappingValue*
     _bLog = context.iSet(ETESTLog) && (context.getItem(ETESTLog) == "yes");
 }
 
-bool CTESTSubsystemObject::sendToHW(std::string& strError)
+bool CTESTSubsystemObject::sendToHW(std::string &strError)
 {
     std::ofstream outputFile;
 
@@ -76,8 +77,7 @@ bool CTESTSubsystemObject::sendToHW(std::string& strError)
     return true;
 }
 
-
-bool CTESTSubsystemObject::receiveFromHW(std::string& /*strError*/)
+bool CTESTSubsystemObject::receiveFromHW(std::string & /*strError*/)
 {
     std::ifstream inputFile;
 
@@ -94,13 +94,13 @@ bool CTESTSubsystemObject::receiveFromHW(std::string& /*strError*/)
     return true;
 }
 
-void CTESTSubsystemObject::sendToFile(std::ofstream& outputFile)
+void CTESTSubsystemObject::sendToFile(std::ofstream &outputFile)
 {
-    for (size_t index = 0 ; index < _arraySize ; index++) {
+    for (size_t index = 0; index < _arraySize; index++) {
 
         std::vector<uint8_t> aucValue(_scalarSize);
 
-        void* pvValue = aucValue.data();
+        void *pvValue = aucValue.data();
 
         // Read Value in BlackBoard
         blackboardRead(pvValue, _scalarSize);
@@ -113,24 +113,23 @@ void CTESTSubsystemObject::sendToFile(std::ofstream& outputFile)
 
             if (_bIsScalar) {
 
-                info() << "TESTSUBSYSTEM: Writing '" << strValue
-                       << "' to file " << _strFilePath;
+                info() << "TESTSUBSYSTEM: Writing '" << strValue << "' to file " << _strFilePath;
             } else {
 
-                info() << "TESTSUBSYSTEM: Writing '" << strValue << "' to file "
-                       << _strFilePath << "[" << index << "]";
+                info() << "TESTSUBSYSTEM: Writing '" << strValue << "' to file " << _strFilePath
+                       << "[" << index << "]";
             }
         }
     }
 }
 
-void CTESTSubsystemObject::receiveFromFile(std::ifstream& inputFile)
+void CTESTSubsystemObject::receiveFromFile(std::ifstream &inputFile)
 {
-    for (size_t index = 0 ; index < _arraySize ; index++) {
+    for (size_t index = 0; index < _arraySize; index++) {
 
         std::vector<uint8_t> aucValue(_scalarSize);
 
-        void* pvValue = aucValue.data();
+        void *pvValue = aucValue.data();
 
         std::string strValue;
 
@@ -140,12 +139,11 @@ void CTESTSubsystemObject::receiveFromFile(std::ifstream& inputFile)
 
             if (_bIsScalar) {
 
-                info() << "TESTSUBSYSTEM: Reading '" << strValue
-                       << "' to file " << _strFilePath;
+                info() << "TESTSUBSYSTEM: Reading '" << strValue << "' to file " << _strFilePath;
             } else {
 
-                info() << "TESTSUBSYSTEM: Reading '" << strValue << "' to file "
-                       << _strFilePath << "[" << index << "]";
+                info() << "TESTSUBSYSTEM: Reading '" << strValue << "' to file " << _strFilePath
+                       << "[" << index << "]";
             }
         }
 

--- a/test/test-subsystem/TESTSubsystemObject.h
+++ b/test/test-subsystem/TESTSubsystemObject.h
@@ -36,22 +36,21 @@ class CMappingContext;
 class CTESTSubsystemObject : public CSubsystemObject
 {
 public:
-    CTESTSubsystemObject(const std::string& strMappingValue,
-                         CInstanceConfigurableElement* pInstanceConfigurableElement,
-                         const CMappingContext& context,
-                         core::log::Logger& logger);
+    CTESTSubsystemObject(const std::string &strMappingValue,
+                         CInstanceConfigurableElement *pInstanceConfigurableElement,
+                         const CMappingContext &context, core::log::Logger &logger);
 
 protected:
     // from CSubsystemObject
     // Sync to/from HW
-    virtual bool sendToHW(std::string& strError);
-    virtual bool receiveFromHW(std::string& strError);
+    virtual bool sendToHW(std::string &strError);
+    virtual bool receiveFromHW(std::string &strError);
 
 private:
-    void sendToFile(std::ofstream& outputFile);
-    void receiveFromFile(std::ifstream& inputFile);
-    virtual std::string toString(const void* pvValue, size_t size) const = 0;
-    virtual void fromString(const std::string& strValue, void* pvValue, size_t size) = 0;
+    void sendToFile(std::ofstream &outputFile);
+    void receiveFromFile(std::ifstream &inputFile);
+    virtual std::string toString(const void *pvValue, size_t size) const = 0;
+    virtual void fromString(const std::string &strValue, void *pvValue, size_t size) = 0;
 
 protected:
     size_t _scalarSize;

--- a/test/test-subsystem/TESTSubsystemString.cpp
+++ b/test/test-subsystem/TESTSubsystemString.cpp
@@ -32,20 +32,19 @@
 
 #define base CTESTSubsystemObject
 
-CTESTSubsystemString::CTESTSubsystemString(const std::string& strMappingValue,
-                                           CInstanceConfigurableElement* pInstanceConfigurableElement,
-                                           const CMappingContext& context,
-                                           core::log::Logger& logger)
+CTESTSubsystemString::CTESTSubsystemString(
+    const std::string &strMappingValue, CInstanceConfigurableElement *pInstanceConfigurableElement,
+    const CMappingContext &context, core::log::Logger &logger)
     : base(strMappingValue, pInstanceConfigurableElement, context, logger)
 {
 }
 
-std::string CTESTSubsystemString::toString(const void* pvValue, size_t /*size*/) const
+std::string CTESTSubsystemString::toString(const void *pvValue, size_t /*size*/) const
 {
-    return (const char*)pvValue;
+    return (const char *)pvValue;
 }
 
-void CTESTSubsystemString::fromString(const std::string& strValue, void* pvValue, size_t size)
+void CTESTSubsystemString::fromString(const std::string &strValue, void *pvValue, size_t size)
 {
-    strncpy((char*)pvValue, strValue.c_str(), size);
+    strncpy((char *)pvValue, strValue.c_str(), size);
 }

--- a/test/test-subsystem/TESTSubsystemString.h
+++ b/test/test-subsystem/TESTSubsystemString.h
@@ -34,15 +34,13 @@
 class CTESTSubsystemString : public CTESTSubsystemObject
 {
 public:
-    CTESTSubsystemString(const std::string& strMappingValue,
-                         CInstanceConfigurableElement* pInstanceConfigurableElement,
-                         const CMappingContext& context,
-                         core::log::Logger& logger);
+    CTESTSubsystemString(const std::string &strMappingValue,
+                         CInstanceConfigurableElement *pInstanceConfigurableElement,
+                         const CMappingContext &context, core::log::Logger &logger);
 
 private:
     // from CTESTSubsystemObject
     // Format Data
-    virtual std::string toString(const void* pvValue, size_t size) const;
-    virtual void fromString(const std::string& strValue, void* pvValue, size_t size);
-
+    virtual std::string toString(const void *pvValue, size_t size) const;
+    virtual void fromString(const std::string &strValue, void *pvValue, size_t size);
 };

--- a/test/tmpfile/TmpFile.hpp
+++ b/test/tmpfile/TmpFile.hpp
@@ -43,7 +43,8 @@ namespace utility
 {
 
 /** Create a temporary file with the given content. */
-class TmpFile {
+class TmpFile
+{
 public:
     TmpFile(std::string content) : mPath(mktmp())
     {
@@ -54,18 +55,15 @@ public:
         file.close();
     }
 
-    TmpFile(TmpFile &&right) : mPath(std::move(right.mPath))
-    {
-        right.mPath.clear();
-    }
+    TmpFile(TmpFile &&right) : mPath(std::move(right.mPath)) { right.mPath.clear(); }
 
     /** Forbid copy semantic as sharing the tmp file is not needed.
      * @{ */
     TmpFile(const TmpFile &right) = delete;
-    TmpFile &operator= (const TmpFile &right) = delete;
+    TmpFile &operator=(const TmpFile &right) = delete;
     /** @} */
 
-    TmpFile &operator= (TmpFile &&right)
+    TmpFile &operator=(TmpFile &&right)
     {
         remove();
         mPath = std::move(right.mPath);
@@ -87,7 +85,8 @@ private:
      *
      * Call it after a c standard function failure.
      */
-    static void throwErrnoError(std::string context) {
+    static void throwErrnoError(std::string context)
+    {
         auto message = context + ": (" + std::to_string(errno) + ") " + std::strerror(errno);
         throw std::runtime_error(message);
     }

--- a/test/tmpfile/windows/TmpFile.cpp
+++ b/test/tmpfile/windows/TmpFile.cpp
@@ -47,15 +47,15 @@ static std::string formatError(DWORD error)
     LPTSTR formatedError = nullptr; // Pointer to the output buffer
 
     FormatMessage(
-       FORMAT_MESSAGE_FROM_SYSTEM |     // use system message tables to retrieve error text
-       FORMAT_MESSAGE_ALLOCATE_BUFFER | // allocate buffer on local heap for error text
-       FORMAT_MESSAGE_IGNORE_INSERTS,   // no insertion parameters
-       NULL, // unused with FORMAT_MESSAGE_FROM_SYSTEM
-       error, // the error to format
-       MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Use default language
-       (LPTSTR)&formatedError,  // output a pointer to the formated string
-       0,                       // minimum size for output buffer
-       NULL);   // No arguments
+        FORMAT_MESSAGE_FROM_SYSTEM |         // use system message tables to retrieve error text
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | // allocate buffer on local heap for error text
+            FORMAT_MESSAGE_IGNORE_INSERTS,   // no insertion parameters
+        NULL,                                // unused with FORMAT_MESSAGE_FROM_SYSTEM
+        error,                               // the error to format
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Use default language
+        (LPTSTR)&formatedError,                    // output a pointer to the formated string
+        0,                                         // minimum size for output buffer
+        NULL);                                     // No arguments
 
     // Release memory allocated by FormatMessage() on exit
     // Ignore LocalFree failure
@@ -77,8 +77,8 @@ std::string TmpFile::mktmp()
         auto error = ::GetLastError();
 
         auto message = std::string() + "Could not create a tmp file in \"" + directory +
-                       "\", with prefix \"" + prefix + "\": (" + to_string(error) +
-                       ") " + formatError(error);
+                       "\", with prefix \"" + prefix + "\": (" + to_string(error) + ") " +
+                       formatError(error);
         throw std::runtime_error(message);
     }
 

--- a/test/tokenizer/Test.cpp
+++ b/test/tokenizer/Test.cpp
@@ -30,7 +30,7 @@
 
 #include "Tokenizer.h"
 
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
+#define CATCH_CONFIG_MAIN // This tells Catch to provide a main()
 #include <catch.hpp>
 
 #include <string>
@@ -39,19 +39,19 @@
 using std::string;
 using std::vector;
 
-SCENARIO("Tokenizer tests") {
-    GIVEN("A default tokenizer") {
+SCENARIO ("Tokenizer tests") {
+    GIVEN ("A default tokenizer") {
 
-        GIVEN("A trivial string") {
+        GIVEN ("A trivial string") {
             Tokenizer tokenizer("a bcd ef");
 
-            THEN("next() api should work") {
+            THEN ("next() api should work") {
                 CHECK(tokenizer.next() == "a");
                 CHECK(tokenizer.next() == "bcd");
                 CHECK(tokenizer.next() == "ef");
                 CHECK(tokenizer.next() == "");
             }
-            THEN("split() api should work") {
+            THEN ("split() api should work") {
                 vector<string> expected;
                 expected.push_back("a");
                 expected.push_back("bcd");
@@ -61,30 +61,30 @@ SCENARIO("Tokenizer tests") {
             }
         }
 
-        GIVEN("An empty string") {
+        GIVEN ("An empty string") {
             Tokenizer tokenizer("");
 
-            THEN("next() api should work") {
+            THEN ("next() api should work") {
                 CHECK(tokenizer.next() == "");
             }
-            THEN("split() api should work") {
+            THEN ("split() api should work") {
                 vector<string> expected;
 
                 CHECK(tokenizer.split().empty());
             }
         }
 
-        GIVEN("A slash-separated string and tokenizer") {
+        GIVEN ("A slash-separated string and tokenizer") {
             Tokenizer tokenizer("/a/bcd/ef g/h/", "/");
 
-            THEN("next() api should work") {
+            THEN ("next() api should work") {
                 CHECK(tokenizer.next() == "a");
                 CHECK(tokenizer.next() == "bcd");
                 CHECK(tokenizer.next() == "ef g");
                 CHECK(tokenizer.next() == "h");
                 CHECK(tokenizer.next() == "");
             }
-            THEN("split() api should work") {
+            THEN ("split() api should work") {
                 vector<string> expected;
                 expected.push_back("a");
                 expected.push_back("bcd");
@@ -95,15 +95,15 @@ SCENARIO("Tokenizer tests") {
             }
         }
 
-        GIVEN("Multiple separators in a row") {
+        GIVEN ("Multiple separators in a row") {
             Tokenizer tokenizer("  a \n\t bc  ");
 
-            THEN("next() api should work") {
+            THEN ("next() api should work") {
                 CHECK(tokenizer.next() == "a");
                 CHECK(tokenizer.next() == "bc");
                 CHECK(tokenizer.next() == "");
             }
-            THEN("split() api should work") {
+            THEN ("split() api should work") {
                 vector<string> expected;
                 expected.push_back("a");
                 expected.push_back("bc");
@@ -112,5 +112,4 @@ SCENARIO("Tokenizer tests") {
             }
         }
     }
-
 }

--- a/test/tokenizer/Test.cpp
+++ b/test/tokenizer/Test.cpp
@@ -39,7 +39,8 @@
 using std::string;
 using std::vector;
 
-SCENARIO ("Tokenizer tests") {
+SCENARIO("Tokenizer tests")
+{
     GIVEN ("A default tokenizer") {
 
         GIVEN ("A trivial string") {

--- a/utility/AlwaysAssert.hpp
+++ b/utility/AlwaysAssert.hpp
@@ -31,24 +31,22 @@
 
 #include <iostream>
 
-
 #ifdef NDEBUG
-#    include <exception>
-#    define ALWAYS_ASSERT_FAILURE(cond) std::terminate()
+#include <exception>
+#define ALWAYS_ASSERT_FAILURE(cond) std::terminate()
 #else
-#    include <cassert>
-#    define ALWAYS_ASSERT_FAILURE(cond) assert(cond)
+#include <cassert>
+#define ALWAYS_ASSERT_FAILURE(cond) assert(cond)
 #endif
 
 // __func__ should be used as per C99 and C++11, but as visual studio 2013 isn't
 // compliant, use __FUNCTION__ which is compatible with linux and WIN32.
 
-
-#define ALWAYS_ASSERT(cond, iostr) \
-    do { \
-         if (!(cond)) { \
-           std::cerr << __FILE__ << ":" << __LINE__ << ":" << __FUNCTION__ \
-           << ": Assert '" #cond "' failed: " << iostr << std::endl; \
-            ALWAYS_ASSERT_FAILURE(cond); \
-         } \
+#define ALWAYS_ASSERT(cond, iostr)                                                                 \
+    do {                                                                                           \
+        if (!(cond)) {                                                                             \
+            std::cerr << __FILE__ << ":" << __LINE__ << ":" << __FUNCTION__                        \
+                      << ": Assert '" #cond "' failed: " << iostr << std::endl;                    \
+            ALWAYS_ASSERT_FAILURE(cond);                                                           \
+        }                                                                                          \
     } while (0)

--- a/utility/BinaryCopy.hpp
+++ b/utility/BinaryCopy.hpp
@@ -33,7 +33,8 @@
 #include "Iterator.hpp"
 #include <cassert>
 
-namespace utility {
+namespace utility
+{
 
 /**
  * Raw copy of one variable to another of the same size
@@ -58,7 +59,8 @@ typename std::remove_reference<Destination>::type binaryCopy(const Source source
 
     using Destination_ = decltype(binaryCopy<Destination>(source));
 
-    union {
+    union
+    {
         Source source;
         Destination_ destination;
     } hack;

--- a/utility/DynamicLibrary.cpp
+++ b/utility/DynamicLibrary.cpp
@@ -28,10 +28,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #include <DynamicLibrary.hpp>
 
-std::string DynamicLibrary::osSanitizePathName(const std::string& path)
+std::string DynamicLibrary::osSanitizePathName(const std::string &path)
 {
     if (path.rfind(_osLibrarySuffix) == (path.length() - _osLibrarySuffix.length())) {
 

--- a/utility/DynamicLibrary.hpp
+++ b/utility/DynamicLibrary.hpp
@@ -33,19 +33,16 @@
 
 #include <string>
 
-
-
 class DynamicLibrary : private utility::NonCopyable
 {
 public:
-
     /**
     * @param[in] path the library path which can be provided either in absolute path or
     *            or OS agnostic (ie. generic) name.
     * Note:
     * If generic name provided, OS specific prefix, suffix are added automatically
     */
-    DynamicLibrary(const std::string& path);
+    DynamicLibrary(const std::string &path);
     ~DynamicLibrary();
 
     /**
@@ -55,21 +52,19 @@ public:
     * @return a symbol's address in the library if it exists, NULL otherwise
     */
     template <typename SymbolType>
-    SymbolType getSymbol(const std::string& symbol) const
+    SymbolType getSymbol(const std::string &symbol) const
     {
         return reinterpret_cast<SymbolType>(osGetSymbol(symbol));
     }
 
-
 private:
-
     /**
     * OS secific helper to get a symbol from library
     *
     * @param[in] symbol the symbol name
     * @return symbol's address in the library if it exists, NULL otherwise
     */
-    void *osGetSymbol(const std::string& symbol) const;
+    void *osGetSymbol(const std::string &symbol) const;
 
     /**
     * Sanitize library path
@@ -77,7 +72,7 @@ private:
     * @param[in] path library stripped path (eg. no prefix, no suffix)
     * @return OS specific library path including prefix and suffix
     */
-    static std::string osSanitizePathName(const std::string& path);
+    static std::string osSanitizePathName(const std::string &path);
 
     /**
     * Opaque object for library handling

--- a/utility/ErrorContext.hpp
+++ b/utility/ErrorContext.hpp
@@ -38,26 +38,17 @@ namespace utility
 class ErrorContext : private NonCopyable
 {
 public:
-    ErrorContext(std::string& error) : mError(error) {}
+    ErrorContext(std::string &error) : mError(error) {}
 
-    void setError(const std::string& error)
-    {
-        mError = error;
-    }
+    void setError(const std::string &error) { mError = error; }
 
-    void appendToError(const std::string& append)
-    {
-        mError += append;
-    }
+    void appendToError(const std::string &append) { mError += append; }
 
-    void prependToError(const std::string& prepend)
-    {
-        mError = prepend + mError;
-    }
+    void prependToError(const std::string &prepend) { mError = prepend + mError; }
 
 private:
     // Error reference
-    std::string& mError;
+    std::string &mError;
 };
 
 } // namespace utility

--- a/utility/Iterator.hpp
+++ b/utility/Iterator.hpp
@@ -31,16 +31,16 @@
 #include <iterator>
 
 #ifdef _MSC_VER
-#   include <iterator>
-    /** Visual studio raises a warning if the check iterator feature is activated
-     * but a raw pointer is used as iterator (as it can not check it's bounds).
-     * As it is a safety feature, do not silent the warning, but use the
-     * microsoft specific `make_check_array_iterator` that take a pointer
-     * and the size of the underline buffer.
-     * For other compiler, use the raw pointer.
-     */
-#   define MAKE_ARRAY_ITERATOR(begin, size) stdext::make_checked_array_iterator(begin, size)
+#include <iterator>
+/** Visual studio raises a warning if the check iterator feature is activated
+ * but a raw pointer is used as iterator (as it can not check it's bounds).
+ * As it is a safety feature, do not silent the warning, but use the
+ * microsoft specific `make_check_array_iterator` that take a pointer
+ * and the size of the underline buffer.
+ * For other compiler, use the raw pointer.
+ */
+#define MAKE_ARRAY_ITERATOR(begin, size) stdext::make_checked_array_iterator(begin, size)
 #else
-    /** By default an array iterator is a pointer to the first element. */
-#   define MAKE_ARRAY_ITERATOR(begin, size) begin
+/** By default an array iterator is a pointer to the first element. */
+#define MAKE_ARRAY_ITERATOR(begin, size) begin
 #endif

--- a/utility/Memory.hpp
+++ b/utility/Memory.hpp
@@ -30,13 +30,14 @@
 
 #include <memory>
 
-namespace utility {
+namespace utility
+{
 
 /** Implementation of C++14's std::make_unique.
  *
  * TODO: Specialisation for array types is not implemented.
  */
-template<class T, class... Args>
+template <class T, class... Args>
 std::unique_ptr<T> make_unique(Args &&... args)
 {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));

--- a/utility/NonCopyable.hpp
+++ b/utility/NonCopyable.hpp
@@ -29,7 +29,8 @@
  */
 #pragma once
 
-namespace utility {
+namespace utility
+{
 
 /** Base class for private inheritance to make the derived class non copyable.
  *

--- a/utility/Tokenizer.h
+++ b/utility/Tokenizer.h
@@ -51,8 +51,8 @@ public:
      * @param[in] delimiters A string containing all the token delimiters
      *            (hence, each delimiter can only be a single character)
      */
-    Tokenizer(const std::string &input, const std::string &delimiters=defaultDelimiters);
-    ~Tokenizer() {};
+    Tokenizer(const std::string &input, const std::string &delimiters = defaultDelimiters);
+    ~Tokenizer(){};
 
     /** Return the next token or an empty string if no more token
      *
@@ -70,7 +70,7 @@ public:
     static const std::string defaultDelimiters;
 
 private:
-    const std::string _input; //< string to be tokenized
+    const std::string _input;      //< string to be tokenized
     const std::string _delimiters; //< token delimiters
 
     std::string::size_type _position; //< end of the last returned token

--- a/utility/Utility.cpp
+++ b/utility/Utility.cpp
@@ -40,36 +40,32 @@ namespace utility
 {
 
 // Format string list
-std::string asString(const std::list<std::string>& lstr,
-                        const std::string& strSeparator)
+std::string asString(const std::list<std::string> &lstr, const std::string &strSeparator)
 {
-    return join<std::string>(begin(lstr), end(lstr),
-                             [strSeparator](string acc, string right) {
-                                 return acc + strSeparator + right;
-                             });
+    return join<std::string>(begin(lstr), end(lstr), [strSeparator](string acc, string right) {
+        return acc + strSeparator + right;
+    });
 }
 
 // Format string map
-std::string asString(const std::map<std::string, std::string>& mapStr,
-                               const std::string& strItemSeparator,
-                               const std::string& strKeyValueSeparator)
+std::string asString(const std::map<std::string, std::string> &mapStr,
+                     const std::string &strItemSeparator, const std::string &strKeyValueSeparator)
 {
     std::list<std::string> listKeysValues;
 
-    for (const auto & item: mapStr) {
+    for (const auto &item : mapStr) {
         listKeysValues.emplace_back(item.first + strKeyValueSeparator + item.second);
     }
 
     return asString(listKeysValues, strItemSeparator);
 }
 
-void appendTitle(string& strTo, const string& strTitle)
+void appendTitle(string &strTo, const string &strTitle)
 {
-    strTo += "\n" + strTitle + "\n" +
-             string(strTitle.size(), '=') + "\n";
+    strTo += "\n" + strTitle + "\n" + string(strTitle.size(), '=') + "\n";
 }
 
-bool isHexadecimal(const string& strValue)
+bool isHexadecimal(const string &strValue)
 {
     return (strValue.compare(0, 2, "0x") == 0) or (strValue.compare(0, 2, "0X") == 0);
 }

--- a/utility/Utility.h
+++ b/utility/Utility.h
@@ -47,10 +47,12 @@ namespace utility
  *           let [first, last[ = list<string>{"1", "2", "3"}
  *           then join(first, last, op) == "1|2|3"
  */
-template<class T, class InputIt, class BinaryOperation>
+template <class T, class InputIt, class BinaryOperation>
 T join(InputIt first, InputIt last, BinaryOperation op, T empty = T{})
 {
-    if (first == last) { return empty; }
+    if (first == last) {
+        return empty;
+    }
     auto init = *first++;
 
     return std::accumulate(first, last, init, op);
@@ -65,8 +67,7 @@ T join(InputIt first, InputIt last, BinaryOperation op, T empty = T{})
 *
 * @return the concatenated elements.
 */
-std::string asString(const std::list<std::string>& lstr,
-                     const std::string& separator = "\n");
+std::string asString(const std::list<std::string> &lstr, const std::string &separator = "\n");
 
 /**
  * Format the items of a map into a string as a list of key-value pairs. The map must be
@@ -77,12 +78,12 @@ std::string asString(const std::list<std::string>& lstr,
  * @param[in] strItemSeparator The separator to use between each item (key-value pair)
  * @param[in] strKeyValueSeparator The separator to use between key and value
  */
-std::string asString(const std::map<std::string, std::string>& mapStr,
-                     const std::string& strItemSeparator = ", ",
-                     const std::string& strKeyValueSeparator = ":");
+std::string asString(const std::map<std::string, std::string> &mapStr,
+                     const std::string &strItemSeparator = ", ",
+                     const std::string &strKeyValueSeparator = ":");
 
 /** Utility to underline */
-void appendTitle(std::string& strTo, const std::string& strTitle);
+void appendTitle(std::string &strTo, const std::string &strTitle);
 
 /**
  * Checks if a string has the written representation of an hexadecimal
@@ -92,6 +93,6 @@ void appendTitle(std::string& strTo, const std::string& strTitle);
  *
  * @return true if the string is written as hexa, false otherwise.
  */
-bool isHexadecimal(const std::string& strValue);
+bool isHexadecimal(const std::string &strValue);
 
 } // utility

--- a/utility/convert.hpp
+++ b/utility/convert.hpp
@@ -43,25 +43,70 @@ namespace details
 {
 
 /* List of allowed types for conversion */
-template<typename T> struct ConvertionAllowed : std::false_type {};
-template<> struct ConvertionAllowed<bool> : std::true_type {};
-template<> struct ConvertionAllowed<uint64_t> : std::true_type {};
-template<> struct ConvertionAllowed<int64_t> : std::true_type {};
-template<> struct ConvertionAllowed<uint32_t> : std::true_type {};
-template<> struct ConvertionAllowed<int32_t> : std::true_type {};
-template<> struct ConvertionAllowed<uint16_t> : std::true_type {};
-template<> struct ConvertionAllowed<int16_t> : std::true_type {};
-template<> struct ConvertionAllowed<int8_t> : std::true_type {};
-template<> struct ConvertionAllowed<uint8_t> : std::true_type {};
-template<> struct ConvertionAllowed<float> : std::true_type {};
-template<> struct ConvertionAllowed<double> : std::true_type {};
+template <typename T>
+struct ConvertionAllowed : std::false_type
+{
+};
+template <>
+struct ConvertionAllowed<bool> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<uint64_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<int64_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<uint32_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<int32_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<uint16_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<int16_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<int8_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<uint8_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<float> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<double> : std::true_type
+{
+};
 
 /* Allow chars and unsigned chars to be converted via integers */
-template<typename T, typename Via> struct ConvertionAllowedVia : std::false_type {};
-template<> struct ConvertionAllowedVia<uint8_t, uint32_t> : std::true_type {};
-template<> struct ConvertionAllowedVia<int8_t, int32_t> : std::true_type {};
+template <typename T, typename Via>
+struct ConvertionAllowedVia : std::false_type
+{
+};
+template <>
+struct ConvertionAllowedVia<uint8_t, uint32_t> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowedVia<int8_t, int32_t> : std::true_type
+{
+};
 
-template<typename T>
+template <typename T>
 static inline bool convertTo(const std::string &str, T &result)
 {
     /* Check that conversion to that type is allowed.
@@ -76,8 +121,7 @@ static inline bool convertTo(const std::string &str, T &result)
     /* Check for a '-' in string. If type is unsigned and a - is found, the
      * parsing fails. This is made necessary because "-1" is read as 65535 for
      * uint16_t, for example */
-    if (str.find("-") != std::string::npos
-        && !std::numeric_limits<T>::is_signed) {
+    if (str.find("-") != std::string::npos && !std::numeric_limits<T>::is_signed) {
         return false;
     }
 
@@ -88,8 +132,7 @@ static inline bool convertTo(const std::string &str, T &result)
     if (str.substr(0, 2) == "0x") {
         if (std::numeric_limits<T>::is_integer) {
             ss >> std::hex >> result;
-        }
-        else {
+        } else {
             /* Conversion undefined for non integers */
             return false;
         }
@@ -100,14 +143,14 @@ static inline bool convertTo(const std::string &str, T &result)
     return ss.eof() && !ss.fail() && !ss.bad();
 }
 
-template<typename T, typename Via>
+template <typename T, typename Via>
 static inline bool convertToVia(const std::string &str, T &result)
 {
     /* Check that conversion to that type is allowed.
      * If this fails, this means that this template was not intended to be used
      * with this type, thus that the result is undefined. */
     static_assert(ConvertionAllowedVia<T, Via>::value,
-            "convertToVia does not support this conversion");
+                  "convertToVia does not support this conversion");
 
     /* We want to override the behaviour of convertTo<T> with that of
      * convertTo<Via> and then safely cast the result into a T. */
@@ -117,8 +160,7 @@ static inline bool convertToVia(const std::string &str, T &result)
         return false;
     }
 
-    if ((res > std::numeric_limits<T>::max())
-        or (res < std::numeric_limits<T>::min())) {
+    if ((res > std::numeric_limits<T>::max()) or (res < std::numeric_limits<T>::min())) {
         return false;
     }
 
@@ -143,7 +185,7 @@ static inline bool convertToVia(const std::string &str, T &result)
  *
  * @return true if conversion was successful, false otherwise.
  */
-template<typename T>
+template <typename T>
 static inline bool convertTo(const std::string &str, T &result)
 {
     return details::convertTo<T>(str, result);
@@ -166,7 +208,7 @@ static inline bool convertTo(const std::string &str, T &result)
  *
  * @return true if conversion was successful, false otherwise.
  */
-template<>
+template <>
 inline bool convertTo<uint8_t>(const std::string &str, uint8_t &result)
 {
     return details::convertToVia<uint8_t, uint32_t>(str, result);
@@ -176,7 +218,7 @@ inline bool convertTo<uint8_t>(const std::string &str, uint8_t &result)
  *
  * @see convertTo<uint8_t>
  */
-template<>
+template <>
 inline bool convertTo<int8_t>(const std::string &str, int8_t &result)
 {
     return details::convertToVia<int8_t, int32_t>(str, result);
@@ -197,7 +239,7 @@ inline bool convertTo<int8_t>(const std::string &str, int8_t &result)
  *
  * @return true if conversion was successful, false otherwise.
  */
-template<>
+template <>
 inline bool convertTo<float>(const std::string &str, float &result)
 {
     if (!details::convertTo(str, result)) {
@@ -226,7 +268,7 @@ inline bool convertTo<float>(const std::string &str, float &result)
  *
  * @return true if conversion was successful, false otherwise.
  */
-template<>
+template <>
 inline bool convertTo<double>(const std::string &str, double &result)
 {
     if (!details::convertTo(str, result)) {
@@ -257,7 +299,7 @@ inline bool convertTo<double>(const std::string &str, double &result)
  *
  * @return true if conversion was successful, false otherwise.
  */
-template<>
+template <>
 inline bool convertTo<bool>(const std::string &str, bool &result)
 {
     if (str == "0" || str == "FALSE" || str == "false") {

--- a/utility/posix/DynamicLibrary.cpp
+++ b/utility/posix/DynamicLibrary.cpp
@@ -28,20 +28,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #include <DynamicLibrary.hpp>
 
 #include <dlfcn.h>
 
 #include <stdexcept>
 
-
-
 const std::string DynamicLibrary::_osLibraryPrefix = "lib";
 const std::string DynamicLibrary::_osLibrarySuffix = ".so";
 
-DynamicLibrary::DynamicLibrary(const std::string& path)
-    : _path(osSanitizePathName(path))
+DynamicLibrary::DynamicLibrary(const std::string &path) : _path(osSanitizePathName(path))
 {
     _handle = dlopen(_path.c_str(), RTLD_LAZY);
 
@@ -57,7 +53,7 @@ DynamicLibrary::~DynamicLibrary(void)
     dlclose(_handle);
 }
 
-void *DynamicLibrary::osGetSymbol(const std::string& symbol) const
+void *DynamicLibrary::osGetSymbol(const std::string &symbol) const
 {
     void *sym = dlsym(_handle, symbol.c_str());
 

--- a/utility/test/utility.cpp
+++ b/utility/test/utility.cpp
@@ -41,23 +41,20 @@ using std::string;
 namespace utility
 {
 
-SCENARIO("join<int>") {
+SCENARIO ("join<int>") {
     struct Test
     {
         list<int> input;
-        std::function<int (int, int)> binaryOpt;
+        std::function<int(int, int)> binaryOpt;
         int empty;
         int result;
         int resultNoEmpty;
     };
-    const list<Test> tests =
-    {
-        {{},           nullptr,                          21, 21,  0},
-        {{5},          nullptr,                          -1, 5,   5},
-        {{5, 2},       [](int, int){return 73;},         -1, 73,  73},
-        {{2, 3, 7},    [](int l, int r){return l * r ;}, -1, 42,  42},
-        {{1, 10, 100}, [](int l, int r){return l + r ;}, -1, 111, 111}
-    };
+    const list<Test> tests = {{{}, nullptr, 21, 21, 0},
+                              {{5}, nullptr, -1, 5, 5},
+                              {{5, 2}, [](int, int) { return 73; }, -1, 73, 73},
+                              {{2, 3, 7}, [](int l, int r) { return l * r; }, -1, 42, 42},
+                              {{1, 10, 100}, [](int l, int r) { return l + r; }, -1, 111, 111}};
     for (auto &test : tests) {
         CAPTURE(Catch::toString(test.input));
         const auto &first = begin(test.input);
@@ -67,8 +64,7 @@ SCENARIO("join<int>") {
     }
 }
 
-
-SCENARIO("asString(list)") {
+SCENARIO ("asString(list)") {
     struct Test
     {
         string title;
@@ -77,27 +73,26 @@ SCENARIO("asString(list)") {
         string result;
         string resultNoSep;
     };
-    const list<Test> tests =
-    {
-        {"Empty list",      {},                  "aa", "",        ""},
-        {"One element",     {"a"},               "<>", "a",       "a"},
-        {"Three elem list", {"1", "2", "3"},     "**", "1**2**3", "1\n2\n3"},
-        {"No separator",    {"12", "ab", "+-"},  "",   "12ab+-",  "12\nab\n+-"},
-        {"empty elem list", {"a", "b", "", "d"}, "|",  "a|b||d",  "a\nb\n\nd"},
+    const list<Test> tests = {
+        {"Empty list", {}, "aa", "", ""},
+        {"One element", {"a"}, "<>", "a", "a"},
+        {"Three elem list", {"1", "2", "3"}, "**", "1**2**3", "1\n2\n3"},
+        {"No separator", {"12", "ab", "+-"}, "", "12ab+-", "12\nab\n+-"},
+        {"empty elem list", {"a", "b", "", "d"}, "|", "a|b||d", "a\nb\n\nd"},
     };
     for (auto &test : tests) {
         CAPTURE(Catch::toString(test.input));
-        WHEN("Separator, " + test.title) {
+        WHEN ("Separator, " + test.title) {
             CAPTURE(test.separator);
             REQUIRE(asString(test.input, test.separator) == test.result);
         }
-        THEN("No separator, " + test.title) {
+        THEN ("No separator, " + test.title) {
             REQUIRE(asString(test.input) == test.resultNoSep);
         }
     }
 }
 
-SCENARIO("asString(map)") {
+SCENARIO ("asString(map)") {
     using std::map;
 
     using Map = map<string, string>;
@@ -110,18 +105,14 @@ SCENARIO("asString(map)") {
         string resultNoKeyValueSep;
         string resultNoSep;
     };
-    const list<Test> tests =
-    {
-        {{}, "itemSep", "keyValueSep", "", "", ""},
-        { Map{{"a", "b"},
-              {"c", "d"},
-              {"e", "f"}}, // input
-          " - ", "\n", // item & keyValue sep
-          "a - b\nc - d\ne - f", //result
-          "a:b\nc:d\ne:f", //resultNoKeyValueSep
-          "a:b, c:d, e:f" //resultNoSep
-        }
-    };
+    const list<Test> tests = {{{}, "itemSep", "keyValueSep", "", "", ""},
+                              {
+                                  Map{{"a", "b"}, {"c", "d"}, {"e", "f"}}, // input
+                                  " - ", "\n",                             // item & keyValue sep
+                                  "a - b\nc - d\ne - f",                   // result
+                                  "a:b\nc:d\ne:f",                         // resultNoKeyValueSep
+                                  "a:b, c:d, e:f"                          // resultNoSep
+                              }};
     for (const auto &test : tests) {
         CAPTURE(Catch::toString(test.input));
         CAPTURE(test.keyValueSep);
@@ -130,31 +121,27 @@ SCENARIO("asString(map)") {
         REQUIRE(asString(test.input, test.keyValueSep) == test.resultNoKeyValueSep);
         REQUIRE(asString(test.input) == test.resultNoSep);
     }
-
 }
 
-SCENARIO("appendTitle") {
+SCENARIO ("appendTitle") {
     struct Test
     {
         string initial;
         string title;
         string result;
     };
-    const list<Test> tests =
-    {
-        {"",      "abc",   "\nabc\n===\n"},
-        {"start", "title", "start\ntitle\n=====\n"}
-    };
+    const list<Test> tests = {{"", "abc", "\nabc\n===\n"},
+                              {"start", "title", "start\ntitle\n=====\n"}};
     for (auto &test : tests) {
         auto quote = [](std::string toQuote) { return '"' + toQuote + '"'; };
 
-        GIVEN("A title: " + quote(test.title)) {
+        GIVEN ("A title: " + quote(test.title)) {
             CAPTURE(test.initial);
             CAPTURE(test.title);
 
-            WHEN("Appending to: " + quote(test.initial)) {
+            WHEN ("Appending to: " + quote(test.initial)) {
                 string output = test.initial;
-                THEN("Result should be:\n" + quote(test.result)) {
+                THEN ("Result should be:\n" + quote(test.result)) {
                     appendTitle(output, test.title);
                     CHECK(output == test.result);
                 }
@@ -163,14 +150,14 @@ SCENARIO("appendTitle") {
     }
 }
 
-SCENARIO("isNotHexadecimal") {
+SCENARIO ("isNotHexadecimal") {
     for (auto &str : {"a", "0", "012", "13", "ABC", "Oxa"}) {
         CAPTURE(str);
         CHECK(not isHexadecimal(str));
     }
 }
 
-SCENARIO("isHexadecimal") {
+SCENARIO ("isHexadecimal") {
     for (auto str : {"0xa", "0X0", "0x012", "0x13", "0xConsider as hexa as starting with 0x"}) {
         CAPTURE(str);
         CHECK(isHexadecimal(str));
@@ -178,7 +165,8 @@ SCENARIO("isHexadecimal") {
 }
 
 template <class T1, class T2>
-void checkBinaryEqual(T1 v1, T2 v2) {
+void checkBinaryEqual(T1 v1, T2 v2)
+{
     // For some yet-unknown reason, GCC 4.8 complains about
     //     CHECK(a == b);
     // and suggests that parentheses should be added. This is related to catch
@@ -198,29 +186,29 @@ void checkBinaryEqual(T1 v1, T2 v2) {
     CHECK((v2 == v1AsT2));
 }
 
-SCENARIO("binaryCopy bit exactness") {
-    GIVEN("Integer representations computed using http://babbage.cs.qc.cuny.edu/IEEE-754/") {
+SCENARIO ("binaryCopy bit exactness") {
+    GIVEN ("Integer representations computed using http://babbage.cs.qc.cuny.edu/IEEE-754/") {
 
-        THEN("Floats should be coded on 32bits and fulfill IEEE-754."
-             " That assumption is made in the Parameter Framework.") {
+        THEN ("Floats should be coded on 32bits and fulfill IEEE-754."
+              " That assumption is made in the Parameter Framework.") {
             REQUIRE(sizeof(float) == sizeof(uint32_t));
             REQUIRE(std::numeric_limits<float>::is_iec559);
         }
-        WHEN("Testing float <=> uint32_t conversion") {
+        WHEN ("Testing float <=> uint32_t conversion") {
             checkBinaryEqual<float, uint32_t>(1.23456f, 0x3f9e0610);
         }
 
-        THEN("Doubles should be coded on 64bits and fulfill IEEE-754."
-             " That assumption is made in the Parameter Framework.") {
+        THEN ("Doubles should be coded on 64bits and fulfill IEEE-754."
+              " That assumption is made in the Parameter Framework.") {
             REQUIRE(sizeof(double) == sizeof(uint64_t));
             REQUIRE(std::numeric_limits<double>::is_iec559);
         }
-        WHEN("Testing double <=> uint64_t conversion") {
+        WHEN ("Testing double <=> uint64_t conversion") {
             checkBinaryEqual<double, uint64_t>(987.65432109876, 0x408edd3c0cb3420e);
         }
     }
 
-    WHEN("Testing int8_t <=> uint8_t conversion") {
+    WHEN ("Testing int8_t <=> uint8_t conversion") {
         checkBinaryEqual<int8_t, uint8_t>(-1, 0xff);
     }
 }

--- a/utility/test/utility.cpp
+++ b/utility/test/utility.cpp
@@ -41,7 +41,8 @@ using std::string;
 namespace utility
 {
 
-SCENARIO ("join<int>") {
+SCENARIO("join<int>")
+{
     struct Test
     {
         list<int> input;
@@ -64,7 +65,8 @@ SCENARIO ("join<int>") {
     }
 }
 
-SCENARIO ("asString(list)") {
+SCENARIO("asString(list)")
+{
     struct Test
     {
         string title;
@@ -92,7 +94,8 @@ SCENARIO ("asString(list)") {
     }
 }
 
-SCENARIO ("asString(map)") {
+SCENARIO("asString(map)")
+{
     using std::map;
 
     using Map = map<string, string>;
@@ -123,7 +126,8 @@ SCENARIO ("asString(map)") {
     }
 }
 
-SCENARIO ("appendTitle") {
+SCENARIO("appendTitle")
+{
     struct Test
     {
         string initial;
@@ -150,14 +154,16 @@ SCENARIO ("appendTitle") {
     }
 }
 
-SCENARIO ("isNotHexadecimal") {
+SCENARIO("isNotHexadecimal")
+{
     for (auto &str : {"a", "0", "012", "13", "ABC", "Oxa"}) {
         CAPTURE(str);
         CHECK(not isHexadecimal(str));
     }
 }
 
-SCENARIO ("isHexadecimal") {
+SCENARIO("isHexadecimal")
+{
     for (auto str : {"0xa", "0X0", "0x012", "0x13", "0xConsider as hexa as starting with 0x"}) {
         CAPTURE(str);
         CHECK(isHexadecimal(str));
@@ -186,7 +192,8 @@ void checkBinaryEqual(T1 v1, T2 v2)
     CHECK((v2 == v1AsT2));
 }
 
-SCENARIO ("binaryCopy bit exactness") {
+SCENARIO("binaryCopy bit exactness")
+{
     GIVEN ("Integer representations computed using http://babbage.cs.qc.cuny.edu/IEEE-754/") {
 
         THEN ("Floats should be coded on 32bits and fulfill IEEE-754."

--- a/utility/windows/DynamicLibrary.cpp
+++ b/utility/windows/DynamicLibrary.cpp
@@ -28,20 +28,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #include <DynamicLibrary.hpp>
 
 #include "windows.h"
 
 #include <stdexcept>
 
-
-
 const std::string DynamicLibrary::_osLibraryPrefix = "";
 const std::string DynamicLibrary::_osLibrarySuffix = ".dll";
 
-DynamicLibrary::DynamicLibrary(const std::string& path)
-    : _path(osSanitizePathName(path))
+DynamicLibrary::DynamicLibrary(const std::string &path) : _path(osSanitizePathName(path))
 {
     static_assert(sizeof(void *) == sizeof(HMODULE), "Incompatible object size");
 
@@ -62,7 +58,7 @@ DynamicLibrary::~DynamicLibrary()
     FreeLibrary(module);
 }
 
-void *DynamicLibrary::osGetSymbol(const std::string& symbol) const
+void *DynamicLibrary::osGetSymbol(const std::string &symbol) const
 {
     HMODULE module = reinterpret_cast<HMODULE>(_handle);
 

--- a/xmlserializer/XmlDocSink.h
+++ b/xmlserializer/XmlDocSink.h
@@ -54,7 +54,7 @@ public:
       *
       * @return true is there was no error during the processing of xmlDocSource
       */
-    bool process(CXmlDocSource& xmlDocSource, CXmlSerializingContext& serializingContext)
+    bool process(CXmlDocSource &xmlDocSource, CXmlSerializingContext &serializingContext)
     {
         if (!xmlDocSource.populate(serializingContext)) {
             return false;
@@ -75,5 +75,6 @@ private:
       *
       * @return true is there was no error during the processing of xmlDocSource
       */
-    virtual bool doProcess(CXmlDocSource& xmlDocSource, CXmlSerializingContext& serializingContext) = 0;
+    virtual bool doProcess(CXmlDocSource &xmlDocSource,
+                           CXmlSerializingContext &serializingContext) = 0;
 };

--- a/xmlserializer/XmlDocSource.cpp
+++ b/xmlserializer/XmlDocSource.cpp
@@ -41,28 +41,18 @@
 using std::string;
 using xml_unique_ptr = std::unique_ptr<xmlChar, decltype(xmlFree)>;
 
-
-CXmlDocSource::CXmlDocSource(_xmlDoc *pDoc, bool bValidateWithSchema,
-                             _xmlNode *pRootNode) :
-      _pDoc(pDoc),
-      _pRootNode(pRootNode),
-      _strRootElementType(""),
-      _strRootElementName(""),
-      _strNameAttributeName(""),
-      _bValidateWithSchema(bValidateWithSchema)
+CXmlDocSource::CXmlDocSource(_xmlDoc *pDoc, bool bValidateWithSchema, _xmlNode *pRootNode)
+    : _pDoc(pDoc), _pRootNode(pRootNode), _strRootElementType(""), _strRootElementName(""),
+      _strNameAttributeName(""), _bValidateWithSchema(bValidateWithSchema)
 {
 }
 
 CXmlDocSource::CXmlDocSource(_xmlDoc *pDoc, bool bValidateWithSchema,
-                             const string& strRootElementType,
-                             const string& strRootElementName,
-                             const string& strNameAttributeName) :
-    _pDoc(pDoc),
-    _pRootNode(xmlDocGetRootElement(pDoc)),
-    _strRootElementType(strRootElementType),
-    _strRootElementName(strRootElementName),
-    _strNameAttributeName(strNameAttributeName),
-    _bValidateWithSchema(bValidateWithSchema)
+                             const string &strRootElementType, const string &strRootElementName,
+                             const string &strNameAttributeName)
+    : _pDoc(pDoc), _pRootNode(xmlDocGetRootElement(pDoc)), _strRootElementType(strRootElementType),
+      _strRootElementName(strRootElementName), _strNameAttributeName(strNameAttributeName),
+      _bValidateWithSchema(bValidateWithSchema)
 {
 }
 
@@ -75,17 +65,17 @@ CXmlDocSource::~CXmlDocSource()
     }
 }
 
-void CXmlDocSource::getRootElement(CXmlElement& xmlRootElement) const
+void CXmlDocSource::getRootElement(CXmlElement &xmlRootElement) const
 {
     xmlRootElement.setXmlElement(_pRootNode);
 }
 
 string CXmlDocSource::getRootElementName() const
 {
-    return (const char*)_pRootNode->name;
+    return (const char *)_pRootNode->name;
 }
 
-string CXmlDocSource::getRootElementAttributeString(const string& strAttributeName) const
+string CXmlDocSource::getRootElementAttributeString(const string &strAttributeName) const
 {
     CXmlElement topMostElement(_pRootNode);
 
@@ -96,10 +86,11 @@ string CXmlDocSource::getRootElementAttributeString(const string& strAttributeNa
 
 string CXmlDocSource::getSchemaUri() const
 {
-    return mkUri(string((const char *)_pDoc->URL), getRootElementAttributeString("noNamespaceSchemaLocation"));
+    return mkUri(string((const char *)_pDoc->URL),
+                 getRootElementAttributeString("noNamespaceSchemaLocation"));
 }
 
-_xmlDoc* CXmlDocSource::getDoc() const
+_xmlDoc *CXmlDocSource::getDoc() const
 {
     return _pDoc;
 }
@@ -110,7 +101,7 @@ bool CXmlDocSource::isParsable() const
     return _pDoc != NULL;
 }
 
-bool CXmlDocSource::populate(CXmlSerializingContext& serializingContext)
+bool CXmlDocSource::populate(CXmlSerializingContext &serializingContext)
 {
     // Check that the doc has been created
     if (!_pDoc) {
@@ -121,8 +112,7 @@ bool CXmlDocSource::populate(CXmlSerializingContext& serializingContext)
     }
 
     // Validate if necessary
-    if (_bValidateWithSchema)
-    {
+    if (_bValidateWithSchema) {
         if (!isInstanceDocumentValid()) {
 
             serializingContext.setError("Document is not valid");
@@ -135,8 +125,8 @@ bool CXmlDocSource::populate(CXmlSerializingContext& serializingContext)
     if (getRootElementName() != _strRootElementType) {
 
         serializingContext.setError("Error: Wrong XML structure document ");
-        serializingContext.appendLineToError("Root Element " + getRootElementName()
-                                             + " mismatches expected type " + _strRootElementType);
+        serializingContext.appendLineToError("Root Element " + getRootElementName() +
+                                             " mismatches expected type " + _strRootElementType);
 
         return false;
     }
@@ -149,10 +139,9 @@ bool CXmlDocSource::populate(CXmlSerializingContext& serializingContext)
         if (!_strRootElementName.empty() && strRootElementNameCheck != _strRootElementName) {
 
             serializingContext.setError("Error: Wrong XML structure document ");
-            serializingContext.appendLineToError(_strRootElementType + " element "
-                                                 + _strRootElementName + " mismatches expected "
-                                                 + _strRootElementType + " type "
-                                                 + strRootElementNameCheck);
+            serializingContext.appendLineToError(
+                _strRootElementType + " element " + _strRootElementName + " mismatches expected " +
+                _strRootElementType + " type " + strRootElementNameCheck);
 
             return false;
         }
@@ -216,22 +205,23 @@ bool CXmlDocSource::isInstanceDocumentValid()
 #endif
 }
 
-std::string CXmlDocSource::mkUri(const std::string& base, const std::string& relative)
+std::string CXmlDocSource::mkUri(const std::string &base, const std::string &relative)
 {
     xml_unique_ptr baseUri(xmlPathToURI((const xmlChar *)base.c_str()), xmlFree);
     xml_unique_ptr relativeUri(xmlPathToURI((const xmlChar *)relative.c_str()), xmlFree);
     /* return null pointer if baseUri or relativeUri are null pointer  */
     xml_unique_ptr xmlUri(xmlBuildURI(relativeUri.get(), baseUri.get()), xmlFree);
 
-    ALWAYS_ASSERT(xmlUri != nullptr, "unable to make URI from: \""
-                                      << base << "\" and \"" << relative << "\"");
+    ALWAYS_ASSERT(xmlUri != nullptr, "unable to make URI from: \"" << base << "\" and \""
+                                                                   << relative << "\"");
 
     return (const char *)xmlUri.get();
 }
 
-_xmlDoc* CXmlDocSource::mkXmlDoc(const string& source, bool fromFile, bool xincludes, CXmlSerializingContext& serializingContext)
+_xmlDoc *CXmlDocSource::mkXmlDoc(const string &source, bool fromFile, bool xincludes,
+                                 CXmlSerializingContext &serializingContext)
 {
-    _xmlDoc* doc = NULL;
+    _xmlDoc *doc = NULL;
     if (fromFile) {
         doc = xmlReadFile(source.c_str(), NULL, 0);
     } else {

--- a/xmlserializer/XmlDocSource.h
+++ b/xmlserializer/XmlDocSource.h
@@ -57,7 +57,7 @@ public:
       * @param[in] pRootNode a pointer to the root element of the document.
       * @param[in] bValidateWithSchema a boolean that toggles schema validation
       */
-    CXmlDocSource(_xmlDoc* pDoc, bool bValidateWithSchema = false, _xmlNode* pRootNode = NULL);
+    CXmlDocSource(_xmlDoc *pDoc, bool bValidateWithSchema = false, _xmlNode *pRootNode = NULL);
 
     /**
       * Constructor
@@ -69,10 +69,10 @@ public:
       * @param[in] strNameAttributeName a string containing the name of the root name attribute
       * @param[in] bValidateWithSchema a boolean that toggles schema validation
       */
-    CXmlDocSource(_xmlDoc* pDoc, bool bValidateWithSchema,
-                           const std::string& strRootElementType = "",
-                           const std::string& strRootElementName = "",
-                           const std::string& strNameAttributeName = "");
+    CXmlDocSource(_xmlDoc *pDoc, bool bValidateWithSchema,
+                  const std::string &strRootElementType = "",
+                  const std::string &strRootElementName = "",
+                  const std::string &strNameAttributeName = "");
 
     /**
       * Destructor
@@ -86,14 +86,14 @@ public:
       *
       * @return false if there are any error
       */
-    virtual bool populate(CXmlSerializingContext& serializingContext);
+    virtual bool populate(CXmlSerializingContext &serializingContext);
 
     /**
       * Method that returns the root element of the Xml tree.
       *
       * @param[out] xmlRootElement a reference to the CXmleElement destination
       */
-    void getRootElement(CXmlElement& xmlRootElement) const;
+    void getRootElement(CXmlElement &xmlRootElement) const;
 
     /**
       * Getter method.
@@ -117,7 +117,7 @@ public:
       *
       * @return the value of the root's attribute named as strAttributeName
       */
-    std::string getRootElementAttributeString(const std::string& strAttributeName) const;
+    std::string getRootElementAttributeString(const std::string &strAttributeName) const;
 
     /**
       * Getter method.
@@ -126,7 +126,7 @@ public:
       *
       * @return the document _pDoc
       */
-    _xmlDoc* getDoc() const;
+    _xmlDoc *getDoc() const;
 
     /**
     * Method that checks that the xml document has been correctly parsed.
@@ -150,7 +150,7 @@ public:
     *
     * @return new made URI if succeeded relative input otherwise
      */
-    static std::string mkUri(const std::string& base, const std::string& relative);
+    static std::string mkUri(const std::string &base, const std::string &relative);
 
     /**
      * Helper method for creating an xml document from either a file or a
@@ -162,22 +162,21 @@ public:
      * @param[in] xincludes if true, process xincludes tags
      * @param[in] serializingContext will receive any serialization error
      */
-    static _xmlDoc* mkXmlDoc(const std::string& source, bool fromFile, bool xincludes, CXmlSerializingContext& serializingContext);
+    static _xmlDoc *mkXmlDoc(const std::string &source, bool fromFile, bool xincludes,
+                             CXmlSerializingContext &serializingContext);
 
 protected:
-
     /**
       * Doc
       */
-    _xmlDoc* _pDoc;
+    _xmlDoc *_pDoc;
 
     /**
       * Root node
       */
-    _xmlNode* _pRootNode;
+    _xmlNode *_pRootNode;
 
 private:
-
     /** Method that check the validity of the document with the xsd file.
       *
       * @return true if document is valid, false if any error occures

--- a/xmlserializer/XmlElement.cpp
+++ b/xmlserializer/XmlElement.cpp
@@ -34,7 +34,7 @@
 
 using std::string;
 
-CXmlElement::CXmlElement(_xmlNode* pXmlElement) : _pXmlElement(pXmlElement)
+CXmlElement::CXmlElement(_xmlNode *pXmlElement) : _pXmlElement(pXmlElement)
 {
 }
 
@@ -42,14 +42,14 @@ CXmlElement::CXmlElement() : _pXmlElement(NULL)
 {
 }
 
-void CXmlElement::setXmlElement(_xmlNode* pXmlElement)
+void CXmlElement::setXmlElement(_xmlNode *pXmlElement)
 {
     _pXmlElement = pXmlElement;
 }
 
 string CXmlElement::getType() const
 {
-    return (const char*)_pXmlElement->name;
+    return (const char *)_pXmlElement->name;
 }
 
 string CXmlElement::getPath() const
@@ -71,9 +71,9 @@ string CXmlElement::getPath() const
     return strPathElement;
 }
 
-bool CXmlElement::hasAttribute(const string& strAttributeName) const
+bool CXmlElement::hasAttribute(const string &strAttributeName) const
 {
-    return xmlHasProp(_pXmlElement, (const xmlChar*)strAttributeName.c_str()) != NULL;
+    return xmlHasProp(_pXmlElement, (const xmlChar *)strAttributeName.c_str()) != NULL;
 }
 
 template <>
@@ -84,13 +84,13 @@ bool CXmlElement::getAttribute<std::string>(const string &name, string &value) c
     }
 
     string backup = value;
-    xmlChar* pucXmlValue = xmlGetProp((xmlNode*)_pXmlElement, (const xmlChar*)name.c_str());
+    xmlChar *pucXmlValue = xmlGetProp((xmlNode *)_pXmlElement, (const xmlChar *)name.c_str());
     if (pucXmlValue == NULL) {
         value = backup;
         return false;
     }
 
-    value = (const char*)pucXmlValue;
+    value = (const char *)pucXmlValue;
 
     xmlFree(pucXmlValue);
 
@@ -123,19 +123,19 @@ string CXmlElement::getNameAttribute() const
 
 string CXmlElement::getTextContent() const
 {
-    xmlChar* pucXmlContent = xmlNodeGetContent(_pXmlElement);
+    xmlChar *pucXmlContent = xmlNodeGetContent(_pXmlElement);
     if (pucXmlContent == NULL) {
         return "";
     }
 
-    string strContent((const char*)pucXmlContent);
+    string strContent((const char *)pucXmlContent);
 
     xmlFree(pucXmlContent);
 
     return strContent;
 }
 
-bool CXmlElement::getChildElement(const string& strType, CXmlElement& childElement) const
+bool CXmlElement::getChildElement(const string &strType, CXmlElement &childElement) const
 {
     CChildIterator childIterator(*this);
 
@@ -149,13 +149,15 @@ bool CXmlElement::getChildElement(const string& strType, CXmlElement& childEleme
     return false;
 }
 
-bool CXmlElement::getChildElement(const string& strType, const string& strNameAttribute, CXmlElement& childElement) const
+bool CXmlElement::getChildElement(const string &strType, const string &strNameAttribute,
+                                  CXmlElement &childElement) const
 {
     CChildIterator childIterator(*this);
 
     while (childIterator.next(childElement)) {
 
-        if ((childElement.getType() == strType) && (childElement.getNameAttribute() == strNameAttribute)) {
+        if ((childElement.getType() == strType) &&
+            (childElement.getNameAttribute() == strNameAttribute)) {
 
             return true;
         }
@@ -177,9 +179,9 @@ size_t CXmlElement::getNbChildElements() const
     return uiNbChildren;
 }
 
-bool CXmlElement::getParentElement(CXmlElement& parentElement) const
+bool CXmlElement::getParentElement(CXmlElement &parentElement) const
 {
-    _xmlNode* pXmlNode = _pXmlElement->parent;
+    _xmlNode *pXmlNode = _pXmlElement->parent;
 
     if (pXmlNode->type == XML_ELEMENT_NODE) {
 
@@ -191,7 +193,7 @@ bool CXmlElement::getParentElement(CXmlElement& parentElement) const
 }
 
 template <>
-void CXmlElement::setAttribute<bool>(const string& name, const bool &value)
+void CXmlElement::setAttribute<bool>(const string &name, const bool &value)
 {
     setAttribute(name, value ? "true" : "false");
 }
@@ -213,23 +215,23 @@ void CXmlElement::setAttribute(const string &name, const char *value)
 }
 
 template <typename T>
-void CXmlElement::setAttribute(const std::string& name, const T &value)
+void CXmlElement::setAttribute(const std::string &name, const T &value)
 {
     setAttribute(name, std::to_string(value).c_str());
 }
 
-void CXmlElement::setNameAttribute(const string& strValue)
+void CXmlElement::setNameAttribute(const string &strValue)
 {
     setAttribute("Name", strValue);
 }
 
-void CXmlElement::setTextContent(const string& strContent)
+void CXmlElement::setTextContent(const string &strContent)
 {
     xmlAddChild(_pXmlElement, xmlNewText(BAD_CAST strContent.c_str()));
 }
 
 // Child creation
-void CXmlElement::createChild(CXmlElement& childElement, const string& strType)
+void CXmlElement::createChild(CXmlElement &childElement, const string &strType)
 {
 #ifdef LIBXML_TREE_ENABLED
     xmlNodePtr pChildNode = xmlNewChild(_pXmlElement, NULL, BAD_CAST strType.c_str(), NULL);
@@ -239,11 +241,12 @@ void CXmlElement::createChild(CXmlElement& childElement, const string& strType)
 }
 
 // Child iteration
-CXmlElement::CChildIterator::CChildIterator(const CXmlElement& xmlElement) : _pCurNode(xmlElement._pXmlElement->children)
+CXmlElement::CChildIterator::CChildIterator(const CXmlElement &xmlElement)
+    : _pCurNode(xmlElement._pXmlElement->children)
 {
 }
 
-bool CXmlElement::CChildIterator::next(CXmlElement& xmlChildElement)
+bool CXmlElement::CChildIterator::next(CXmlElement &xmlChildElement)
 {
     while (_pCurNode) {
 
@@ -270,9 +273,9 @@ template bool CXmlElement::getAttribute(const std::string &name, bool &value) co
 template bool CXmlElement::getAttribute(const std::string &name, double &value) const;
 template bool CXmlElement::getAttribute(const std::string &name, float &value) const;
 
-template void CXmlElement::setAttribute(const std::string& name, const std::string &value);
-template void CXmlElement::setAttribute(const std::string& name, const bool &value);
-template void CXmlElement::setAttribute(const std::string& name, const int32_t &value);
-template void CXmlElement::setAttribute(const std::string& name, const uint32_t &value);
-template void CXmlElement::setAttribute(const std::string& name, const uint64_t &value);
-template void CXmlElement::setAttribute(const std::string& name, const float &value);
+template void CXmlElement::setAttribute(const std::string &name, const std::string &value);
+template void CXmlElement::setAttribute(const std::string &name, const bool &value);
+template void CXmlElement::setAttribute(const std::string &name, const int32_t &value);
+template void CXmlElement::setAttribute(const std::string &name, const uint32_t &value);
+template void CXmlElement::setAttribute(const std::string &name, const uint64_t &value);
+template void CXmlElement::setAttribute(const std::string &name, const float &value);

--- a/xmlserializer/XmlElement.h
+++ b/xmlserializer/XmlElement.h
@@ -38,77 +38,80 @@ struct _xmlDoc;
 class CXmlElement
 {
     friend class CChildIterator;
+
 public:
-    CXmlElement(_xmlNode* pXmlElement);
+    CXmlElement(_xmlNode *pXmlElement);
     CXmlElement();
 
     // Xml element
-    void setXmlElement(_xmlNode* pXmlElement);
+    void setXmlElement(_xmlNode *pXmlElement);
 
     // Getters
     std::string getType() const;
     std::string getPath() const;
     std::string getNameAttribute() const;
-    bool hasAttribute(const std::string& strAttributeName) const;
+    bool hasAttribute(const std::string &strAttributeName) const;
 
-     /** Get attribute
-      *
-      * If the attribute does not exists or there is a libxml2 error while
-      * reading it or conversion from string to T fails, false is returned. In
-      * case of failure, the content of value is the same as before calling
-      * this method.
-      *
-      * Note: if T==string, no conversion takes place.
-      *
-      * @tparam T the type of the value to retrieve
-      * @param[in] name The attribute name
-      * @param[out] value The attribute value
-      * @return true if success, false otherwise
-      */
+    /** Get attribute
+     *
+     * If the attribute does not exists or there is a libxml2 error while
+     * reading it or conversion from string to T fails, false is returned. In
+     * case of failure, the content of value is the same as before calling
+     * this method.
+     *
+     * Note: if T==string, no conversion takes place.
+     *
+     * @tparam T the type of the value to retrieve
+     * @param[in] name The attribute name
+     * @param[out] value The attribute value
+     * @return true if success, false otherwise
+     */
     template <typename T>
     bool getAttribute(const std::string &name, T &value) const;
 
     std::string getTextContent() const;
 
     // Navigation
-    bool getChildElement(const std::string& strType, CXmlElement& childElement) const;
-    bool getChildElement(const std::string& strType, const std::string& strNameAttribute, CXmlElement& childElement) const;
+    bool getChildElement(const std::string &strType, CXmlElement &childElement) const;
+    bool getChildElement(const std::string &strType, const std::string &strNameAttribute,
+                         CXmlElement &childElement) const;
     size_t getNbChildElements() const;
-    bool getParentElement(CXmlElement& parentElement) const;
+    bool getParentElement(CXmlElement &parentElement) const;
 
-     /** Set attribute
-      *
-      * @tparam T the type of the value to retrieve
-      * @param[in] name The attribute name
-      * @param[in] value The attribute value
-      */
+    /** Set attribute
+     *
+     * @tparam T the type of the value to retrieve
+     * @param[in] name The attribute name
+     * @param[in] value The attribute value
+     */
     template <typename T>
-    void setAttribute(const std::string& name, const T &value);
-     /** Set attribute - special case for C-style strings
-      *
-      * @param[in] name The attribute name
-      * @param[in] value The attribute value
-      */
-    void setAttribute(const std::string& name, const char *value);
+    void setAttribute(const std::string &name, const T &value);
+    /** Set attribute - special case for C-style strings
+     *
+     * @param[in] name The attribute name
+     * @param[in] value The attribute value
+     */
+    void setAttribute(const std::string &name, const char *value);
 
-    void setNameAttribute(const std::string& strValue);
-    void setTextContent(const std::string& strContent);
+    void setNameAttribute(const std::string &strValue);
+    void setTextContent(const std::string &strContent);
 
     // Child creation
-    void createChild(CXmlElement& childElement, const std::string& strType);
+    void createChild(CXmlElement &childElement, const std::string &strType);
 
 public:
     // Child iteration
     class CChildIterator
     {
     public:
-        CChildIterator(const CXmlElement& xmlElement);
+        CChildIterator(const CXmlElement &xmlElement);
 
-        bool next(CXmlElement& xmlChildElement);
+        bool next(CXmlElement &xmlChildElement);
+
     private:
-        _xmlNode* _pCurNode;
+        _xmlNode *_pCurNode;
     };
 
 private:
-    _xmlNode* _pXmlElement;
+    _xmlNode *_pXmlElement;
 };

--- a/xmlserializer/XmlMemoryDocSink.cpp
+++ b/xmlserializer/XmlMemoryDocSink.cpp
@@ -32,13 +32,12 @@
 
 #define base CXmlDocSink
 
-CXmlMemoryDocSink::CXmlMemoryDocSink(IXmlSink* pXmlSink):
-    _pXmlSink(pXmlSink)
+CXmlMemoryDocSink::CXmlMemoryDocSink(IXmlSink *pXmlSink) : _pXmlSink(pXmlSink)
 {
 }
 
-bool CXmlMemoryDocSink::doProcess(CXmlDocSource& xmlDocSource,
-                                  CXmlSerializingContext& serializingContext)
+bool CXmlMemoryDocSink::doProcess(CXmlDocSource &xmlDocSource,
+                                  CXmlSerializingContext &serializingContext)
 {
 
     CXmlElement docElement;

--- a/xmlserializer/XmlMemoryDocSink.h
+++ b/xmlserializer/XmlMemoryDocSink.h
@@ -44,7 +44,7 @@ public:
       * @param[out] pXmlSink a pointer to a parameter-framework structure that can parse an xml
       * description to instanciate itself
       */
-    CXmlMemoryDocSink(IXmlSink* pXmlSink);
+    CXmlMemoryDocSink(IXmlSink *pXmlSink);
 
 private:
     /**
@@ -57,8 +57,8 @@ private:
       *
       * @return false if any error occurs
       */
-    virtual bool doProcess(CXmlDocSource& xmlDocSource, CXmlSerializingContext& serializingContext);
+    virtual bool doProcess(CXmlDocSource &xmlDocSource, CXmlSerializingContext &serializingContext);
 
     // Xml Sink
-    IXmlSink* _pXmlSink;
+    IXmlSink *_pXmlSink;
 };

--- a/xmlserializer/XmlMemoryDocSource.cpp
+++ b/xmlserializer/XmlMemoryDocSource.cpp
@@ -34,16 +34,14 @@
 
 #define base CXmlDocSource
 
-CXmlMemoryDocSource::CXmlMemoryDocSource(const IXmlSource* pXmlSource, bool bValidateWithSchema,
-                                         const std::string& strRootElementType,
-                                         const std::string& schemaBaseUri,
-                                         const std::string& strProduct,
-                                         const std::string& strVersion):
-     base(xmlNewDoc(BAD_CAST "1.0"), bValidateWithSchema,
-          xmlNewNode(NULL, BAD_CAST strRootElementType.c_str())),
-     _pXmlSource(pXmlSource),
-     _strProduct(strProduct),
-     _strVersion(strVersion)
+CXmlMemoryDocSource::CXmlMemoryDocSource(const IXmlSource *pXmlSource, bool bValidateWithSchema,
+                                         const std::string &strRootElementType,
+                                         const std::string &schemaBaseUri,
+                                         const std::string &strProduct,
+                                         const std::string &strVersion)
+    : base(xmlNewDoc(BAD_CAST "1.0"), bValidateWithSchema,
+           xmlNewNode(NULL, BAD_CAST strRootElementType.c_str())),
+      _pXmlSource(pXmlSource), _strProduct(strProduct), _strVersion(strVersion)
 {
     // Get Schema file
     _strXmlSchemaFile = CXmlDocSource::mkUri(schemaBaseUri, strRootElementType + ".xsd");
@@ -60,7 +58,7 @@ void CXmlMemoryDocSource::init()
 #endif
 }
 
-bool CXmlMemoryDocSource::populate(CXmlSerializingContext& serializingContext)
+bool CXmlMemoryDocSource::populate(CXmlSerializingContext &serializingContext)
 {
 #ifndef LIBXML_TREE_ENABLED
     serializingContext.setError("XML file exporting feature unsupported on this image. " +
@@ -71,7 +69,7 @@ bool CXmlMemoryDocSource::populate(CXmlSerializingContext& serializingContext)
 #endif
 
     // Create Xml element with the Doc
-     CXmlElement docElement(_pRootNode);
+    CXmlElement docElement(_pRootNode);
 
     if (!_strXmlSchemaFile.empty()) {
 

--- a/xmlserializer/XmlMemoryDocSource.h
+++ b/xmlserializer/XmlMemoryDocSource.h
@@ -50,11 +50,10 @@ public:
       * @param[in] strVersion a string containing the version number
       * @param[in] bValidateWithSchema a boolean that toggles schema validation
       */
-    CXmlMemoryDocSource(const IXmlSource* pXmlSource, bool bValidateWithSchema,
-                        const std::string& strRootElementType,
-                        const std::string& schemaBaseUri = "",
-                        const std::string& strProduct = "",
-                        const std::string& strVersion = "");
+    CXmlMemoryDocSource(const IXmlSource *pXmlSource, bool bValidateWithSchema,
+                        const std::string &strRootElementType,
+                        const std::string &schemaBaseUri = "", const std::string &strProduct = "",
+                        const std::string &strVersion = "");
 
     /**
       * Implementation of CXmlDocSource::populate() method.
@@ -64,9 +63,9 @@ public:
       *
       * @return false if any error occurs
       */
-    virtual bool populate(CXmlSerializingContext& serializingContext);
-private:
+    virtual bool populate(CXmlSerializingContext &serializingContext);
 
+private:
     /**
       * Initialize root element
       */
@@ -75,7 +74,7 @@ private:
     /**
       * Xml Source
       */
-    const IXmlSource* _pXmlSource;
+    const IXmlSource *_pXmlSource;
 
     /**
       * Schema file

--- a/xmlserializer/XmlSerializingContext.cpp
+++ b/xmlserializer/XmlSerializingContext.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
@@ -31,7 +31,7 @@
 #include <libxml/xmlerror.h>
 #include <cstdio>
 
-CXmlSerializingContext::CXmlSerializingContext(std::string& strError)
+CXmlSerializingContext::CXmlSerializingContext(std::string &strError)
     : utility::ErrorContext(strError)
 {
     xmlSetStructuredErrorFunc(this, structuredErrorHandler);
@@ -44,7 +44,7 @@ CXmlSerializingContext::~CXmlSerializingContext()
     prependToError(_strXmlError);
 }
 
-void CXmlSerializingContext::appendLineToError(const std::string& strAppend)
+void CXmlSerializingContext::appendLineToError(const std::string &strAppend)
 {
     appendToError("\n" + strAppend);
 }
@@ -55,13 +55,12 @@ void CXmlSerializingContext::appendLineToError(const std::string& strAppend)
   * @param[in] format is the xml error output format
   *
   */
-void CXmlSerializingContext::structuredErrorHandler(void* userData, xmlErrorPtr error)
+void CXmlSerializingContext::structuredErrorHandler(void *userData, xmlErrorPtr error)
 {
     CXmlSerializingContext *self = static_cast<CXmlSerializingContext *>(userData);
 
     std::string filename = (error->file != NULL) ? error->file : "(user input)";
     // xmlErrorPtr->int2 contains the column; see xmlerror.h
-    self->_strXmlError += filename + ":" +
-                          std::to_string(error->line) + ":" + std::to_string(error->int2) + ": " +
-                          error->message;
+    self->_strXmlError += filename + ":" + std::to_string(error->line) + ":" +
+                          std::to_string(error->int2) + ": " + error->message;
 }

--- a/xmlserializer/XmlSerializingContext.h
+++ b/xmlserializer/XmlSerializingContext.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2015, Intel Corporation
  * All rights reserved.
  *
@@ -49,11 +49,11 @@ struct _xmlError;
 class CXmlSerializingContext : public utility::ErrorContext
 {
 public:
-    CXmlSerializingContext(std::string& strError);
+    CXmlSerializingContext(std::string &strError);
     ~CXmlSerializingContext();
 
     // Error
-    void appendLineToError(const std::string& strAppend);
+    void appendLineToError(const std::string &strAppend);
 
     /** XML error handler
       *
@@ -61,7 +61,7 @@ public:
       * @param[in] format is the xml error output format
       *
       */
-    static void structuredErrorHandler(void* userData, _xmlError *error);
+    static void structuredErrorHandler(void *userData, _xmlError *error);
 
 private:
     std::string _strXmlError;

--- a/xmlserializer/XmlSink.h
+++ b/xmlserializer/XmlSink.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -35,7 +35,8 @@
 class IXmlSink
 {
 public:
-    virtual bool fromXml(const CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) = 0;
+    virtual bool fromXml(const CXmlElement &xmlElement,
+                         CXmlSerializingContext &serializingContext) = 0;
 
 protected:
     virtual ~IXmlSink() {}

--- a/xmlserializer/XmlSource.h
+++ b/xmlserializer/XmlSource.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2011-2014, Intel Corporation
  * All rights reserved.
  *
@@ -35,7 +35,8 @@
 class IXmlSource
 {
 public:
-    virtual void toXml(CXmlElement& xmlElement, CXmlSerializingContext& serializingContext) const = 0;
+    virtual void toXml(CXmlElement &xmlElement,
+                       CXmlSerializingContext &serializingContext) const = 0;
 
 protected:
     virtual ~IXmlSource() {}

--- a/xmlserializer/XmlStreamDocSink.cpp
+++ b/xmlserializer/XmlStreamDocSink.cpp
@@ -32,15 +32,14 @@
 
 #define base CXmlDocSink
 
-CXmlStreamDocSink::CXmlStreamDocSink(std::ostream& output):
-    _output(output)
+CXmlStreamDocSink::CXmlStreamDocSink(std::ostream &output) : _output(output)
 {
 }
 
-bool CXmlStreamDocSink::doProcess(CXmlDocSource& xmlDocSource,
-                                  CXmlSerializingContext& serializingContext)
+bool CXmlStreamDocSink::doProcess(CXmlDocSource &xmlDocSource,
+                                  CXmlSerializingContext &serializingContext)
 {
-    xmlChar* dumpedDoc = NULL;
+    xmlChar *dumpedDoc = NULL;
 
     int iSize;
     xmlDocDumpFormatMemoryEnc(xmlDocSource.getDoc(), &dumpedDoc, &iSize, "UTF-8", 1);
@@ -52,7 +51,7 @@ bool CXmlStreamDocSink::doProcess(CXmlDocSource& xmlDocSource,
         return false;
     }
 
-    _output << static_cast<unsigned char*>(dumpedDoc);
+    _output << static_cast<unsigned char *>(dumpedDoc);
 
     xmlFree(dumpedDoc);
 

--- a/xmlserializer/XmlStreamDocSink.h
+++ b/xmlserializer/XmlStreamDocSink.h
@@ -44,7 +44,7 @@ public:
       *
       * @param[out] output a reference to a ostream that will be filled by the doProcess method
       */
-    CXmlStreamDocSink(std::ostream& output);
+    CXmlStreamDocSink(std::ostream &output);
 
 private:
     /** Implementation of CXmlDocSink::doProcess()
@@ -55,11 +55,10 @@ private:
       *
       * @return false if any error occurs
       */
-    virtual bool doProcess(CXmlDocSource& xmlDocSource, CXmlSerializingContext& serializingContext);
+    virtual bool doProcess(CXmlDocSource &xmlDocSource, CXmlSerializingContext &serializingContext);
 
     /**
       * Result ostream containing the XML informations
       */
-    std::ostream& _output;
+    std::ostream &_output;
 };
-

--- a/xmlserializer/XmlUtil.cpp
+++ b/xmlserializer/XmlUtil.cpp
@@ -39,7 +39,8 @@ public:
      * @see http://xmlsoft.org/threads.html
      * @see http://www.programmershare.com/1669782/
      */
-    CXmlUtil() {
+    CXmlUtil()
+    {
         xmlInitParser();
         atexit(xmlCleanupParser);
     }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/319%23issuecomment-163186769%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23issuecomment-163270521%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23issuecomment-163334818%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23issuecomment-163335457%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46933755%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46933805%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46934050%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46934059%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46934301%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46934476%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46962510%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46962594%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r47062208%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r47062285%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r47062372%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/319%23issuecomment-163186769%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%40dawagner%20%20%40krocard%20%20Plz%20review%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A49%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T14%3A48%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%40dawagner%20%40krocard%20Plz%20review%22%2C%20%22created_at%22%3A%20%222015-12-09T17%3A37%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-12-09T17%3A40%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20790249c98931418ce8b43e4bb6eb9e451948cac3%20bindings/c/Test.cpp%2085%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46934050%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20this%20put%20on%20a%20separate%20line%3F%22%2C%20%22created_at%22%3A%20%222015-12-08T10%3A00%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agree%20but%20I%20don%27t%20know%20to%20avoid%20it.%20I%20think%20that%20clang-format%20doesn%27t%20like%20multiline%20strings.%22%2C%20%22created_at%22%3A%20%222015-12-09T08%3A32%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/c/Test.cpp%3AL135-196%22%7D%2C%20%22Pull%20790249c98931418ce8b43e4bb6eb9e451948cac3%20bindings/c/Test.cpp%2093%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46934059%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ditto%22%2C%20%22created_at%22%3A%20%222015-12-08T10%3A00%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/c/Test.cpp%3AL135-196%22%7D%2C%20%22Pull%20790249c98931418ce8b43e4bb6eb9e451948cac3%20parameter/AreaConfiguration.cpp%20124%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46934301%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20get%20that%20we%20want%20this%20for%20methods%20defined%20in%20headers%20%28for%20concision%29%20but%20it%20is%20against%20our%20coding%20style%20to%20do%20it%20in%20source%20files.%20Is%20there%20a%20way%20to%20selectively%20turn%20it%20on%3F%22%2C%20%22created_at%22%3A%20%222015-12-08T10%3A03%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20it%27s%20not%20possible%20to%20discriminate%20headers/source.%20So%20we%20have%20to%20choose.%22%2C%20%22created_at%22%3A%20%222015-12-09T08%3A30%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/AreaConfiguration.cpp%3AL128-174%22%7D%2C%20%22Pull%20790249c98931418ce8b43e4bb6eb9e451948cac3%20bindings/c/ParameterFramework.h%20105%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46933805%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20isn%27t%20this%20particular%20asterisk%20correctly%20aligned%3F%22%2C%20%22created_at%22%3A%20%222015-12-08T09%3A58%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-12-08T14%3A59%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/c/ParameterFramework.h%3AL192-200%22%7D%2C%20%22Pull%20790249c98931418ce8b43e4bb6eb9e451948cac3%20parameter/ArrayParameter.cpp%20291%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46934476%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Wow%2C%20this%20line%20break%20is%20really%20strange.%22%2C%20%22created_at%22%3A%20%222015-12-08T10%3A05%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agree%2C%20I%20don%27t%20have%20found%20an%20option%20to%20avoid%20it.%22%2C%20%22created_at%22%3A%20%222015-12-09T08%3A31%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ArrayParameter.cpp%3AL426-444%22%7D%2C%20%22Pull%20790249c98931418ce8b43e4bb6eb9e451948cac3%20bindings/c/ParameterFramework.h%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/319%23discussion_r46933755%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Wrongfully%20aligned%20comment.%22%2C%20%22created_at%22%3A%20%222015-12-08T09%3A57%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-12-08T14%3A59%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20bindings/c/ParameterFramework.h%3AL113-138%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/dawagner%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%7D%2C%20%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/dawagner'><img src='https://avatars.githubusercontent.com/u/6430928?v=3' width=34 height=34></a><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 790249c98931418ce8b43e4bb6eb9e451948cac3 bindings/c/ParameterFramework.h 78'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/319#discussion_r46933755'>File: bindings/c/ParameterFramework.h:L113-138</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Wrongfully aligned comment.
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> fixed
- [ ] <a href='#crh-comment-Pull 790249c98931418ce8b43e4bb6eb9e451948cac3 bindings/c/ParameterFramework.h 105'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/319#discussion_r46933805'>File: bindings/c/ParameterFramework.h:L192-200</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Why isn't this particular asterisk correctly aligned?
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> fixed
- [ ] <a href='#crh-comment-Pull 790249c98931418ce8b43e4bb6eb9e451948cac3 bindings/c/Test.cpp 85'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/319#discussion_r46934050'>File: bindings/c/Test.cpp:L135-196</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Why is this put on a separate line?
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> I agree but I don't know to avoid it. I think that clang-format doesn't like multiline strings.
- [ ] <a href='#crh-comment-Pull 790249c98931418ce8b43e4bb6eb9e451948cac3 bindings/c/Test.cpp 93'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/319#discussion_r46934059'>File: bindings/c/Test.cpp:L135-196</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> ditto
- [ ] <a href='#crh-comment-Pull 790249c98931418ce8b43e4bb6eb9e451948cac3 parameter/AreaConfiguration.cpp 124'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/319#discussion_r46934301'>File: parameter/AreaConfiguration.cpp:L128-174</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I get that we want this for methods defined in headers (for concision) but it is against our coding style to do it in source files. Is there a way to selectively turn it on?
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> No it's not possible to discriminate headers/source. So we have to choose.
- [ ] <a href='#crh-comment-Pull 790249c98931418ce8b43e4bb6eb9e451948cac3 parameter/ArrayParameter.cpp 291'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/319#discussion_r46934476'>File: parameter/ArrayParameter.cpp:L426-444</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Wow, this line break is really strange.
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> I agree, I don't have found an option to avoid it.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/319#issuecomment-163186769'>General Comment</a></b>
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :+1:
@dawagner  @krocard  Plz review
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :+1:
@dawagner @krocard Plz review


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/319?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/319?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/319?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/319'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>