### PR TITLE
Integer template specializations: use builtin types instead of stdint

### DIFF
--- a/utility/convert.hpp
+++ b/utility/convert.hpp
@@ -52,35 +52,43 @@ struct ConvertionAllowed<bool> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowed<uint64_t> : std::true_type
+struct ConvertionAllowed<long long> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowed<int64_t> : std::true_type
+struct ConvertionAllowed<unsigned long long> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowed<uint32_t> : std::true_type
+struct ConvertionAllowed<long> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowed<int32_t> : std::true_type
+struct ConvertionAllowed<unsigned long> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowed<uint16_t> : std::true_type
+struct ConvertionAllowed<int> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowed<int16_t> : std::true_type
+struct ConvertionAllowed<unsigned int> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowed<int8_t> : std::true_type
+struct ConvertionAllowed<short> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowed<uint8_t> : std::true_type
+struct ConvertionAllowed<unsigned short> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<unsigned char> : std::true_type
+{
+};
+template <>
+struct ConvertionAllowed<signed char> : std::true_type
 {
 };
 template <>
@@ -98,11 +106,11 @@ struct ConvertionAllowedVia : std::false_type
 {
 };
 template <>
-struct ConvertionAllowedVia<uint8_t, uint32_t> : std::true_type
+struct ConvertionAllowedVia<unsigned char, unsigned int> : std::true_type
 {
 };
 template <>
-struct ConvertionAllowedVia<int8_t, int32_t> : std::true_type
+struct ConvertionAllowedVia<signed char, int> : std::true_type
 {
 };
 
@@ -191,16 +199,16 @@ static inline bool convertTo(const std::string &str, T &result)
     return details::convertTo<T>(str, result);
 }
 
-/** Specialization for uint8_t of convertTo template function.
+/** Specialization for unsigned char of convertTo template function.
  *
  * This function follows the same paradigm than it's generic version.
  *
- * The generic version was converting int8 as it was a character
- * (uint8_t is an alias to unsigned char on most compiler).
+ * The generic version was converting char as it was a character
+ * (unsigned char is an alias to unsigned char on most compiler).
  * Thus converting "1" would return 49 ie '1'.
  * As convertTo is thought as an _numerical_ convertion tool
  * (contrary to boost::lexical_cast for example),
- * forbid considering the input as a character and consider uint8_t
+ * forbid considering the input as a character and consider unsigned char
  * (aka unsigned char) as a number exclusively.
  *
  * @param[in]  str    the string to parse.
@@ -209,21 +217,20 @@ static inline bool convertTo(const std::string &str, T &result)
  * @return true if conversion was successful, false otherwise.
  */
 template <>
-inline bool convertTo<uint8_t>(const std::string &str, uint8_t &result)
+inline bool convertTo<unsigned char>(const std::string &str, unsigned char &result)
 {
-    return details::convertToVia<uint8_t, uint32_t>(str, result);
+    return details::convertToVia<unsigned char, unsigned int>(str, result);
 }
 
-/** Specialization for int8_t of convertTo template function.
+/** Specialization for signed char of convertTo template function.
  *
- * @see convertTo<uint8_t>
+ * @see convertTo<unsigned char>
  */
 template <>
-inline bool convertTo<int8_t>(const std::string &str, int8_t &result)
+inline bool convertTo<signed char>(const std::string &str, signed char &result)
 {
-    return details::convertToVia<int8_t, int32_t>(str, result);
+    return details::convertToVia<signed char, int>(str, result);
 }
