### PR TITLE
[review] Xml generation: check conflicting elements

### DIFF
--- a/parameter/ConfigurableDomain.cpp
+++ b/parameter/ConfigurableDomain.cpp
@@ -686,8 +686,6 @@ bool CConfigurableDomain::deleteConfiguration(const string &strName, string &str
 
 void CConfigurableDomain::listAssociatedToElements(string &strResult) const
 {
-    strResult = "\n";
-
     ConfigurableElementListIterator it;
 
     // Browse all configurable elements

--- a/parameter/ConfigurableDomains.cpp
+++ b/parameter/ConfigurableDomains.cpp
@@ -317,8 +317,6 @@ bool CConfigurableDomains::split(const string &domainName, CConfigurableElement 
 
 void CConfigurableDomains::listAssociatedElements(string &strResult) const
 {
-    strResult = "\n";
-
     std::set<const CConfigurableElement *> configurableElementSet;
 
     // Get all owned configurable elements
@@ -341,8 +339,6 @@ void CConfigurableDomains::listAssociatedElements(string &strResult) const
 
 void CConfigurableDomains::listConflictingElements(string &strResult) const
 {
-    strResult = "\n";
-
     std::set<const CConfigurableElement *> configurableElementSet;
 
     // Get all owned configurable elements
@@ -369,8 +365,6 @@ void CConfigurableDomains::listConflictingElements(string &strResult) const
 
 void CConfigurableDomains::listDomains(string &strResult) const
 {
-    strResult = "\n";
-
     // List domains
     size_t uiNbConfigurableDomains = getNbChildren();
 

--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -468,8 +468,6 @@ void CConfigurableElement::listBelongingDomains(std::string &strResult, bool bVe
 // Elements with no domains
 void CConfigurableElement::listRogueElements(std::string &strResult) const
 {
-    strResult = "\n";
-
     // Get rogue element aggregate list (no associated domain)
     std::list<const CConfigurableElement *> rogueElementList;
 
@@ -568,11 +566,6 @@ void CConfigurableElement::listDomains(
     const std::list<const CConfigurableDomain *> &configurableDomainList, std::string &strResult,
     bool bVertical) const
 {
-    if (bVertical && configurableDomainList.empty()) {
-
-        strResult = "\n";
-    }
-
     // Fill list
     ConfigurableDomainListConstIterator it;
     bool bFirst = true;

--- a/parameter/Element.cpp
+++ b/parameter/Element.cpp
@@ -122,7 +122,6 @@ string CElement::dumpContent(utility::ErrorContext &errorContext, const size_t d
 // Element properties
 void CElement::showProperties(string &strResult) const
 {
-    strResult = "\n";
     strResult += "Kind: " + getKind() + "\n";
     showDescriptionProperty(strResult);
 }
@@ -330,8 +329,6 @@ bool CElement::removeChild(CElement *pChild)
 
 void CElement::listChildren(string &strChildList) const
 {
-    strChildList = "\n";
-
     // Get list of children names
     for (CElement *pChild : _childArray) {
 

--- a/parameter/MappingData.cpp
+++ b/parameter/MappingData.cpp
@@ -38,7 +38,7 @@ bool CMappingData::init(const std::string &rawMapping, std::string &error)
 
     std::string strMappingElement;
 
-    while (!(strMappingElement = mappingTok.next()).empty()) {
+    for (const auto &strMappingElement : mappingTok.split()) {
 
         std::string::size_type iFistDelimiterOccurrence = strMappingElement.find_first_of(':');
 

--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -1370,8 +1370,6 @@ CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::listElementsCommand
         return CCommandHandler::EFailed;
     }
 
-    strResult = string("\n");
-
     if (!pLocatedElement) {
 
         // List from root folder
@@ -1398,8 +1396,6 @@ CParameterMgr::CCommandHandler::CommandStatus CParameterMgr::listParametersComma
 
         return CCommandHandler::EFailed;
     }
-
-    strResult = string("\n");
 
     if (!pLocatedElement) {
 

--- a/remote-processor/RemoteCommandHandlerTemplate.h
+++ b/remote-processor/RemoteCommandHandlerTemplate.h
@@ -194,8 +194,6 @@ private:
     {
         initMaxCommandUsageLength();
 
-        strResult = "\n";
-
         // Show usages
         for (const auto *pRemoteCommandParserItem : _remoteCommandParserVector) {
 

--- a/test/tokenizer/Test.cpp
+++ b/test/tokenizer/Test.cpp
@@ -81,4 +81,34 @@ SCENARIO("Tokenizer tests")
             CHECK(tokenizer.split() == expected);
         }
     }
+
+    GIVEN ("A tokenizer that doesn't merge consecutive separators") {
+
+        GIVEN ("An empty string") {
+            Tokenizer tokenizer("", Tokenizer::defaultDelimiters, false);
+            Expected expected{};
+
+            THEN ("split() should be empty") {
+                CHECK(tokenizer.split() == expected);
+            }
+        }
+
+        GIVEN ("A string consisting only of a delimiter") {
+            Tokenizer tokenizer(",", ",", false);
+            Expected expected{"", ""};
+
+            THEN ("split() should return two empty tokens") {
+                CHECK(tokenizer.split() == expected);
+            }
+        }
+
+        GIVEN ("Multiple separators in a row") {
+            Tokenizer tokenizer(" a  b \nc d ", Tokenizer::defaultDelimiters, false);
+            Expected expected{"", "a", "", "b", "", "c", "d", ""};
+
+            THEN ("split() api should work") {
+                CHECK(tokenizer.split() == expected);
+            }
+        }
+    }
 }

--- a/test/tokenizer/Test.cpp
+++ b/test/tokenizer/Test.cpp
@@ -46,12 +46,6 @@ SCENARIO("Tokenizer tests")
         GIVEN ("A trivial string") {
             Tokenizer tokenizer("a bcd ef");
 
-            THEN ("next() api should work") {
-                CHECK(tokenizer.next() == "a");
-                CHECK(tokenizer.next() == "bcd");
-                CHECK(tokenizer.next() == "ef");
-                CHECK(tokenizer.next() == "");
-            }
             THEN ("split() api should work") {
                 vector<string> expected;
                 expected.push_back("a");
@@ -65,9 +59,6 @@ SCENARIO("Tokenizer tests")
         GIVEN ("An empty string") {
             Tokenizer tokenizer("");
 
-            THEN ("next() api should work") {
-                CHECK(tokenizer.next() == "");
-            }
             THEN ("split() api should work") {
                 vector<string> expected;
 
@@ -78,13 +69,6 @@ SCENARIO("Tokenizer tests")
         GIVEN ("A slash-separated string and tokenizer") {
             Tokenizer tokenizer("/a/bcd/ef g/h/", "/");
 
-            THEN ("next() api should work") {
-                CHECK(tokenizer.next() == "a");
-                CHECK(tokenizer.next() == "bcd");
-                CHECK(tokenizer.next() == "ef g");
-                CHECK(tokenizer.next() == "h");
-                CHECK(tokenizer.next() == "");
-            }
             THEN ("split() api should work") {
                 vector<string> expected;
                 expected.push_back("a");
@@ -99,11 +83,6 @@ SCENARIO("Tokenizer tests")
         GIVEN ("Multiple separators in a row") {
             Tokenizer tokenizer("  a \n\t bc  ");
 
-            THEN ("next() api should work") {
-                CHECK(tokenizer.next() == "a");
-                CHECK(tokenizer.next() == "bc");
-                CHECK(tokenizer.next() == "");
-            }
             THEN ("split() api should work") {
                 vector<string> expected;
                 expected.push_back("a");

--- a/test/tokenizer/Test.cpp
+++ b/test/tokenizer/Test.cpp
@@ -39,57 +39,46 @@
 using std::string;
 using std::vector;
 
+using Expected = vector<string>;
+
 SCENARIO("Tokenizer tests")
 {
     GIVEN ("A default tokenizer") {
 
         GIVEN ("A trivial string") {
             Tokenizer tokenizer("a bcd ef");
+            Expected expected{"a", "bcd", "ef"};
 
             THEN ("split() api should work") {
-                vector<string> expected;
-                expected.push_back("a");
-                expected.push_back("bcd");
-                expected.push_back("ef");
-
                 CHECK(tokenizer.split() == expected);
             }
         }
 
         GIVEN ("An empty string") {
             Tokenizer tokenizer("");
+            Expected expected{};
 
-            THEN ("split() api should work") {
-                vector<string> expected;
-
-                CHECK(tokenizer.split().empty());
-            }
-        }
-
-        GIVEN ("A slash-separated string and tokenizer") {
-            Tokenizer tokenizer("/a/bcd/ef g/h/", "/");
-
-            THEN ("split() api should work") {
-                vector<string> expected;
-                expected.push_back("a");
-                expected.push_back("bcd");
-                expected.push_back("ef g");
-                expected.push_back("h");
-
+            THEN ("split() should be empty") {
                 CHECK(tokenizer.split() == expected);
             }
         }
 
         GIVEN ("Multiple separators in a row") {
             Tokenizer tokenizer("  a \n\t bc  ");
+            Expected expected{"a", "bc"};
 
             THEN ("split() api should work") {
-                vector<string> expected;
-                expected.push_back("a");
-                expected.push_back("bc");
-
                 CHECK(tokenizer.split() == expected);
             }
+        }
+    }
+
+    GIVEN ("A slash-separated string and tokenizer") {
+        Tokenizer tokenizer("/a/bcd/ef g/h/", "/");
+        Expected expected{"a", "bcd", "ef g", "h"};
+
+        THEN ("split() api should work") {
+            CHECK(tokenizer.split() == expected);
         }
     }
 }

--- a/test/xml-generator/PFConfig/duplicate_criterion_value.txt
+++ b/test/xml-generator/PFConfig/duplicate_criterion_value.txt
@@ -1,0 +1,1 @@
+InclusiveCriterion Duplicate : Foo Foo

--- a/test/xml-generator/PFConfig/structure.xml
+++ b/test/xml-generator/PFConfig/structure.xml
@@ -10,6 +10,9 @@
         <InstanceDefinition>
 
             <Component Name="included" Type="Included"/>
+            <ParameterBlock Name="inline">
+                <BooleanParameter Name="bool"/>
+            </ParameterBlock>
 
             <ParameterBlock Name="block" ArrayLength="5">
                 <FixedPointParameter Name="q2.5" Size="8" Integral="2" Fractional="5"/>

--- a/test/xml-generator/test.py
+++ b/test/xml-generator/test.py
@@ -90,27 +90,33 @@ basedir = os.path.dirname(sys.argv[0])
 config_dir = os.path.join(basedir, "PFConfig")
 vector_dir = os.path.join(basedir, "testVector")
 class TestCase(unittest.TestCase):
-    nominal_reference = open(os.path.join(vector_dir, "reference.xml")).read().splitlines()
-    nominal_pfconfig = PfConfig(os.path.join(config_dir, "configuration.xml"),
-                                os.path.join(config_dir, "criteria.txt"),
-                                os.path.join(basedir, "../../schemas"))
-    nominal_vector = TestVector(os.path.join(vector_dir, "initialSettings.xml"),
-                                [os.path.join(vector_dir, "first.pfw"),
-                                 os.path.join(vector_dir, "second.pfw"),
-                                 os.path.join(vector_dir, "complex.pfw")],
-                                [os.path.join(vector_dir, "third.xml"),
-                                 os.path.join(vector_dir, "fourth.xml")])
+    def setUp(self):
+        self.nominal_reference = open(os.path.join(vector_dir, "reference.xml")).read().splitlines()
+        self.nominal_pfconfig = PfConfig(os.path.join(config_dir, "configuration.xml"),
+                                         os.path.join(config_dir, "criteria.txt"),
+                                         os.path.join(basedir, "../../schemas"))
+        self.nominal_vector = TestVector(os.path.join(vector_dir, "initialSettings.xml"),
+                                         [os.path.join(vector_dir, "first.pfw"),
+                                          os.path.join(vector_dir, "second.pfw"),
+                                          os.path.join(vector_dir, "complex.pfw")],
+                                         [os.path.join(vector_dir, "third.xml"),
+                                          os.path.join(vector_dir, "fourth.xml")])
 
     def test_nominal(self):
         tester = Tester(self.nominal_pfconfig, self.nominal_vector)
         tester.check(self.nominal_reference)
 
     def test_nonfatalError(self):
-        vector = copy.copy(self.nominal_vector)
-        vector.edds.append(os.path.join(vector_dir, "duplicate.pfw"))
+        self.nominal_vector.edds.append(os.path.join(vector_dir, "duplicate.pfw"))
+
+        tester = Tester(self.nominal_pfconfig, self.nominal_vector)
+        tester.check(self.nominal_reference, expectedErrors=1)
+
+    def test_conflicting(self):
+        vector = TestVector(edds=[os.path.join(vector_dir, "conflicting.pfw")])
 
         tester = Tester(self.nominal_pfconfig, vector)
-        tester.check(self.nominal_reference, expectedErrors=1)
+        tester.check(expectedErrors=1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/xml-generator/test.py
+++ b/test/xml-generator/test.py
@@ -118,5 +118,14 @@ class TestCase(unittest.TestCase):
         tester = Tester(self.nominal_pfconfig, vector)
         tester.check(expectedErrors=1)
 
+    def test_fail_criteria(self):
+        self.nominal_pfconfig.criteria = os.path.join(config_dir, "duplicate_criterion_value.txt")
+        # Empty test vector: we want to make sure that the erroneous criterion
+        # is the only source of error
+        empty_vector = TestVector()
+
+        tester = Tester(self.nominal_pfconfig, empty_vector)
+        tester.check(expectedErrors=1)
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/xml-generator/testVector/complex.pfw
+++ b/test/xml-generator/testVector/complex.pfw
@@ -33,8 +33,8 @@ domainGroup: Red sequenceAware
 						Colors Includes Blue
 
 						component: /Test/test
-							component: block/3
+							component: block/0
 								q2.5 = 1.18750
 								string = 12 ab @ 	 <![CDATA[ < > \n \0 ✔ "'\
-							component: included
+							component: inline
 								bool = 1

--- a/test/xml-generator/testVector/conflicting.pfw
+++ b/test/xml-generator/testVector/conflicting.pfw
@@ -1,0 +1,7 @@
+# Causes a conflicting-element error
+domain: First
+	conf: Default
+		/Test/test/included/bool = 1
+domain: Second
+	conf: Default
+		/Test/test/included/bool = 0

--- a/test/xml-generator/testVector/first.pfw
+++ b/test/xml-generator/testVector/first.pfw
@@ -15,7 +15,8 @@ domainGroup: EddGroup
 
 				component: /Test/test/block/1
 					q2.5 = 1.2
-					string = some string
+					# set to an empty string
+					string =
 
 			# Inherits from "EddGroup" domainGroup, "First" domain
 			# and from "Green" confGroup

--- a/test/xml-generator/testVector/reference.xml
+++ b/test/xml-generator/testVector/reference.xml
@@ -200,19 +200,19 @@
       </Configuration>
     </Configurations>
     <ConfigurableElements>
-      <ConfigurableElement Path="/Test/test/block/3/q2.5"/>
-      <ConfigurableElement Path="/Test/test/block/3/string"/>
-      <ConfigurableElement Path="/Test/test/included/bool"/>
+      <ConfigurableElement Path="/Test/test/block/0/q2.5"/>
+      <ConfigurableElement Path="/Test/test/block/0/string"/>
+      <ConfigurableElement Path="/Test/test/inline/bool"/>
     </ConfigurableElements>
     <Settings>
       <Configuration Name="green.confGroup..On.Blue.dot">
-        <ConfigurableElement Path="/Test/test/block/3/q2.5">
+        <ConfigurableElement Path="/Test/test/block/0/q2.5">
           <FixedPointParameter Name="q2.5">1.18750</FixedPointParameter>
         </ConfigurableElement>
-        <ConfigurableElement Path="/Test/test/block/3/string">
+        <ConfigurableElement Path="/Test/test/block/0/string">
           <StringParameter Name="string">12 ab @ 	 &lt;![CDATA[ &lt; &gt; \n \0 ✔ "'\</StringParameter>
         </ConfigurableElement>
-        <ConfigurableElement Path="/Test/test/included/bool">
+        <ConfigurableElement Path="/Test/test/inline/bool">
           <BooleanParameter Name="bool">1</BooleanParameter>
         </ConfigurableElement>
       </Configuration>

--- a/test/xml-generator/testVector/reference.xml
+++ b/test/xml-generator/testVector/reference.xml
@@ -94,7 +94,7 @@
           <FixedPointParameter Name="q2.5">1.18750</FixedPointParameter>
         </ConfigurableElement>
         <ConfigurableElement Path="/Test/test/block/1/string">
-          <StringParameter Name="string">some string</StringParameter>
+          <StringParameter Name="string"></StringParameter>
         </ConfigurableElement>
       </Configuration>
       <Configuration Name="Green.Off">

--- a/tools/xmlGenerator/domainGeneratorConnector.cpp
+++ b/tools/xmlGenerator/domainGeneratorConnector.cpp
@@ -155,7 +155,7 @@ size_t XmlGenerator::parse(std::istream &input)
     while (not input.eof()) {
         std::getline(std::cin, line);
 
-        auto tokens = Tokenizer(line, string(1, '\0')).split();
+        auto tokens = Tokenizer(line, string(1, '\0'), false).split();
         if (tokens.empty()) {
             continue;
         }

--- a/utility/Tokenizer.cpp
+++ b/utility/Tokenizer.cpp
@@ -35,41 +35,36 @@ using std::vector;
 const string Tokenizer::defaultDelimiters = " \n\r\t\v\f";
 
 Tokenizer::Tokenizer(const string &input, const string &delimiters)
-    : _input(input), _delimiters(delimiters), _position(0)
+    : _input(input), _delimiters(delimiters)
 {
-}
-
-string Tokenizer::next()
-{
-    string token;
-
-    // Skip all leading delimiters
-    string::size_type tokenStart = _input.find_first_not_of(_delimiters, _position);
-
-    // Special case if there isn't any token anymore (string::substr's
-    // throws when pos==npos)
-    if (tokenStart == string::npos) {
-        return "";
-    }
-
-    // Starting from the token's start, find the first delimiter
-    string::size_type tokenEnd = _input.find_first_of(_delimiters, tokenStart);
-
-    _position = tokenEnd;
-
-    return _input.substr(tokenStart, tokenEnd - tokenStart);
 }
 
 vector<string> Tokenizer::split()
 {
     vector<string> result;
     string token;
+    bool leftover = false;
 
-    while (true) {
-        token = next();
-        if (token.empty()) {
-            return result;
+    for (const auto character : _input) {
+        if (_delimiters.find(character) != string::npos) {
+            leftover = false;
+            if (token.empty()) {
+                // skip consecutive delimiters
+                continue;
+            }
+
+            result.push_back(token);
+            token.clear();
+            continue;
         }
+        token += character;
+        leftover = true;
+    }
+
+    // push any leftover token:
+    if (leftover) {
         result.push_back(token);
     }
+
+    return result;
 }

--- a/utility/Tokenizer.cpp
+++ b/utility/Tokenizer.cpp
@@ -34,8 +34,8 @@ using std::vector;
 
 const string Tokenizer::defaultDelimiters = " \n\r\t\v\f";
 
-Tokenizer::Tokenizer(const string &input, const string &delimiters)
-    : _input(input), _delimiters(delimiters)
+Tokenizer::Tokenizer(const string &input, const string &delimiters, bool mergeDelimiters)
+    : _input(input), _delimiters(delimiters), _mergeDelimiters(mergeDelimiters)
 {
 }
 
@@ -47,10 +47,18 @@ vector<string> Tokenizer::split()
 
     for (const auto character : _input) {
         if (_delimiters.find(character) != string::npos) {
-            leftover = false;
-            if (token.empty()) {
-                // skip consecutive delimiters
-                continue;
+            if (_mergeDelimiters) {
+                leftover = false;
+                if (token.empty()) {
+                    // skip consecutive delimiters
+                    continue;
+                }
+            } else {
+                // We've encountered a delimiter, which means that there is a
+                // left-hand token and a right-side token. We are going to add
+                // the left-hand one but must not forget that there is a
+                // right-hand one (possibly empty)
+                leftover = true;
             }
 
             result.push_back(token);

--- a/utility/Tokenizer.h
+++ b/utility/Tokenizer.h
@@ -54,15 +54,11 @@ public:
     Tokenizer(const std::string &input, const std::string &delimiters = defaultDelimiters);
     ~Tokenizer(){};
 
-    /** Return the next token or an empty string if no more token
+    /** Return a vector of all tokens
      *
      * Multiple consecutive delimiters are considered as a single one - i.e.
      * "a     bc d   " will be tokenized as ("a", "bc", "d") if the delimiter
      * is ' '.
-     */
-    std::string next();
-
-    /** Return a vector of all tokens
      */
     std::vector<std::string> split();
 
@@ -72,6 +68,4 @@ public:
 private:
     const std::string _input;      //< string to be tokenized
     const std::string _delimiters; //< token delimiters
-
-    std::string::size_type _position; //< end of the last returned token
 };

--- a/utility/Tokenizer.h
+++ b/utility/Tokenizer.h
@@ -38,9 +38,6 @@
  *
  * Must be initialized with a string to be tokenized and, optionally, a string
  * of delimiters (@see Tokenizer::defaultDelimiters).
- *
- * Multiple consecutive delimiters (even if different) are considered as a
- * single one. As a result, there can't be empty tokens.
  */
 class Tokenizer : private utility::NonCopyable
 {
@@ -50,15 +47,15 @@ public:
      * @param[in] input The string to be tokenized
      * @param[in] delimiters A string containing all the token delimiters
      *            (hence, each delimiter can only be a single character)
+     * @param[in] mergeDelimiters If true, consecutive delimiters are considered
+     *            as one; leading and trailing delimiters are also ignored.
+     *            If false, consecutive delimiters produce empty tokens
      */
-    Tokenizer(const std::string &input, const std::string &delimiters = defaultDelimiters);
+    Tokenizer(const std::string &input, const std::string &delimiters = defaultDelimiters,
+              bool mergeDelimiters = true);
     ~Tokenizer(){};
 
     /** Return a vector of all tokens
-     *
-     * Multiple consecutive delimiters are considered as a single one - i.e.
-     * "a     bc d   " will be tokenized as ("a", "bc", "d") if the delimiter
-     * is ' '.
      */
     std::vector<std::string> split();
 
@@ -68,4 +65,5 @@ public:
 private:
     const std::string _input;      //< string to be tokenized
     const std::string _delimiters; //< token delimiters
+    const bool _mergeDelimiters;   //< whether subsequent delimiters should be merged
 };


### PR DESCRIPTION
Conflicting elements are elements belonging to more than one domain. The behaviour in such a case is unspecified.

In the context of XML generation from user input, this denotes a mistake from the user. We now warn him and fail the generation.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/329%23issuecomment-169950312%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/329%23discussion_r49187748%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/329%23issuecomment-170004971%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/329%23issuecomment-170836830%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/329%23discussion_r49456730%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/329%23discussion_r49460027%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/329%23discussion_r49462946%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/329%23issuecomment-169950312%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20please%20review.%22%2C%20%22created_at%22%3A%20%222016-01-08T09%3A52%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20%22%2C%20%22created_at%22%3A%20%222016-01-08T13%3A33%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%22%2C%20%22created_at%22%3A%20%222016-01-12T08%3A31%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20576f4445e7f7b8641644cafc75f623f0a858b811%20test/xml-generator/test.py%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/329%23discussion_r49456730%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22line%202%20long%22%2C%20%22created_at%22%3A%20%222016-01-12T14%3A03%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22nope%3A%20it%20is%2098%20chars%20long.%22%2C%20%22created_at%22%3A%20%222016-01-12T14%3A31%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-01-12T14%3A53%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/xml-generator/test.py%3AL90-132%22%7D%2C%20%22Pull%2037f085be71caaca56d5bdd9325355dac80ba8367%20test/xml-generator/test.py%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/329%23discussion_r49187748%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%20-%20deep%20copy%20%3F%5Cr%5Cn%20-%20Would%20it%20not%20be%20better%20to%20have%20nominal_pfconfig%20a%20NON%20static%20variable%20to%20avoid%20all%20those%20copy.%22%2C%20%22created_at%22%3A%20%222016-01-08T13%3A33%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/xml-generator/test.py%3AL115-136%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/329#issuecomment-169950312'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard please review.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :-1:
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :-1:
- [ ] <a href='#crh-comment-Pull 37f085be71caaca56d5bdd9325355dac80ba8367 test/xml-generator/test.py 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/329#discussion_r49187748'>File: test/xml-generator/test.py:L115-136</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - deep copy ?
- Would it not be better to have nominal_pfconfig a NON static variable to avoid all those copy.
- [x] <a href='#crh-comment-Pull 576f4445e7f7b8641644cafc75f623f0a858b811 test/xml-generator/test.py 46'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/329#discussion_r49456730'>File: test/xml-generator/test.py:L90-132</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> line 2 long
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> nope: it is 98 chars long.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/329?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/329?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/329'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>