### PR TITLE
CMake/Windows: Require CMake 3.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# working on 2.8.12 - broken on older versions
+# working on 2.8.12 - broken on older versions.
+# Visual Studio 14 needs 3.3.0; see https://cmake.org/Bug/print_bug_page.php?bug_id=15552
 cmake_minimum_required(VERSION 2.8.12)
+if(CMAKE_GENERATOR STRGREATER "Visual Studio 14 2015")
+    cmake_minimum_required(VERSION 3.3.0)
+endif()
 
 project(parameter-framework)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ sections:
 
 In order to compile you'll need, at the very least:
 
-- CMake (v2.8.12 or later);
+- CMake (v2.8.12 or later) (v3.3.0 or later on Windows);
 - A C/C++ compiler supporting C++11;
 - libxml2 headers and libraries (Provided by the `libxml2-dev` on debian-based
 distributions);


### PR DESCRIPTION
A bug on CMake prevents CPack from working with Visual Studio 14 prior to CMake
3.3.0, cf. https://cmake.org/Bug/print_bug_page.php?bug_id=15552. When using
this toolchain, make sure that at least CMake 3.3.0 is used.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/349%23issuecomment-179742613%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/349%23issuecomment-179749845%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/349%23issuecomment-179749964%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/349%23issuecomment-179742613%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6078.80%25%60%5Cn%3E%20Merging%20%2A%2A%23349%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20not%20affect%20coverage%20as%20of%20%5B%60ce38400%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%23349%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20210%20%20%20%20210%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%207159%20%20%207159%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hit%20%20%20%20%20%20%20%20%20%20%205642%20%20%205642%20%20%20%20%20%20%20%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%201517%20%20%201517%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60ce38400%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework%3Fref%3Dce38400631f91b4f192d942af1f39a1cdf09cd9f%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/features/suggestions%3Fref%3Dce38400631f91b4f192d942af1f39a1cdf09cd9f%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/commit/ce38400631f91b4f192d942af1f39a1cdf09cd9f%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/compare/8ca3cad1af2c24d79ca8de22a15274c85341fc27...ce38400631f91b4f192d942af1f39a1cdf09cd9f%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A01%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A16%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-02-04T10%3A16%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/349#issuecomment-179742613'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `78.80%`
> Merging **#349** into **master** will not affect coverage as of [`ce38400`][3]
```diff
@@            master   #349   diff @@
=====================================
Files          210    210
Stmts         7159   7159
Branches         0      0
Methods          0      0
=====================================
Hit           5642   5642
Partial          0      0
Missed        1517   1517
```
> Review entire [Coverage Diff][4] as of [`ce38400`][3]
[1]: https://codecov.io/github/01org/parameter-framework?ref=ce38400631f91b4f192d942af1f39a1cdf09cd9f
[2]: https://codecov.io/github/01org/parameter-framework/features/suggestions?ref=ce38400631f91b4f192d942af1f39a1cdf09cd9f
[3]: https://codecov.io/github/01org/parameter-framework/commit/ce38400631f91b4f192d942af1f39a1cdf09cd9f
[4]: https://codecov.io/github/01org/parameter-framework/compare/8ca3cad1af2c24d79ca8de22a15274c85341fc27...ce38400631f91b4f192d942af1f39a1cdf09cd9f
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/349?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/349?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/349'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>