### PR TITLE
Switch from coveralls to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ addons:
             - clang-format-3.8
 
 install:
-    - pip install --user cpp-coveralls; export PATH=$HOME/.local/bin:$PATH
+    - wget https://codecov.io/bash -O $HOME/codecov; chmod +x $HOME/codecov
     # This version of catch is known to work.
     - wget --directory-prefix $PREFIX/include
               https://raw.github.com/philsquared/Catch/v1.2.1/single_include/catch.hpp
@@ -82,22 +82,25 @@ script:
         make install )
 
 after_success:
-    # Push coverage info on coveralls.io.
+    # Push coverage info on codecov.io.
     # Ignore generated files, samples and tests
     - if [ "${coverage}" = "ON" ]; then
-          coveralls --exclude "build_debug/bindings/python"
-                    --exclude "build_debug/CMakeFiles"
-                    --exclude "build"
-                    --exclude "install"
-                    --exclude "skeleton-subsystem"
-                    --exclude "tools/clientSimulator"
-                    --exclude "test/test-subsystem"
-                    --exclude "test/functional-tests"
-                    --exclude "bindings/c/Test.cpp"
-                    --exclude "test/tokenizer"
-                    --exclude "utility/test"
-                    --gcov /usr/bin/gcov-4.8
-                    --gcov-options '\--long-file-names --preserve-paths';
+          $HOME/codecov
+               -g "*/build_debug/bindings/python/*"
+               -g "*/build_debug/CMakeFiles/*"
+               -g "*/build/*"
+               -g "*/install/*"
+               -g "*/skeleton-subsystem/*"
+               -g "*/tools/clientSimulator/*"
+               -g "*/test/test-subsystem/*"
+               -g "*/test/introspection-subsystem/*"
+               -g "*/test/functional-tests/*"
+               -g "*/test/tmpfile/*"
+               -g "*/test/tokenizer/*"
+               -g "*/bindings/c/Test.cpp"
+               -g "*/utility/test/*"
+               -x /usr/bin/gcov-4.8
+               -a '\--long-file-names --preserve-paths';
       fi
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/01org/parameter-framework.svg?branch=master)](https://travis-ci.org/01org/parameter-framework)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/ga24jp8tet0qimbu/branch/master)](https://ci.appveyor.com/project/parameter-framework/parameter-framework)
-[![Coverage Status](https://coveralls.io/repos/01org/parameter-framework/badge.svg?branch=master)](https://coveralls.io/r/01org/parameter-framework)
+[![Coverage Status](https://codecov.io/github/01org/parameter-framework/coverage.svg?branch=master)](https://codecov.io/github/01org/parameter-framework?branch=master)
 
 ## Introduction
 


### PR DESCRIPTION
Codecov has a nicer UI and more features even though the coverage script is a
bit more painful to use.

Among nice new features is the ability to have coverage information displayed
on Pull Requests through a browser extension.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/344%23issuecomment-174933046%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/344%23issuecomment-174933768%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/344%23discussion_r50959079%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/344%23issuecomment-176245435%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/344%23issuecomment-174933046%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6078.80%25%60%5Cn%3EBranch%20%2A%2A%23344%2A%2A%20has%20no%20coverage%20reports%20uploaded%20yet.%5Cn%5Cn%5Cn%3E%20No%20diff%20could%20be%20generated.%20No%20reports%20for%20%60master%60%20found.%5Cn%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework%3Fref%3Dd3be3d6815508cca6d9c7be87e4643cedefeadee%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/features/suggestions%3Fref%3Dd3be3d6815508cca6d9c7be87e4643cedefeadee%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/commit/d3be3d6815508cca6d9c7be87e4643cedefeadee%5Cn%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-01-26T09%3A50%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40krocard%20%40tcahuzax%20please%20review.%22%2C%20%22created_at%22%3A%20%222016-01-26T09%3A52%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40krocard%20please%20re-review%22%2C%20%22created_at%22%3A%20%222016-01-28T15%3A54%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ce7f9799d726e5a4a303bb9e32cecee39ea4fcf4%20.travis.yml%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/344%23discussion_r50959079%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%20-%20Why%20use%20a%20process%20substitution%20instead%20of%20a%20regular%20pipe%20%3F%5Cr%5Cn%20-%20I%20would%20rather%20do%20the%20curl%20on%20a%20separate%20line%20in%20order%20to%20detect%20and%20explicit%20download%20failure%5Cr%5Cn%20-%20Why%20using%20curl%20where%20the%20rest%20of%20the%20script%20uses%20wget%20%28and%20long%20options%29%22%2C%20%22created_at%22%3A%20%222016-01-27T09%3A31%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20.travis.yml%3AL81-106%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/344#issuecomment-174933046'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `78.80%`
>Branch **#344** has no coverage reports uploaded yet.
> No diff could be generated. No reports for `master` found.
[1]: https://codecov.io/github/01org/parameter-framework?ref=d3be3d6815508cca6d9c7be87e4643cedefeadee
[2]: https://codecov.io/github/01org/parameter-framework/features/suggestions?ref=d3be3d6815508cca6d9c7be87e4643cedefeadee
[3]: https://codecov.io/github/01org/parameter-framework/commit/d3be3d6815508cca6d9c7be87e4643cedefeadee
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard @tcahuzax please review.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard please re-review
- [ ] <a href='#crh-comment-Pull ce7f9799d726e5a4a303bb9e32cecee39ea4fcf4 .travis.yml 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/344#discussion_r50959079'>File: .travis.yml:L81-106</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> - Why use a process substitution instead of a regular pipe ?
- I would rather do the curl on a separate line in order to detect and explicit download failure
- Why using curl where the rest of the script uses wget (and long options)


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/344?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/344?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/344'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>