### PR TITLE
[review] Allow a client to send "remote" commands programatically

### DIFF
--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(parameter SHARED
     BitParameterType.cpp
     BitwiseAreaConfiguration.cpp
     BooleanParameterType.cpp
+    CommandHandlerWrapper.cpp
     ComponentInstance.cpp
     ComponentLibrary.cpp
     ComponentType.cpp
@@ -107,7 +108,7 @@ generate_export_header(parameter)
 target_link_libraries(parameter
     # Unfortunatly xmlSink and xmlSource need to be exposed to the plugins
     PUBLIC xmlserializer
-    PRIVATE remote-processor pfw_utility
+    PRIVATE pfw_utility remote-processor
     PRIVATE ${CMAKE_DL_LIBS})
 
 target_include_directories(parameter
@@ -121,6 +122,7 @@ install(TARGETS parameter LIBRARY DESTINATION lib RUNTIME DESTINATION bin ARCHIV
 # Client headers
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/parameter_export.h"
+    include/CommandHandlerInterface.h
     include/ElementHandle.h
     include/ParameterHandle.h
     include/ParameterMgrLoggerForward.h

--- a/parameter/CommandHandlerWrapper.cpp
+++ b/parameter/CommandHandlerWrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,45 +27,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "RemoteProcessorServer.h"
-#include <memory>
-#include <future>
 
-class BackgroundRemoteProcessorServer final : public IRemoteProcessorServerInterface
+#include "CommandHandlerWrapper.h"
+#include <RequestMessage.h>
+
+CommandHandlerWrapper::CommandHandlerWrapper(std::unique_ptr<IRemoteCommandHandler> &&wrapped)
+    : mWrapped(std::move(wrapped))
+{}
+
+bool CommandHandlerWrapper::process(const std::string &command,
+                                    const std::vector<std::string> &arguments,
+                                    std::string &output)
 {
-public:
-    BackgroundRemoteProcessorServer(uint16_t uiPort,
-                                    std::unique_ptr<IRemoteCommandHandler> &&commandHandler)
-        : _server(uiPort), mCommandHandler(std::move(commandHandler))
-    {
+    CRequestMessage request(command);
+
+    for (auto &arg : arguments) {
+        request.addArgument(arg);
     }
 
-    ~BackgroundRemoteProcessorServer() { stop(); }
-
-    bool start(std::string &error) override
-    {
-        if (!_server.start(error)) {
-            return false;
-        }
-        try {
-            mServerSuccess = std::async(std::launch::async, &CRemoteProcessorServer::process,
-                                        &_server, std::ref(*mCommandHandler));
-        } catch (std::exception &e) {
-            error = "Could not create a remote processor thread: " + std::string(e.what());
-            return false;
-        }
-
-        return true;
-    }
-
-    bool stop() override
-    {
-        _server.stop();
-        return mServerSuccess.get();
-    }
-
-private:
-    CRemoteProcessorServer _server;
-    std::unique_ptr<IRemoteCommandHandler> mCommandHandler;
-    std::future<bool> mServerSuccess;
-};
+    return mWrapped->remoteCommandProcess(request, output);
+}

--- a/parameter/CommandHandlerWrapper.h
+++ b/parameter/CommandHandlerWrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,45 +27,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "RemoteProcessorServer.h"
-#include <memory>
-#include <future>
+#pragma once
 
-class BackgroundRemoteProcessorServer final : public IRemoteProcessorServerInterface
+#include "CommandHandlerInterface.h"
+#include <RemoteCommandHandler.h>
+#include <memory>
+
+class CommandHandlerWrapper : public CommandHandlerInterface
 {
 public:
-    BackgroundRemoteProcessorServer(uint16_t uiPort,
-                                    std::unique_ptr<IRemoteCommandHandler> &&commandHandler)
-        : _server(uiPort), mCommandHandler(std::move(commandHandler))
-    {
-    }
+    CommandHandlerWrapper(std::unique_ptr<IRemoteCommandHandler> &&wrapped);
 
-    ~BackgroundRemoteProcessorServer() { stop(); }
-
-    bool start(std::string &error) override
-    {
-        if (!_server.start(error)) {
-            return false;
-        }
-        try {
-            mServerSuccess = std::async(std::launch::async, &CRemoteProcessorServer::process,
-                                        &_server, std::ref(*mCommandHandler));
-        } catch (std::exception &e) {
-            error = "Could not create a remote processor thread: " + std::string(e.what());
-            return false;
-        }
-
-        return true;
-    }
-
-    bool stop() override
-    {
-        _server.stop();
-        return mServerSuccess.get();
-    }
+    bool process(const std::string &command,
+                 const std::vector<std::string> &arguments,
+                 std::string &output) override;
 
 private:
-    CRemoteProcessorServer _server;
-    std::unique_ptr<IRemoteCommandHandler> mCommandHandler;
-    std::future<bool> mServerSuccess;
+    std::unique_ptr<IRemoteCommandHandler> mWrapped;
 };

--- a/parameter/ParameterMgrFullConnector.cpp
+++ b/parameter/ParameterMgrFullConnector.cpp
@@ -31,6 +31,8 @@
 #include "ParameterMgr.h"
 #include "ParameterMgrLogger.h"
 
+#include "CommandHandlerWrapper.h"
+
 #include <list>
 
 using std::string;
@@ -38,6 +40,11 @@ using std::string;
 CParameterMgrFullConnector::CParameterMgrFullConnector(const string &strConfigurationFilePath)
     : CParameterMgrPlatformConnector(strConfigurationFilePath)
 {
+}
+
+CommandHandlerInterface *CParameterMgrFullConnector::createCommandHandler()
+{
+    return new CommandHandlerWrapper(_pParameterMgr->createCommandHandler());
 }
 
 void CParameterMgrFullConnector::setFailureOnMissingSubsystem(bool bFail)

--- a/parameter/include/CommandHandlerInterface.h
+++ b/parameter/include/CommandHandlerInterface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,45 +27,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "RemoteProcessorServer.h"
-#include <memory>
-#include <future>
+#pragma once
 
-class BackgroundRemoteProcessorServer final : public IRemoteProcessorServerInterface
+#include <string>
+#include <vector>
+
+class CommandHandlerInterface
 {
 public:
-    BackgroundRemoteProcessorServer(uint16_t uiPort,
-                                    std::unique_ptr<IRemoteCommandHandler> &&commandHandler)
-        : _server(uiPort), mCommandHandler(std::move(commandHandler))
-    {
-    }
+    virtual bool process(const std::string &command,
+                         const std::vector<std::string> &arguments,
+                         std::string &output) = 0;
 
-    ~BackgroundRemoteProcessorServer() { stop(); }
-
-    bool start(std::string &error) override
-    {
-        if (!_server.start(error)) {
-            return false;
-        }
-        try {
-            mServerSuccess = std::async(std::launch::async, &CRemoteProcessorServer::process,
-                                        &_server, std::ref(*mCommandHandler));
-        } catch (std::exception &e) {
-            error = "Could not create a remote processor thread: " + std::string(e.what());
-            return false;
-        }
-
-        return true;
-    }
-
-    bool stop() override
-    {
-        _server.stop();
-        return mServerSuccess.get();
-    }
-
-private:
-    CRemoteProcessorServer _server;
-    std::unique_ptr<IRemoteCommandHandler> mCommandHandler;
-    std::future<bool> mServerSuccess;
+    virtual ~CommandHandlerInterface() {};
 };

--- a/parameter/include/ParameterMgrFullConnector.h
+++ b/parameter/include/ParameterMgrFullConnector.h
@@ -36,6 +36,7 @@
 #include "ParameterHandle.h"
 #include "ParameterMgrLoggerForward.h"
 #include "ParameterMgrPlatformConnector.h"
+#include "CommandHandlerInterface.h"
 
 #include <string>
 #include <list>
@@ -51,6 +52,15 @@ public:
     typedef std::list<std::string> Results;
 
     CParameterMgrFullConnector(const std::string &strConfigurationFilePath);
+
+    /** Create and return a command handler for this ParameterMgr instance
+     *
+     * The caller owns the returned pointer and is responsible for deleting it
+     * before destroying the Connector object.
+     *
+     * @returns a Command Handler
+     */
+    CommandHandlerInterface *createCommandHandler();
 
     /** @deprecated Same as its overload without error handling.
      * @note this deprecated method in not available in the python wrapper.


### PR DESCRIPTION
Users can already send commands to a Parameter Framework instance through a
socket (provided that they asked for this interface to be started). Some
features are only available through this interface.

In upcoming patches, we want to use those features and send such commands but
we don't want to use a remote interface, which is sometimes painful. This patch
makes the "remote" commands available through a programmatic API. This API
expects a command name and a string-vector containing the arguments; which
makes it fairly easy to use and to implement a user interface providing the
same commands as they are used to - but without the need of a socket.

The object that provides this API is allocated by the Parameter Framework but
is owned by the client - we want to be C++03-retrocompatible, which forbids us
from returning a unique_ptr, this is why we return a raw pointer.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/321%23issuecomment-167596411%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/321%23discussion_r48496624%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/321%23discussion_r48538742%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/321%23issuecomment-167596411%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A-1%3A%22%2C%20%22created_at%22%3A%20%222015-12-28T16%3A13%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ae06b06d37059f985e53774f165ff7b58bd5977e%20parameter/ParameterMgrFullConnector.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/321%23discussion_r48496624%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20new%20is%20not%20useful%20%20CommandHandlerInterface%20should%20be%20returned%20by%20copy.%20Actually%20can%20a%20return%20by%20copy%20not%20be%20used%20everywere%20%28since%20with%20move%20semantic%20it%20is%20cheap%29%20%3F%22%2C%20%22created_at%22%3A%20%222015-12-28T18%3A33%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tried%2C%20but%20as%20the%20commandHandler%20is%20only%20movable%20and%20the%20api%20is%20c%2B%2B03%2C%20their%20is%20no%20way%20to%20avoid%20this%20client%20deletion%20%28other%20than%20implementing%20a%20%60auto_ptr%60%20like%20semantic%20that%20would%20be%20more%20dangerous%20than%20useful%29.%22%2C%20%22created_at%22%3A%20%222015-12-29T13%3A03%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ParameterMgrFullConnector.cpp%3AL42-53%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/321#issuecomment-167596411'>General Comment</a></b>
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :-1:
- [ ] <a href='#crh-comment-Pull ae06b06d37059f985e53774f165ff7b58bd5977e parameter/ParameterMgrFullConnector.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/321#discussion_r48496624'>File: parameter/ParameterMgrFullConnector.cpp:L42-53</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> This new is not useful  CommandHandlerInterface should be returned by copy. Actually can a return by copy not be used everywere (since with move semantic it is cheap) ?
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I tried, but as the commandHandler is only movable and the api is c++03, their is no way to avoid this client deletion (other than implementing a `auto_ptr` like semantic that would be more dangerous than useful).


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/321?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/321?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/321'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>