### PR TITLE
[review] Xml Generation bugfix

### DIFF
--- a/test/xml-generator/testVector/duplicate.pfw
+++ b/test/xml-generator/testVector/duplicate.pfw
@@ -1,0 +1,2 @@
+# Should trigger a non fatal error
+domain: EddGroup.First

--- a/test/xml-generator/testVector/first.pfw
+++ b/test/xml-generator/testVector/first.pfw
@@ -31,5 +31,3 @@ domainGroup: EddGroup
 			component: /Test/test/block/1
 				q2.5 = 0
 				string = some other string
-	# Should trigger a non fatal error
-	domain: First

--- a/tools/xmlGenerator/domainGenerator.py
+++ b/tools/xmlGenerator/domainGenerator.py
@@ -58,6 +58,7 @@ def parseArgs():
             help="Initial XML settings file (containing a \
         <ConfigurableDomains>  tag",
             nargs='?',
+            default=None,
             metavar="XML_SETTINGS_FILE")
     argparser.add_argument('--add-domains',
             help="List of single domain files (each containing a single \
@@ -184,7 +185,6 @@ def main():
     # EDD files (aka ".pfw" files)
     #
     parsed_edds = parseEdd(args.edd_files, args.verbose)
-    error_nb = 0
 
     # We need to modify the toplevel configuration file to account for differences
     # between development setup and target (installation) setup, in particular, the
@@ -209,7 +209,9 @@ def main():
                             args.schemas_dir],
                            stdout=sys.stdout, stdin=subprocess.PIPE, stderr=sys.stderr)
 
-    initial_settings = os.path.realpath(args.initial_settings)
+    initial_settings = None
+    if args.initial_settings:
+        initial_settings = os.path.realpath(args.initial_settings)
 
     for command in generateDomainCommands(logging, all_criteria, initial_settings,
                                        args.xml_domain_files, parsed_edds):
@@ -219,8 +221,8 @@ def main():
     # Closing the connector's input triggers the domain generation
     connector.stdin.close()
     connector.wait()
-    fake_toplevel_config.delete()
-    return connector.return_code
+    os.remove(fake_toplevel_config.name)
+    return connector.returncode
 
 # If this file is directly executed
 if __name__ == "__main__":

--- a/tools/xmlGenerator/domainGeneratorConnector.cpp
+++ b/tools/xmlGenerator/domainGeneratorConnector.cpp
@@ -209,8 +209,8 @@ void XmlGenerator::exportDomains(std::ostream &output)
 static const char *usage =
     R"(Usage: domainGeneratorConnector <top-level config> <verbose> <validate> <path>
 
- <verbose>       '1': verbose,  else: terse
- <validate>      '1' validate, else: don't validate
+ <verbose>       'verbose': verbose, else: terse
+ <validate>      'validate': validate, else: don't validate
  <path>          path to the schemas' directory
 
 All arguments are mandatory. If no validation is required,