-
 /**
  * Specialization for float of convertTo template function.
  *

--- a/xmlserializer/XmlElement.cpp
+++ b/xmlserializer/XmlElement.cpp
@@ -265,17 +265,27 @@ bool CXmlElement::CChildIterator::next(CXmlElement &xmlChildElement)
 }
 
 template bool CXmlElement::getAttribute(const std::string &name, std::string &value) const;
-template bool CXmlElement::getAttribute(const std::string &name, uint16_t &value) const;
-template bool CXmlElement::getAttribute(const std::string &name, uint32_t &value) const;
-template bool CXmlElement::getAttribute(const std::string &name, int32_t &value) const;
-template bool CXmlElement::getAttribute(const std::string &name, uint64_t &value) const;
 template bool CXmlElement::getAttribute(const std::string &name, bool &value) const;
-template bool CXmlElement::getAttribute(const std::string &name, double &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, short &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, unsigned short &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, int &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, unsigned int &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, long &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, unsigned long &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, long long &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, unsigned long long &value) const;
 template bool CXmlElement::getAttribute(const std::string &name, float &value) const;
+template bool CXmlElement::getAttribute(const std::string &name, double &value) const;
 
 template void CXmlElement::setAttribute(const std::string &name, const std::string &value);
 template void CXmlElement::setAttribute(const std::string &name, const bool &value);
-template void CXmlElement::setAttribute(const std::string &name, const int32_t &value);
-template void CXmlElement::setAttribute(const std::string &name, const uint32_t &value);
-template void CXmlElement::setAttribute(const std::string &name, const uint64_t &value);
+template void CXmlElement::setAttribute(const std::string &name, const short &value);
+template void CXmlElement::setAttribute(const std::string &name, const unsigned short &value);
+template void CXmlElement::setAttribute(const std::string &name, const int &value);
+template void CXmlElement::setAttribute(const std::string &name, const unsigned int &value);
+template void CXmlElement::setAttribute(const std::string &name, const long &value);
+template void CXmlElement::setAttribute(const std::string &name, const unsigned long &value);
+template void CXmlElement::setAttribute(const std::string &name, const long long &value);
+template void CXmlElement::setAttribute(const std::string &name, const unsigned long long &value);
 template void CXmlElement::setAttribute(const std::string &name, const float &value);
+template void CXmlElement::setAttribute(const std::string &name, const double &value);


### PR DESCRIPTION
Template resolution is tied to name mangling. Since we can't know for sure
which builtin type is used for each of int64_t, uint32_t, etc. we can't rely on
these typedefs. Builtin types, however, are reliable.

As an exemple: on some ABIs, size_t can be a long long but uint64_t a mere
long which means that for this particular platform, a call with a size_t
argument will not match a template instantiation with a uint64_t.

Signed-off-by: David Wagner <david.wagner@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/354%23issuecomment-188155332%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/354%23issuecomment-188168005%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/354%23issuecomment-188251033%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/354%23issuecomment-188251725%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/354%23discussion_r53931248%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/354%23discussion_r53931949%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/354%23discussion_r53935734%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/354%23issuecomment-188155332%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6080.33%25%60%5Cn%3E%20Merging%20%2A%2A%23354%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20not%20affect%20coverage%20as%20of%20%5B%605e23c39%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23354%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20210%20%20%20%20%20210%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%207179%20%20%20%207179%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hit%20%20%20%20%20%20%20%20%20%20%205767%20%20%20%205767%20%20%20%20%20%20%20%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%201412%20%20%20%201412%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%605e23c39%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework%3Fref%3D5e23c39772d5612b6b81456e6072eb54b57d4604%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/features/suggestions%3Fref%3D5e23c39772d5612b6b81456e6072eb54b57d4604%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/commit/5e23c39772d5612b6b81456e6072eb54b57d4604%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/compare/155f46f017b1974a9b0dd8e88d1f1e0221b5196a...5e23c39772d5612b6b81456e6072eb54b57d4604%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-02-24T09%3A19%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tcahuzax%20%40krocard%20%40cc6565%20please%20review.%22%2C%20%22created_at%22%3A%20%222016-02-24T09%3A48%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-02-24T13%3A14%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-24T13%3A18%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a143c75887af2184185c9c389434f571cc7e7b77%20utility/convert.hpp%2059%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/354%23discussion_r53931248%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Consider%20using%20unsigned%20char%20instead%20of%20uint8_t%20to%20convert%20it.%22%2C%20%22created_at%22%3A%20%222016-02-24T12%3A29%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20utility/convert.hpp%3AL217-224%22%7D%2C%20%22Pull%20a143c75887af2184185c9c389434f571cc7e7b77%20xmlserializer/XmlElement.cpp%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/354%23discussion_r53931949%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20symmetrizing%20the%20set%20and%20get%20supported%20type.%22%2C%20%22created_at%22%3A%20%222016-02-24T12%3A36%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222016-02-24T13%3A15%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20xmlserializer/XmlElement.cpp%3AL265-288%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/krocard%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/krocard'><img src='https://avatars.githubusercontent.com/u/6862950?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull a143c75887af2184185c9c389434f571cc7e7b77 utility/convert.hpp 59'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/354#discussion_r53931248'>File: utility/convert.hpp:L217-224</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Consider using unsigned char instead of uint8_t to convert it.
- [ ] <a href='#crh-comment-Pull a143c75887af2184185c9c389434f571cc7e7b77 xmlserializer/XmlElement.cpp 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/354#discussion_r53931949'>File: xmlserializer/XmlElement.cpp:L265-288</a></b>
- <a href='https://github.com/krocard'><img border=0 src='https://avatars.githubusercontent.com/u/6862950?v=3' height=16 width=16'></a> Please symmetrizing the set and get supported type.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> done
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/354#issuecomment-188155332'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `80.33%`
> Merging **#354** into **master** will not affect coverage as of [`5e23c39`][3]
```diff
@@            master    #354   diff @@
======================================
Files          210     210
Stmts         7179    7179
Branches         0       0
Methods          0       0
======================================
Hit           5767    5767
Partial          0       0
Missed        1412    1412
```
> Review entire [Coverage Diff][4] as of [`5e23c39`][3]
[1]: https://codecov.io/github/01org/parameter-framework?ref=5e23c39772d5612b6b81456e6072eb54b57d4604
[2]: https://codecov.io/github/01org/parameter-framework/features/suggestions?ref=5e23c39772d5612b6b81456e6072eb54b57d4604
[3]: https://codecov.io/github/01org/parameter-framework/commit/5e23c39772d5612b6b81456e6072eb54b57d4604
[4]: https://codecov.io/github/01org/parameter-framework/compare/155f46f017b1974a9b0dd8e88d1f1e0221b5196a...5e23c39772d5612b6b81456e6072eb54b57d4604
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @tcahuzax @krocard @cc6565 please review.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/354?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/354?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/354?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/354'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>