### PR TITLE
cmake: Use CXX properties instead of CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ execute_process(COMMAND git describe --tags --dirty
 # call the wrapper
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
+# Require standard C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CXX_EXTENSIONS OFF)
+set(CXX_STANDARD_REQUIRED ON)
+
 if(WIN32)
     # By default cmake adds a warning level.
     # Nevertheless a different level is wanted for this project.
@@ -77,7 +82,7 @@ if(WIN32)
     # FIXME: Once we have removed all warnings on windows, add the /WX flags if
     # FATAL_WARNINGS is enabled
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wconversion -Wno-sign-conversion")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wconversion -Wno-sign-conversion")
     if(FATAL_WARNINGS)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
     endif()

--- a/skeleton-subsystem/CMakeLists.txt
+++ b/skeleton-subsystem/CMakeLists.txt
@@ -37,8 +37,13 @@ if(WIN32)
     # but doing so breaks compilation of windows headers...
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /FIiso646.h")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra -Wconversion")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Wconversion")
 endif()
+
+# Require standard C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CXX_EXTENSIONS OFF)
+set(CXX_STANDARD_REQUIRED ON)
 
 # Hide symbols by default, then exposed symbols are the same in linux and windows
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
Instead of using the gnu/clang specific flag `-std`,
use cmake C++ specific but compiler independent properties.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/326?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/326'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>