### PR TITLE
[wip] New c++ domain generator

### DIFF
--- a/parameter/CMakeLists.txt
+++ b/parameter/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(parameter SHARED
     BitParameterType.cpp
     BitwiseAreaConfiguration.cpp
     BooleanParameterType.cpp
+    CommandHandlerWrapper.cpp
     ComponentInstance.cpp
     ComponentLibrary.cpp
     ComponentType.cpp
@@ -107,7 +108,7 @@ generate_export_header(parameter)
 target_link_libraries(parameter
     # Unfortunatly xmlSink and xmlSource need to be exposed to the plugins
     PUBLIC xmlserializer
-    PRIVATE remote-processor pfw_utility
+    PRIVATE pfw_utility remote-processor
     PRIVATE ${CMAKE_DL_LIBS})
 
 target_include_directories(parameter
@@ -121,6 +122,7 @@ install(TARGETS parameter LIBRARY DESTINATION lib RUNTIME DESTINATION bin ARCHIV
 # Client headers
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/parameter_export.h"
+    include/CommandHandlerInterface.h
     include/ElementHandle.h
     include/ParameterHandle.h
     include/ParameterMgrLoggerForward.h

--- a/parameter/CommandHandlerWrapper.cpp
+++ b/parameter/CommandHandlerWrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,45 +27,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "RemoteProcessorServer.h"
-#include <memory>
-#include <future>
 
-class BackgroundRemoteProcessorServer final : public IRemoteProcessorServerInterface
+#include "CommandHandlerWrapper.h"
+#include <RequestMessage.h>
+
+CommandHandlerWrapper::CommandHandlerWrapper(std::unique_ptr<IRemoteCommandHandler> &&wrapped)
+    : mWrapped(std::move(wrapped))
+{}
+
+bool CommandHandlerWrapper::process(const std::string &command,
+                                    const std::vector<std::string> &arguments,
+                                    std::string &output)
 {
-public:
-    BackgroundRemoteProcessorServer(uint16_t uiPort,
-                                    std::unique_ptr<IRemoteCommandHandler> &&commandHandler)
-        : _server(uiPort), mCommandHandler(std::move(commandHandler))
-    {
+    CRequestMessage request(command);
+
+    for (auto &arg : arguments) {
+        request.addArgument(arg);
     }
 
-    ~BackgroundRemoteProcessorServer() { stop(); }
-
-    bool start(std::string &error) override
-    {
-        if (!_server.start(error)) {
-            return false;
-        }
-        try {
-            mServerSuccess = std::async(std::launch::async, &CRemoteProcessorServer::process,
-                                        &_server, std::ref(*mCommandHandler));
-        } catch (std::exception &e) {
-            error = "Could not create a remote processor thread: " + std::string(e.what());
-            return false;
-        }
-
-        return true;
-    }
-
-    bool stop() override
-    {
-        _server.stop();
-        return mServerSuccess.get();
-    }
-
-private:
-    CRemoteProcessorServer _server;
-    std::unique_ptr<IRemoteCommandHandler> mCommandHandler;
-    std::future<bool> mServerSuccess;
-};
+    return mWrapped->remoteCommandProcess(request, output);
+}

--- a/parameter/CommandHandlerWrapper.h
+++ b/parameter/CommandHandlerWrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,45 +27,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "RemoteProcessorServer.h"
-#include <memory>
-#include <future>
+#pragma once
 
-class BackgroundRemoteProcessorServer final : public IRemoteProcessorServerInterface
+#include "CommandHandlerInterface.h"
+#include <RemoteCommandHandler.h>
+#include <memory>
+
+class CommandHandlerWrapper : public CommandHandlerInterface
 {
 public:
-    BackgroundRemoteProcessorServer(uint16_t uiPort,
-                                    std::unique_ptr<IRemoteCommandHandler> &&commandHandler)
-        : _server(uiPort), mCommandHandler(std::move(commandHandler))
-    {
-    }
+    CommandHandlerWrapper(std::unique_ptr<IRemoteCommandHandler> &&wrapped);
 
-    ~BackgroundRemoteProcessorServer() { stop(); }
-
-    bool start(std::string &error) override
-    {
-        if (!_server.start(error)) {
-            return false;
-        }
-        try {
-            mServerSuccess = std::async(std::launch::async, &CRemoteProcessorServer::process,
-                                        &_server, std::ref(*mCommandHandler));
-        } catch (std::exception &e) {
-            error = "Could not create a remote processor thread: " + std::string(e.what());
-            return false;
-        }
-
-        return true;
-    }
-
-    bool stop() override
-    {
-        _server.stop();
-        return mServerSuccess.get();
-    }
+    bool process(const std::string &command,
+                 const std::vector<std::string> &arguments,
+                 std::string &output) override;
 
 private:
-    CRemoteProcessorServer _server;
-    std::unique_ptr<IRemoteCommandHandler> mCommandHandler;
-    std::future<bool> mServerSuccess;
+    std::unique_ptr<IRemoteCommandHandler> mWrapped;
 };

--- a/parameter/ParameterMgrFullConnector.cpp
+++ b/parameter/ParameterMgrFullConnector.cpp
@@ -31,6 +31,8 @@
 #include "ParameterMgr.h"
 #include "ParameterMgrLogger.h"
 
+#include "CommandHandlerWrapper.h"
+
 #include <list>
 
 using std::string;
@@ -38,6 +40,11 @@ using std::string;
 CParameterMgrFullConnector::CParameterMgrFullConnector(const string &strConfigurationFilePath)
     : CParameterMgrPlatformConnector(strConfigurationFilePath)
 {
+}
+
+CommandHandlerInterface *CParameterMgrFullConnector::createCommandHandler()
+{
+    return new CommandHandlerWrapper(_pParameterMgr->createCommandHandler());
 }
 
 void CParameterMgrFullConnector::setFailureOnMissingSubsystem(bool bFail)

--- a/parameter/include/CommandHandlerInterface.h
+++ b/parameter/include/CommandHandlerInterface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014, Intel Corporation
+ * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,45 +27,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "RemoteProcessorServer.h"
-#include <memory>
-#include <future>
+#pragma once
 
-class BackgroundRemoteProcessorServer final : public IRemoteProcessorServerInterface
+#include <string>
+#include <vector>
+
+class CommandHandlerInterface
 {
 public:
-    BackgroundRemoteProcessorServer(uint16_t uiPort,
-                                    std::unique_ptr<IRemoteCommandHandler> &&commandHandler)
-        : _server(uiPort), mCommandHandler(std::move(commandHandler))
-    {
-    }
+    virtual bool process(const std::string &command,
+                         const std::vector<std::string> &arguments,
+                         std::string &output) = 0;
 
-    ~BackgroundRemoteProcessorServer() { stop(); }
-
-    bool start(std::string &error) override
-    {
-        if (!_server.start(error)) {
-            return false;
-        }
-        try {
-            mServerSuccess = std::async(std::launch::async, &CRemoteProcessorServer::process,
-                                        &_server, std::ref(*mCommandHandler));
-        } catch (std::exception &e) {
-            error = "Could not create a remote processor thread: " + std::string(e.what());
-            return false;
-        }
-
-        return true;
-    }
-
-    bool stop() override
-    {
-        _server.stop();
-        return mServerSuccess.get();
-    }
-
-private:
-    CRemoteProcessorServer _server;
-    std::unique_ptr<IRemoteCommandHandler> mCommandHandler;
-    std::future<bool> mServerSuccess;
+    virtual ~CommandHandlerInterface() {};
 };

--- a/parameter/include/ParameterMgrFullConnector.h
+++ b/parameter/include/ParameterMgrFullConnector.h
@@ -36,6 +36,7 @@
 #include "ParameterHandle.h"
 #include "ParameterMgrLoggerForward.h"
 #include "ParameterMgrPlatformConnector.h"
+#include "CommandHandlerInterface.h"
 
 #include <string>
 #include <list>
@@ -51,6 +52,15 @@ public:
     typedef std::list<std::string> Results;
 
     CParameterMgrFullConnector(const std::string &strConfigurationFilePath);
+
+    /** Create and return a command handler for this ParameterMgr instance
+     *
+     * The caller owns the returned pointer and is responsible for deleting it
+     * before destroying the Connector object.
+     *
+     * @returns a Command Handler
+     */
+    CommandHandlerInterface *createCommandHandler();
 
     /** @deprecated Same as its overload without error handling.
      * @note this deprecated method in not available in the python wrapper.

--- a/tools/xmlGenerator/CMakeLists.txt
+++ b/tools/xmlGenerator/CMakeLists.txt
@@ -26,6 +26,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+add_executable(domainGeneratorConnector domainGeneratorConnector.cpp)
+target_link_libraries(domainGeneratorConnector PRIVATE parameter pfw_utility)
+
+install(TARGETS domainGeneratorConnector RUNTIME DESTINATION bin)
+
 install(PROGRAMS
     domainGenerator.sh
     domainGenerator.py

--- a/tools/xmlGenerator/PFWScriptGenerator.py
+++ b/tools/xmlGenerator/PFWScriptGenerator.py
@@ -36,65 +36,39 @@ import sys
 
 class PfwScriptTranslator(PfwBaseTranslator):
 
-    def __init__(self):
+    def __init__(self, separator=" "):
         super(PfwScriptTranslator, self).__init__()
 
+        self._separator = separator
         self._script = []
 
     def getScript(self):
         return self._script
 
     def _doCreateDomain(self, name):
-        self._script.append(
-                "{cmd} {domain}".format(
-                cmd="createDomain",
-                domain=name))
+        self._script.append(self._separator.join(["createDomain", name]))
 
     def _doSetSequenceAware(self):
-        self._script.append(
-                "{cmd} {domain} {aware}".format(
-                cmd="setSequenceAwareness",
-                domain=self._ctx_domain,
-                aware="true"))
+        self._script.append(self._separator.join(
+            ["setSequenceAwareness", self._ctx_domain, "true"]))
 
     def _doAddElement(self, path):
-        self._script.append(
-                "{cmd} {domain} {path}".format(
-                cmd="addElement",
-                domain=self._ctx_domain,
-                path=path))
+        self._script.append(self._separator.join(["addElement", self._ctx_domain, path]))
 
     def _doCreateConfiguration(self, name):
-        self._script.append(
-                "{cmd} {domain} {config}".format(
-                cmd="createConfiguration",
-                domain=self._ctx_domain,
-                config=name))
+        self._script.append(self._separator.join(["createConfiguration", self._ctx_domain, name]))
 
     def _doSetElementSequence(self, paths):
-        self._script.append(
-                "{cmd} {domain} {config} {paths}".format(
-                cmd="setElementSequence",
-                domain=self._ctx_domain,
-                config=self._ctx_configuration,
-                paths=" ".join(paths)))
+        self._script.append(self._separator.join(
+            ["setElementSequence", self._ctx_domain, self._ctx_configuration, " ".join(paths)]))
 
     def _doSetRule(self, rule):
-        self._script.append(
-                "{cmd} {domain} {config} {rule}".format(
-                cmd="setRule",
-                domain=self._ctx_domain,
-                config=self._ctx_configuration,
-                rule=rule))
+        self._script.append(self._separator.join(
+            ["setRule", self._ctx_domain, self._ctx_configuration, rule]))
 
     def _doSetParameter(self, path, value):
-        self._script.append(
-                "{cmd} {domain} {config} {path} '{value}'".format(
-                cmd="setConfigurationParameter",
-                domain=self._ctx_domain,
-                config=self._ctx_configuration,
-                path=path,
-                value=value))
+        self._script.append(self._separator.join(
+            ["setConfigurationParameter", self._ctx_domain, self._ctx_configuration, path, value]))
 
 class ArgparseArgumentParser(object) :
     """class that parse command line arguments with argparse library

--- a/tools/xmlGenerator/domainGeneratorConnector.cpp
+++ b/tools/xmlGenerator/domainGeneratorConnector.cpp
@@ -1,0 +1,205 @@
+#include <ParameterMgrFullConnector.h>
+#include <Tokenizer.h>
+
+#include <iostream>
+#include <sstream>
+#include <memory>
+#include <string>
+#include <stdexcept>
+
+using std::string;
+using std::runtime_error;
+
+class MyLogger final : public CParameterMgrFullConnector::ILogger
+{
+public:
+    void info(const std::string &log) override { std::cerr << "Info: " << log << std::endl; }
+
+    void warning(const std::string &log) override { std::cerr << "Warning: " << log << std::endl; }
+};
+
+class XmlGenerator
+{
+public:
+    XmlGenerator(const string &toplevelConfig, bool validate, bool verbose, string schemasDir)
+        : mConnector(toplevelConfig),
+          mCommandHandler(mConnector.createCommandHandler())
+    {
+        if (verbose) {
+            mLogger.reset(new MyLogger);
+            mConnector.setLogger(mLogger.get());
+        }
+
+        mConnector.setSchemaUri(schemasDir);
+        mConnector.setValidateSchemasOnStart(validate);
+
+        // Disable irrelevant failure conditions
+        mConnector.setFailureOnMissingSubsystem(false);
+        mConnector.setFailureOnFailedSettingsLoad(false);
+
+        // Disable the remote interface because we don't need it and it might
+        // get in the way (e.g. the port is already in use)
+        mConnector.setForceNoRemoteInterface(true);
+    }
+
+    /** Read each line of the input stream and takes an action accordingly
+     *
+     * Returns when the input stream reaches end of file
+     *
+     * @param[in] input The input stream to read from
+     */
+    void parse(std::istream &input);
+
+    /** Prints the Parameter Framework's instance configuration
+     *
+     * @param[out] output The stream to which output the configuration
+     */
+    void exportDomains(std::ostream &output);
+
+private:
+    void addCriteria(std::vector<string> &tokens);
+    void start();
+
+    CParameterMgrFullConnector mConnector;
+    std::unique_ptr<MyLogger> mLogger;
+    std::unique_ptr<CommandHandlerInterface> mCommandHandler;
+};
+
+void XmlGenerator::addCriteria(std::vector<string> &tokens)
+{
+    if (tokens.size() < 3) {
+        throw runtime_error("Not enough arguments to criterion creation request");
+    }
+
+    auto inclusiveness = tokens.front() == "inclusive";
+    tokens.erase(begin(tokens));
+
+    auto name = tokens.front();
+    tokens.erase(begin(tokens));
+
+    auto criterionType = mConnector.createSelectionCriterionType(inclusiveness);
+    if (criterionType == nullptr) {
+        throw runtime_error("Failed to create an " +
+                        string(inclusiveness ? "inclusive" : "exclusive") +
+                        " criterion type");
+    }
+
+    int index = 0;
+    for (const auto &literalValue : tokens) {
+        // inclusive criteria are bitfields
+        int numericalCriterionValue = inclusiveness ? 1 << index : index;
+        string error;
+        bool success = criterionType->addValuePair(numericalCriterionValue, literalValue, error);
+
+        if (not success) {
+            std::ostringstream message;
+            message << "Valuepair '" << numericalCriterionValue << "/" << literalValue
+                    << " rejected for " << name << ". (" << error << ")";
+            throw runtime_error(message.str());
+        }
+        index++;
+    }
+
+    // We don't need to keep a reference to the criterion - no need to store
+    // the returned pointer.
+    if (mConnector.createSelectionCriterion(name, criterionType) == nullptr) {
+        throw runtime_error("Failed to create criterion '" + name + "'");
+    }
+}
+
+void XmlGenerator::parse(std::istream &input)
+{
+    // Read each command from the input
+    // if it is a "createSelectionCriterion" command, apply special
+    // treatment to handle it ourselves instead of passing the command to the
+    // command handler.
+    // Such lines will look like:
+    //     createSelectionCriterion inclusive|exclusive <name> <value> [value, ...]
+    // If it is a "start", it means that the caller has finished creating the
+    // criteria and the Parameter Framework must be started.
+    string line;
+    while (not input.eof()) {
+        std::getline(std::cin, line);
+
+        auto tokens = Tokenizer(line, string(1, '\0')).split();
+        if (tokens.empty()) {
+            continue;
+        }
+        auto command = tokens.front();
+        tokens.erase(begin(tokens)); // drop the command name
+
+        if (command == "createSelectionCriterion") {
+            addCriteria(tokens);
+        } else if (command == "start") {
+            start();
+        } else {
+            string output;
+            if (not mCommandHandler->process(command, tokens, output)) {
+                std::cerr << output << std::endl;
+            }
+        }
+    }
+}
+
+void XmlGenerator::start()
+{
+    string error;
+    if (not mConnector.start(error)) {
+        throw runtime_error("Start failed: " + error);
+    }
+
+    error.clear();
+    if (not mConnector.setTuningMode(true, error)) {
+        throw runtime_error("Failed to turn tuning mode on: " + error);
+    }
+}
+
+void XmlGenerator::exportDomains(std::ostream &output)
+{
+    string error;
+    string domains;
+    if (not mConnector.exportDomainsXml(domains, true, false, error)) {
+        throw runtime_error("Export failed: " + error);
+    } else {
+        output << domains;
+    }
+}
+
+void usage()
+{
+    std::cerr << "Usage:" << std::endl;
+    std::cerr << "\t" << "domainGeneratorConnector"
+              << " <top-level config>"
+                 " <verbose ('1': verbose, else: terse)>"
+                 " <validate ('1': validate, else: don't validate)>"
+                 " <path to the schemas' directory>" << std::endl;
+    std::cerr << "All arguments are mandatory. If no validation is required, the path to the"
+                 " schemas can be an empty string." << std::endl;
+    std::cerr << "This program is not intended to be used standalone but rather called through"
+                 " domainGenerator.py" << std::endl;
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc <= 4) {
+        usage();
+        return 1;
+    }
+
+    string toplevelConfig(argv[1]);
+    bool verbose = string(argv[2]) == "1";
+    bool validate = string(argv[3]) == "1";
+    string schemasDir(argv[4]);
+
+    try {
+        XmlGenerator xmlGenerator(toplevelConfig, validate, verbose, schemasDir);
+        xmlGenerator.parse(std::cin);
+        // TODO: add a check for conflicting elements
+        xmlGenerator.exportDomains(std::cout);
+    } catch (runtime_error e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48021954%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022071%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022117%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022159%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022223%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022312%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022349%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48042716%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48042874%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48043053%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48043204%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48604862%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48604870%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48604931%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48604936%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48605001%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48605004%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48605069%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48605083%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGeneratorConnector.cpp%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022349%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Reads%22%2C%20%22created_at%22%3A%20%222015-12-18T13%3A00%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGeneratorConnector.cpp%3AL1-205%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGenerator.py%20248%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48043204%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Forward%20the%20connector%27s%20return%20code.%22%2C%20%22created_at%22%3A%20%222015-12-18T16%3A35%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-30T14%3A04%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGenerator.py%3AL159-208%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGeneratorConnector.cpp%20138%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48043053%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Throw%20an%20error.%22%2C%20%22created_at%22%3A%20%222015-12-18T16%3A33%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20The%20code%20now%20continues%20on%20error%20but%20keep%20track%20of%20how%20many%20occurred%20and%20report%20it%20with%20the%20exit%20code.%22%2C%20%22created_at%22%3A%20%222015-12-30T14%3A04%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGeneratorConnector.cpp%3AL1-205%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGeneratorConnector.cpp%2097%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48042874%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Missing%20closing%20%60%27%60%20before%20%60%20rejected%60.%22%2C%20%22created_at%22%3A%20%222015-12-18T16%3A32%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGeneratorConnector.cpp%3AL1-205%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGenerator.py%20246%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022117%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22flush%20may%20not%20be%20needed.%22%2C%20%22created_at%22%3A%20%222015-12-18T12%3A56%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-30T14%3A00%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGenerator.py%3AL159-208%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGeneratorConnector.cpp%2090%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48042716%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60numericalValue%60%20%28for%20naming%20consistency%29%22%2C%20%22created_at%22%3A%20%222015-12-18T16%3A30%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGeneratorConnector.cpp%3AL1-205%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20newDomainGenerator.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48021954%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22oops%2C%20I%20did%20not%20intend%20to%20add%20this%20file.%20I%27ll%20remove%20it.%22%2C%20%22created_at%22%3A%20%222015-12-18T12%3A54%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-30T14%3A05%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20newDomainGenerator.py%3AL1-324%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGeneratorConnector.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022223%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20a%20custom%20exception%20class%20to%20differentiate%20Parameter%20Framework%20errors%20from%20other%20ones.%22%2C%20%22created_at%22%3A%20%222015-12-18T12%3A58%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGeneratorConnector.cpp%3AL1-205%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGeneratorConnector.cpp%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022312%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20we%20could%20unconditionally%20instantiate%20the%20logger%3A%20it%20doesn%27t%20cost%20much.%22%2C%20%22created_at%22%3A%20%222015-12-18T12%3A59%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20it%20is%20just%20as%20good%20as%20is.%20No%20need%20to%20complexity%20the%20code.%22%2C%20%22created_at%22%3A%20%222015-12-30T14%3A02%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-30T14%3A02%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGeneratorConnector.cpp%3AL1-205%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGenerator.py%20223%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022071%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22no%20need%20to%20flush%20here.%22%2C%20%22created_at%22%3A%20%222015-12-18T12%3A56%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222015-12-30T14%3A00%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-30T14%3A05%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGenerator.py%3AL159-208%22%7D%2C%20%22Pull%200b584463582fc436cd0ce0f10a6f4610771cfa7c%20tools/xmlGenerator/domainGeneratorConnector.cpp%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/322%23discussion_r48022159%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22missing%20license%20header%22%2C%20%22created_at%22%3A%20%222015-12-18T12%3A57%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGeneratorConnector.cpp%3AL1-205%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGeneratorConnector.cpp 1'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48022159'>File: tools/xmlGenerator/domainGeneratorConnector.cpp:L1-205</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> missing license header
- [ ] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGeneratorConnector.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48022223'>File: tools/xmlGenerator/domainGeneratorConnector.cpp:L1-205</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Add a custom exception class to differentiate Parameter Framework errors from other ones.
- [ ] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGeneratorConnector.cpp 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48022349'>File: tools/xmlGenerator/domainGeneratorConnector.cpp:L1-205</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Reads
- [ ] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGeneratorConnector.cpp 90'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48042716'>File: tools/xmlGenerator/domainGeneratorConnector.cpp:L1-205</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> `numericalValue` (for naming consistency)
- [ ] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGeneratorConnector.cpp 97'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48042874'>File: tools/xmlGenerator/domainGeneratorConnector.cpp:L1-205</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Missing closing `'` before ` rejected`.
- [x] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c newDomainGenerator.py 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48021954'>File: newDomainGenerator.py:L1-324</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> oops, I did not intend to add this file. I'll remove it.
- [x] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGenerator.py 223'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48022071'>File: tools/xmlGenerator/domainGenerator.py:L159-208</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> no need to flush here.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> done
- [x] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGenerator.py 246'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48022117'>File: tools/xmlGenerator/domainGenerator.py:L159-208</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> flush may not be needed.
- [x] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGeneratorConnector.cpp 29'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48022312'>File: tools/xmlGenerator/domainGeneratorConnector.cpp:L1-205</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Maybe we could unconditionally instantiate the logger: it doesn't cost much.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> I think it is just as good as is. No need to complexity the code.
- [x] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGeneratorConnector.cpp 138'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48043053'>File: tools/xmlGenerator/domainGeneratorConnector.cpp:L1-205</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Throw an error.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :+1: The code now continues on error but keep track of how many occurred and report it with the exit code.
- [x] <a href='#crh-comment-Pull 0b584463582fc436cd0ce0f10a6f4610771cfa7c tools/xmlGenerator/domainGenerator.py 248'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/322#discussion_r48043204'>File: tools/xmlGenerator/domainGenerator.py:L159-208</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Forward the connector's return code.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/322?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/322?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/322'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>