### PR DESCRIPTION
There were some coding errors in domainGenerator.py. This branch fixes them and add more tests to ensure it doesn't happen again.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/328%23issuecomment-169364092%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/328%23issuecomment-169797891%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r48971795%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r48972223%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r48976401%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r48976417%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r49054379%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r49057329%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r49057331%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/328%23issuecomment-169364092%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20please%20review.%22%2C%20%22created_at%22%3A%20%222016-01-06T15%3A48%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222016-01-07T20%3A36%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b3d8dc70c18cfde64587a112d6ac792451344cef%20tools/xmlGenerator/domainGenerator.py%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r48971795%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20not%20keeping%20%60None%60%20%3F%20Why%20is%20%60%5C%22%5C%22%60%20as%20special%20value%22%2C%20%22created_at%22%3A%20%222016-01-06T15%3A56%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5C%22keep%5C%22%20implies%20that%20it%20has%20another%20value%20beforehand%2C%20which%20it%20doesn%27t.%5Cr%5Cn%5Cr%5CnThe%20point%20of%20this%20change%20is%20that%20of%20args.initial_settings%20isn%27t%20set%2C%20it%20musn%27t%20be%20passed%20to%20%60os.path.realpath%28%29%60.%20But%20we%20need%20%60initial_settings%60%20to%20be%20exist%20regardless%20since%20we%20are%20passing%20to%20as%20argument%20to%20%60generateDomainCommands%28%29%60%20below.%20%60%5C%22%5C%22%60%20evaluates%20to%20%60False%60%2C%20so%20it%20seems%20sensible%20to%20indicate%20an%20absence%20of%20value%3B%20but%20I%20understand%20your%20point.%22%2C%20%22created_at%22%3A%20%222016-01-06T16%3A29%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%7C%3E%20%5C%22%5C%22%7C%20evaluates%20to%20%7CFalse%7C%2C%5CnNone%20too%2C%20so%20I%20do%20not%20see%20the%20drawback%20of%20using%20%60None%60%20instead%20of%20%60%5C%22%5C%22%60.%5Cn---------------------------------------------------------------------%5CnIntel%20Corporation%20SAS%20%28French%20simplified%20joint%20stock%20company%29%5CnRegistered%20headquarters%3A%20%5C%22Les%20Montalets%5C%22-%202%2C%20rue%20de%20Paris%2C%20%5Cn92196%20Meudon%20Cedex%2C%20France%5CnRegistration%20Number%3A%20%20302%20456%20199%20R.C.S.%20NANTERRE%5CnCapital%3A%204%2C572%2C000%20Euros%5Cn%5CnThis%20e-mail%20and%20any%20attachments%20may%20contain%20confidential%20material%20for%5Cnthe%20sole%20use%20of%20the%20intended%20recipient%28s%29.%20Any%20review%20or%20distribution%5Cnby%20others%20is%20strictly%20prohibited.%20If%20you%20are%20not%20the%20intended%5Cnrecipient%2C%20please%20contact%20the%20sender%20and%20delete%20all%20copies.%5Cn%22%2C%20%22created_at%22%3A%20%222016-01-07T09%3A21%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-01-07T09%3A57%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/xmlGenerator/domainGenerator.py%3AL209-218%22%7D%2C%20%22Pull%20b3d8dc70c18cfde64587a112d6ac792451344cef%20test/xml-generator/test.py%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/328%23discussion_r48972223%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22dead%20code%20%3F%22%2C%20%22created_at%22%3A%20%222016-01-06T15%3A58%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22oops.%22%2C%20%22created_at%22%3A%20%222016-01-06T16%3A29%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-01-07T09%3A57%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/xml-generator/test.py%3AL31-120%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/328#issuecomment-169364092'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard please review.
- [x] <a href='#crh-comment-Pull b3d8dc70c18cfde64587a112d6ac792451344cef tools/xmlGenerator/domainGenerator.py 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/328#discussion_r48971795'>File: tools/xmlGenerator/domainGenerator.py:L209-218</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> why not keeping `None` ? Why is `""` as special value
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> "keep" implies that it has another value beforehand, which it doesn't.
The point of this change is that of args.initial_settings isn't set, it musn't be passed to `os.path.realpath()`. But we need `initial_settings` to be exist regardless since we are passing to as argument to `generateDomainCommands()` below. `""` evaluates to `False`, so it seems sensible to indicate an absence of value; but I understand your point.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> |> ""| evaluates to |False|,
None too, so I do not see the drawback of using `None` instead of `""`.
---------------------------------------------------------------------
Intel Corporation SAS (French simplified joint stock company)
Registered headquarters: "Les Montalets"- 2, rue de Paris,
92196 Meudon Cedex, France
Registration Number:  302 456 199 R.C.S. NANTERRE
Capital: 4,572,000 Euros
This e-mail and any attachments may contain confidential material for
the sole use of the intended recipient(s). Any review or distribution
by others is strictly prohibited. If you are not the intended
recipient, please contact the sender and delete all copies.
- [x] <a href='#crh-comment-Pull b3d8dc70c18cfde64587a112d6ac792451344cef test/xml-generator/test.py 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/328#discussion_r48972223'>File: test/xml-generator/test.py:L31-120</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> dead code ?
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> oops.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/328?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/328?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/328?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/328'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>