### PR TITLE
Windows/Resource.rc: use user-provided version as "nice" fileversion

### DIFF
--- a/SetVersion.cmake
+++ b/SetVersion.cmake
@@ -55,6 +55,9 @@ if(NOT DEFINED PF_VERSION)
             set(PF_VERSION "${CMAKE_MATCH_1}-0")
         endif()
     endif()
+else()
+    # Set the "nice version string" to the one forced by the user
+    set(NICE_PF_VERSION "${PF_VERSION}")
 endif()
 
 # Parse the version number to extract the various fields
@@ -68,8 +71,8 @@ if(PF_VERSION MATCHES ${REGEX})
     set(PF_VERSION_DIRTY ${CMAKE_MATCH_8}) # Skip the 7th: it is a superset of the 8th
 endif()
 
-# If we are precisely on a tag, make a nicer version string
-set(NICE_PF_VERSION "${PF_VERSION}")
-if((PF_VERSION_TWEAK EQUAL 0) AND (NOT PF_VERSION_DIRTY))
+# If we are precisely on a tag, make a nicer version string (unless otherwise
+# forced by the user - see above)
+if((NOT DEFINED NICE_PF_VERSION) AND (PF_VERSION_TWEAK EQUAL 0) AND (NOT PF_VERSION_DIRTY))
     set(NICE_PF_VERSION "v${PF_VERSION_MAJOR}.${PF_VERSION_MINOR}.${PF_VERSION_PATCH}")
 endif()

--- a/SetVersion.cmake
+++ b/SetVersion.cmake
@@ -27,12 +27,12 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Fallback values:
-set(PF_VERSION_MAJOR 0 CACHE INTERNAL "Parameter Framework's version major number")
-set(PF_VERSION_MINOR 0 CACHE INTERNAL "Parameter Framework's version minor number")
-set(PF_VERSION_PATCH 0 CACHE INTERNAL "Parameter Framework's version patch number")
-set(PF_VERSION_TWEAK 0 CACHE INTERNAL "Parameter Framework's version tweak (or build) number")
-set(PF_VERSION_SHA1 "g0000000000" CACHE INTERNAL "Parameter Framework's sources git SHA1")
-set(PF_VERSION_DIRTY "" CACHE INTERNAL "Parameter Framework's sources dirty marker")
+set(PF_VERSION_MAJOR 0)
+set(PF_VERSION_MINOR 0)
+set(PF_VERSION_PATCH 0)
+set(PF_VERSION_TWEAK 0)
+set(PF_VERSION_SHA1 "g0000000000")
+set(PF_VERSION_DIRTY "")
 
 # Find and set the Parameter Framework's version
 # First, let's see if the user forced a version (i.e. "vX.Y.Z-N")
@@ -69,7 +69,7 @@ if(PF_VERSION MATCHES ${REGEX})
 endif()
 
 # If we are precisely on a tag, make a nicer version string
-set(NICE_PF_VERSION "${PF_VERSION}" CACHE INTERNAL "")
+set(NICE_PF_VERSION "${PF_VERSION}")
 if((PF_VERSION_TWEAK EQUAL 0) AND (NOT PF_VERSION_DIRTY))
     set(NICE_PF_VERSION "v${PF_VERSION_MAJOR}.${PF_VERSION_MINOR}.${PF_VERSION_PATCH}")
 endif()

--- a/support/windows/Resource.rc.in
+++ b/support/windows/Resource.rc.in
@@ -60,12 +60,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Intel Corporation"
             VALUE "FileDescription", "@WINRC_FILE_DESCRIPTION@"
-            VALUE "FileVersion", "v@WINRC_MAJOR@.@WINRC_MINOR@.@WINRC_PATCH@.@WINRC_TWEAK@"
+            VALUE "FileVersion", "@NICE_PF_VERSION@"
             VALUE "InternalName", WINRC_FILENAME
             VALUE "LegalCopyright", "Copyright (c) 2011-2016 Intel Corporation"
             VALUE "OriginalFilename", WINRC_FILENAME
             VALUE "ProductName", "Parameter Framework"
