### PR TITLE
Fix ElementHandle::setAs.*Array methods

### DIFF
--- a/parameter/ElementHandle.cpp
+++ b/parameter/ElementHandle.cpp
@@ -41,6 +41,20 @@ using std::string;
 using std::mutex;
 using std::lock_guard;
 
+/** @return 0 by default, ie for non overloaded types. */
+template <class T>
+static size_t getUserInputSize(const T & /*scalar*/)
+{
+    return 0;
+}
+
+/** @return the vector's size. */
+template <class T>
+static size_t getUserInputSize(const std::vector<T> &vector)
+{
+    return vector.size();
+}
+
 ElementHandle::ElementHandle(CConfigurableElement &element, CParameterMgr &parameterMgr)
     : mElement(element), mParameterMgr(parameterMgr)
 {
@@ -146,18 +160,6 @@ struct isVector<std::vector<T>> : std::true_type
 {
 };
 
-template <class T>
-size_t ElementHandle::getSize(T /*value*/)
-{
-    return 0;
-}
-
-template <class T>
-size_t ElementHandle::getSize(std::vector<T> &values)
-{
-    return values.size();
-}
-
 bool ElementHandle::getAsXML(std::string &xmlValue, std::string &error) const
 {
     std::string result;
@@ -194,7 +196,7 @@ bool ElementHandle::setAsBytes(const std::vector<uint8_t> &bytesValue, std::stri
 template <class T>
 bool ElementHandle::setAs(const T value, string &error) const
 {
-    if (not checkSetValidity(getSize(value), error)) {
+    if (not checkSetValidity(getUserInputSize(value), error)) {
         return false;
     }
     // Safe downcast thanks to isParameter check in checkSetValidity

--- a/parameter/include/ElementHandle.h
+++ b/parameter/include/ElementHandle.h
@@ -234,11 +234,6 @@ private:
     template <class T>
     bool getAs(T &value, std::string &error) const;
 
-    template <class T>
-    static size_t getSize(T value);
-    template <class T>
-    static size_t getSize(std::vector<T> &values);
-
     CBaseParameter &getParameter();
     const CBaseParameter &getParameter() const;
 

--- a/test/functional-tests/Handle.cpp
+++ b/test/functional-tests/Handle.cpp
@@ -602,4 +602,46 @@ SCENARIO("Mapping handle access", "[handler][mapping]")
     }
 }
 
+SCENARIO_METHOD(SettingsTestPF, "Handle Get/Set as various kinds", "[handler][dynamic]")
+{
+    ElementHandle intScalar(*this, "/test/test/parameter_block/integer");
+    WHEN ("Setting a scalar integer") {
+        WHEN ("As an array") {
+            THEN ("It should fail") {
+                CHECK_THROWS(intScalar.setAsIntegerArray({0, 0}));
+            }
+        }
+        WHEN ("As a scalalar") {
+            THEN ("It should succeed") {
+                uint32_t expected = 111;
+                CHECK_NOTHROW(intScalar.setAsInteger(expected));
+                AND_THEN ("Getting it back should give the same value") {
+                    uint32_t back = 42;
+                    CHECK_NOTHROW(intScalar.getAsInteger(back));
+                    CHECK(back == expected);
+                }
+            }
+        }
+    }
+
+    ElementHandle intArray(*this, "/test/test/parameter_block/integer_array");
+    WHEN ("Setting a array integer") {
+        WHEN ("As a scalar") {
+            THEN ("It should fail") {
+                CHECK_THROWS(intArray.setAsSignedInteger(0));
+            }
+        }
+        WHEN ("As a integer") {
+            THEN ("It should succeed") {
+                const std::vector<int32_t> expected = {-9, 8, -7, 6};
+                CHECK_NOTHROW(intArray.setAsSignedIntegerArray(expected));
+                AND_THEN ("Getting it back should give the same value") {
+                    std::vector<int32_t> back = {-42, 42, 43, -43};
+                    CHECK_NOTHROW(intArray.getAsSignedIntegerArray(back));
+                    CHECK(back == expected);
+                }
+            }
+        }
+    }
+}
 } // namespace parameterFramework

--- a/test/functional-tests/include/ElementHandle.hpp
+++ b/test/functional-tests/include/ElementHandle.hpp
@@ -76,6 +76,28 @@ public:
     /** Wrap EH::getAsDouble to throw an exception on failure. */
     void getAsDouble(double &value) const { mayFailCall(&EH::getAsDouble, value); }
 
+    void setAsInteger(uint32_t value) { mayFailCall(&EH::setAsInteger, value); }
+    void getAsInteger(uint32_t &value) const { mayFailCall(&EH::getAsInteger, value); }
+    void setAsIntegerArray(const std::vector<uint32_t> &value)
+    {
+        mayFailCall(&EH::setAsIntegerArray, value);
+    }
+    void getAsIntegerArray(std::vector<uint32_t> &value) const
+    {
+        mayFailCall(&EH::getAsIntegerArray, value);
+    }
+
+    void setAsSignedInteger(int32_t value) { mayFailCall(&EH::setAsSignedInteger, value); }
+    void getAsSignedInteger(int32_t &value) const { mayFailCall(&EH::getAsSignedInteger, value); }
+    void setAsSignedIntegerArray(const std::vector<int32_t> &value)
+    {
+        mayFailCall(&EH::setAsSignedIntegerArray, value);
+    }
+    void getAsSignedIntegerArray(std::vector<int32_t> &value) const
+    {
+        mayFailCall(&EH::getAsSignedIntegerArray, value);
+    }
+
     std::string getStructureAsXML() const { return mayFailGet(&EH::getStructureAsXML); }
 
     std::string getAsXML() const { return mayFailGet(&EH::getAsXML); }


### PR DESCRIPTION
Direct accesses to array parameters were incorrectly identified, resulting in
an error when the client tried to set them. This was caused by a programming
mistake in using overloaded methods because `T`, `const T`, `T &` and `const
T&` are different. This is fixed by using the SFINAE principle and correctly
handing all the cases described above.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/351%23issuecomment-181279657%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/351%23issuecomment-181285501%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/351%23discussion_r52152550%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/351%23discussion_r52178211%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/351%23discussion_r52188344%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/351%23issuecomment-181449961%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/351%23issuecomment-181279657%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40krocard%20%40tcahuzax%20please%20review.%22%2C%20%22created_at%22%3A%20%222016-02-08T09%3A46%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6079.54%25%60%5Cn%3E%20Merging%20%2A%2A%23351%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20increase%20coverage%20by%20%2A%2A%2B0.73%25%2A%2A%20as%20of%20%5B%6030a7c5f%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23351%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20210%20%20%20%20%20210%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%207161%20%20%20%207163%20%20%20%20%20%2B2%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hit%20%20%20%20%20%20%20%20%20%20%205644%20%20%20%205698%20%20%20%20%2B54%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%2B%20Missed%20%20%20%20%20%20%20%201517%20%20%20%201465%20%20%20%20-52%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%6030a7c5f%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework%3Fref%3D30a7c5fef48042e48b5e54c75a5bbb4ae0c7cb89%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/features/suggestions%3Fref%3D30a7c5fef48042e48b5e54c75a5bbb4ae0c7cb89%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/commit/30a7c5fef48042e48b5e54c75a5bbb4ae0c7cb89%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/compare/cea9fe75d7b5eea4ed917e4127f304bce395d6d7...30a7c5fef48042e48b5e54c75a5bbb4ae0c7cb89%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-02-08T10%3A03%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-08T16%3A30%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20469d9a066f3a7224f95cf38d0bbf595e23654633%20parameter/ElementHandle.cpp%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/351%23discussion_r52152550%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Consider%20using%20SFINAL%20to%20test%20for%20size%28%29%20method%20existence%5Cr%5Cn%60%60%60%20cpp%5Cr%5Cn%5Cr%5Cn/%2A%2A%20%40return%200%20by%20default%2C%20ie%20for%20non%20overloaded%20types.%20%2A/%5Cr%5Cn%20size_t%20getUserInputSize%28...%29%20%7B%20return%200%3B%20%7D%5Cr%5Cn%5Cr%5Cn/%2A%2A%20%40return%20collection%20size%20if%20it%20has%20a%20size%28%29%20method.%20does%20not%20participate%20to%20overload%20otherwise.%20%2A/%5Cr%5Cntemplate%20%3Cclass%20T%2C%20class...%2C%20class%20%3D%20decltype%28%26T%3A%3Asize%29%3E%5Cr%5Cnsize_t%20getUserInputSize%28T%20collection%29%20%7B%20return%20collection.size%28%29%3B%20%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-02-08T10%3A28%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%20it%20is%20worth%20it%3A%20It%20works%20but%20only%20if%20I%20add%20an%20overload%20for%20std%3A%3Astring%20%28it%20has%20a%20size%20method%20but%20we%20don%27t%20want%20to%20consider%20it%20as%20a%20collection%29.%20I%20can%27t%20guarantee%2C%20ahead%20of%20time%2C%20that%20no%20future%20%5C%22scalar%5C%22%20type%20will%20have%20a%20size%28%29%20method.%20We%20would%20rely%20too%20much%20on%20future%20tests%20begin%20correctly%20written.%22%2C%20%22created_at%22%3A%20%222016-02-08T14%3A58%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20right%2C%20then%20this%20should%20work%3A%5Cr%5Cn%60%60%60%5Cr%5Cnsize_t%20f%28...%29%20%7B%20return%200%3B%20%7D%5Cr%5Cn%5Cr%5Cntemplate%20%3Cclass%20T%3E%5Cr%5Cnsize_t%20f%28const%20std%3A%3Avector%3CT%3E%20%26t%29%20%7B%20return%20t.size%28%29%3B%20%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-02-08T16%3A12%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/ElementHandle.cpp%3AL41-77%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 469d9a066f3a7224f95cf38d0bbf595e23654633 parameter/ElementHandle.cpp 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/351#discussion_r52152550'>File: parameter/ElementHandle.cpp:L41-77</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Consider using SFINAL to test for size() method existence
``` cpp
/** @return 0 by default, ie for non overloaded types. */
size_t getUserInputSize(...) { return 0; }
/** @return collection size if it has a size() method. does not participate to overload otherwise. */
template <class T, class..., class = decltype(&T::size)>
size_t getUserInputSize(T collection) { return collection.size(); }
```
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> I'm not sure it is worth it: It works but only if I add an overload for std::string (it has a size method but we don't want to consider it as a collection). I can't guarantee, ahead of time, that no future "scalar" type will have a size() method. We would rely too much on future tests begin correctly written.
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> You are right, then this should work:
```
size_t f(...) { return 0; }
template <class T>
size_t f(const std::vector<T> &t) { return t.size(); }
```
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/351#issuecomment-181279657'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard @tcahuzax please review.
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `79.54%`
> Merging **#351** into **master** will increase coverage by **+0.73%** as of [`30a7c5f`][3]
```diff
@@            master    #351   diff @@
======================================
Files          210     210
Stmts         7161    7163     +2
Branches         0       0
Methods          0       0
======================================
+ Hit           5644    5698    +54
Partial          0       0
+ Missed        1517    1465    -52
```
> Review entire [Coverage Diff][4] as of [`30a7c5f`][3]
[1]: https://codecov.io/github/01org/parameter-framework?ref=30a7c5fef48042e48b5e54c75a5bbb4ae0c7cb89
[2]: https://codecov.io/github/01org/parameter-framework/features/suggestions?ref=30a7c5fef48042e48b5e54c75a5bbb4ae0c7cb89
[3]: https://codecov.io/github/01org/parameter-framework/commit/30a7c5fef48042e48b5e54c75a5bbb4ae0c7cb89
[4]: https://codecov.io/github/01org/parameter-framework/compare/cea9fe75d7b5eea4ed917e4127f304bce395d6d7...30a7c5fef48042e48b5e54c75a5bbb4ae0c7cb89
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/351?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/351?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/351'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>