### PR TITLE
Travis: Use dpkg asio instead of downloading it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,6 @@ install:
     # This version of catch is known to work.
     - wget --directory-prefix $PREFIX/include
               https://raw.github.com/philsquared/Catch/v1.2.1/single_include/catch.hpp
-    - wget 'https://01.org/sites/default/files/asio-1.10.6.tar.gz'
-    - tar xf asio-1.10.6.tar.gz -C $PREFIX --strip-components=1
 
 before_script:
     - coverage=OFF

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
             - ubuntu-toolchain-r-test
             - kubuntu-backports
             - llvm-toolchain-precise
+            - boost-latest
         # Travis white list of dpkg packages
         # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
         packages:
@@ -33,7 +34,7 @@ addons:
             - g++-4.8
             - cmake
             - python3-dev
-            - libasio-dev
+            - boost1.55 # For ASIO, their is no recent standalone package
             - clang-format-3.8
 
 install:


### PR DESCRIPTION
ASIO was downloaded and install instead of relying on Debian package.
This leaded to slower build and useless Travis worker bandwidth.

Use the white-listed libasio-dev apt package.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/333?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/333'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>