-            VALUE "ProductVersion", "v@WINRC_MAJOR@.@WINRC_MINOR@.@WINRC_PATCH@.@WINRC_TWEAK@"
+            VALUE "ProductVersion", "@NICE_PF_VERSION@"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
There are two instances of FileVersion (resp. ProductVersion): a numerical one
and a literal one. If the user forced a version string, use it as-is as the
literal one.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/348%23issuecomment-179361978%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23issuecomment-179364209%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23issuecomment-179732028%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23issuecomment-179762313%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23issuecomment-179770264%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23issuecomment-179773231%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23discussion_r51854809%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23discussion_r51855006%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23discussion_r51855195%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23discussion_r51855956%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/348%23discussion_r51858404%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/348%23issuecomment-179361978%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40tcahuzax%20%40krocard%20please%20review%22%2C%20%22created_at%22%3A%20%222016-02-03T17%3A28%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6078.80%25%60%5Cn%3E%20Merging%20%2A%2A%23348%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20not%20affect%20coverage%20as%20of%20%5B%60a7ee525%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%23348%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20210%20%20%20%20210%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%207159%20%20%207159%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hit%20%20%20%20%20%20%20%20%20%20%205642%20%20%205642%20%20%20%20%20%20%20%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%201517%20%20%201517%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60a7ee525%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework%3Fref%3Da7ee5258fbbd01fe45a4232cc77af7c2740529a0%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/features/suggestions%3Fref%3Da7ee5258fbbd01fe45a4232cc77af7c2740529a0%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/commit/a7ee5258fbbd01fe45a4232cc77af7c2740529a0%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/compare/58f14518c668eb52789ecced4fe45258d9e5304e...a7ee5258fbbd01fe45a4232cc77af7c2740529a0%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-02-03T17%3A33%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-02-04T09%3A34%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A35%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40krocard%20please%20re-review%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A56%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-04T11%3A06%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2000c35bab12caf3f32083f2f4f52a8a51da25236b%20SetVersion.cmake%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/348%23discussion_r51854809%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Set%20the%20CACHE%5Cu00a0variable%2C%20do%20not%20create%20a%20new%20normal%20one%20with%20the%20same%20name%5Cu00a0%21%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A32%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22see%20https%3A//cmake.org/cmake/help/v3.0/command/set.html%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A33%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-04T11%3A05%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20SetVersion.cmake%3AL56-65%22%7D%2C%20%22Pull%2000c35bab12caf3f32083f2f4f52a8a51da25236b%20SetVersion.cmake%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/348%23discussion_r51855195%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22idem%20on%20the%20next%20line%2C%20set%20the%20cache%20variable%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A35%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20you%20want%20to%20move%20this%20test%20in%20the%20%60if%28NOT%20DEFINED%20PF_VERSION%29%60%20block.%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A40%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20SetVersion.cmake%3AL72-80%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 00c35bab12caf3f32083f2f4f52a8a51da25236b SetVersion.cmake 27'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/348#discussion_r51855195'>File: SetVersion.cmake:L72-80</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> idem on the next line, set the cache variable
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Maybe you want to move this test in the `if(NOT DEFINED PF_VERSION)` block.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/348#issuecomment-179361978'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @tcahuzax @krocard please review
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `78.80%`
> Merging **#348** into **master** will not affect coverage as of [`a7ee525`][3]
```diff
@@            master   #348   diff @@
=====================================
Files          210    210
Stmts         7159   7159
Branches         0      0
Methods          0      0
=====================================
Hit           5642   5642
Partial          0      0
Missed        1517   1517
```
> Review entire [Coverage Diff][4] as of [`a7ee525`][3]
[1]: https://codecov.io/github/01org/parameter-framework?ref=a7ee5258fbbd01fe45a4232cc77af7c2740529a0
[2]: https://codecov.io/github/01org/parameter-framework/features/suggestions?ref=a7ee5258fbbd01fe45a4232cc77af7c2740529a0
[3]: https://codecov.io/github/01org/parameter-framework/commit/a7ee5258fbbd01fe45a4232cc77af7c2740529a0
[4]: https://codecov.io/github/01org/parameter-framework/compare/58f14518c668eb52789ecced4fe45258d9e5304e...a7ee5258fbbd01fe45a4232cc77af7c2740529a0
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> :-1:
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard please re-review
- [x] <a href='#crh-comment-Pull 00c35bab12caf3f32083f2f4f52a8a51da25236b SetVersion.cmake 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/348#discussion_r51854809'>File: SetVersion.cmake:L56-65</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Set the CACHE variable, do not create a new normal one with the same name !
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> see https://cmake.org/cmake/help/v3.0/command/set.html


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/348?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/348?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/348?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/348'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>