### PR TITLE
Loose version format parsing

### DIFF
--- a/SetVersion.cmake
+++ b/SetVersion.cmake
@@ -58,7 +58,7 @@ if(NOT DEFINED PF_VERSION)
 endif()
 
 # Parse the version number to extract the various fields
-set(REGEX "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)-([0-9]+)(-(g[0-9a-f]+)?)?(-(dirty)?)?$")
+set(REGEX "([0-9]+).([0-9]+).([0-9]+).([0-9]+)(-(g[0-9a-f]+)?)?(-(dirty)?)?")
 if(PF_VERSION MATCHES ${REGEX})
     set(PF_VERSION_MAJOR ${CMAKE_MATCH_1})
     set(PF_VERSION_MINOR ${CMAKE_MATCH_2})


### PR DESCRIPTION
The CI can not set the version in a 0.0.0.0 format with
the PF_VERSION cmake variable. This is not consistent
with other internal project and not user friendly.

Allow the version tag to be any string composed of 4 numbers separated by any
non numeric character.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/346%23issuecomment-177955248%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/346%23issuecomment-177983378%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/346%23issuecomment-177955248%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6078.80%25%60%5Cn%3E%20Merging%20%2A%2A%23346%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20not%20affect%20coverage%20as%20of%20%5B%60acb01ed%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%23346%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20210%20%20%20%20210%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%207157%20%20%207157%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hit%20%20%20%20%20%20%20%20%20%20%205640%20%20%205640%20%20%20%20%20%20%20%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%201517%20%20%201517%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60acb01ed%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework%3Fref%3Dacb01ed6635870cc8e3c72689c4e36d983544472%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/features/suggestions%3Fref%3Dacb01ed6635870cc8e3c72689c4e36d983544472%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/commit/acb01ed6635870cc8e3c72689c4e36d983544472%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/compare/88d1d136eeb4d8d1d86e4acff230be9a809351d2...acb01ed6635870cc8e3c72689c4e36d983544472%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-02-01T12%3A38%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-01T13%3A59%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/346#issuecomment-177955248'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `78.80%`
> Merging **#346** into **master** will not affect coverage as of [`acb01ed`][3]
```diff
@@            master   #346   diff @@
=====================================
Files          210    210
Stmts         7157   7157
Branches         0      0
Methods          0      0
=====================================
Hit           5640   5640
Partial          0      0
Missed        1517   1517
```
> Review entire [Coverage Diff][4] as of [`acb01ed`][3]
[1]: https://codecov.io/github/01org/parameter-framework?ref=acb01ed6635870cc8e3c72689c4e36d983544472
[2]: https://codecov.io/github/01org/parameter-framework/features/suggestions?ref=acb01ed6635870cc8e3c72689c4e36d983544472
[3]: https://codecov.io/github/01org/parameter-framework/commit/acb01ed6635870cc8e3c72689c4e36d983544472
[4]: https://codecov.io/github/01org/parameter-framework/compare/88d1d136eeb4d8d1d86e4acff230be9a809351d2...acb01ed6635870cc8e3c72689c4e36d983544472
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/346?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/346?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/346'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>