### PR TITLE
xml-generator: be compatible with both python2.7 and 3.x

### DIFF
--- a/tools/xmlGenerator/EddParser.py
+++ b/tools/xmlGenerator/EddParser.py
@@ -877,12 +877,12 @@ the rest is the rest of the line."""
                 context.append(myelement)
                 context[-2].addChild(myelement)
 
-            except MySyntaxWarning, ex:
+            except MySyntaxWarning as ex:
                 ex.setLine(line, num + 1)
                 if verbose :
-                    print >>sys.stderr, ex
+                    sys.stderr.write("{}\n".format(ex))
 
-            except MySyntaxError, ex :
+            except MySyntaxErro as  ex :
                 ex.setLine(line, num + 1)
                 raise
 

--- a/tools/xmlGenerator/PFWScriptGenerator.py
+++ b/tools/xmlGenerator/PFWScriptGenerator.py
@@ -133,7 +133,7 @@ def main ():
         try:
             myroot.propagate()
 
-        except EddParser.MyPropagationError, ex :
+        except EddParser.MyPropagationError as ex :
             printE(ex)
             printE("EXIT ON FAILURE")
             exit(1)

--- a/tools/xmlGenerator/domainGenerator.py
+++ b/tools/xmlGenerator/domainGenerator.py
@@ -140,7 +140,7 @@ def parseEdd(EDDFiles):
 
         try:
             root.propagate()
-        except EddParser.MyPropagationError, ex :
+        except EddParser.MyPropagationError as ex :
             logging.critical(str(ex))
             logging.info("EXIT ON FAILURE")
             exit(1)


### PR DESCRIPTION
The xml-generator scripts were using deprecated Python 2 constructs and were
unable to run with Python 3.x. This is an issue on Windows because CMake seems
to use the highest version available even when there is a version closer to
what was requested. If both 2.7 and 3.x are installed on the system,

    find_package(PythonInterp 2.7 EXACT REQUIRED)

may fail and

    find_package(PythonInterp 2.7 REQUIRED)

may find 3.x.

This is a known issue for some time now:

    https://public.kitware.com/Bug/view.php?id=15661
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/358%23issuecomment-192233183%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/358%23issuecomment-192258230%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/358%23issuecomment-192297600%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/358%23issuecomment-193779517%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/358%23issuecomment-192233183%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6080.30%25%60%5Cn%3E%20Merging%20%2A%2A%23358%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20not%20affect%20coverage%20as%20of%20%5B%60e380905%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%23358%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20211%20%20%20%20211%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%207184%20%20%207184%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hit%20%20%20%20%20%20%20%20%20%20%205769%20%20%205769%20%20%20%20%20%20%20%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%201415%20%20%201415%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60e380905%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework%3Fref%3De3809053b266a21306c374fc1d03a53aeea97618%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/features/suggestions%3Fref%3De3809053b266a21306c374fc1d03a53aeea97618%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/commit/e3809053b266a21306c374fc1d03a53aeea97618%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/compare/9a5416965ad2a1d311d572863487e15f2dedbb4e...e3809053b266a21306c374fc1d03a53aeea97618%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-03-04T10%3A59%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-03-04T12%3A17%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11178583%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcahuzax%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40krocard%20Please%20review.%22%2C%20%22created_at%22%3A%20%222016-03-04T14%3A15%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-08T13%3A10%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6862950%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/krocard%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/358#issuecomment-192233183'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `80.30%`
> Merging **#358** into **master** will not affect coverage as of [`e380905`][3]
```diff
@@            master   #358   diff @@
=====================================
Files          211    211
Stmts         7184   7184
Branches         0      0
Methods          0      0
=====================================
Hit           5769   5769
Partial          0      0
Missed        1415   1415
```
> Review entire [Coverage Diff][4] as of [`e380905`][3]
[1]: https://codecov.io/github/01org/parameter-framework?ref=e3809053b266a21306c374fc1d03a53aeea97618
[2]: https://codecov.io/github/01org/parameter-framework/features/suggestions?ref=e3809053b266a21306c374fc1d03a53aeea97618
[3]: https://codecov.io/github/01org/parameter-framework/commit/e3809053b266a21306c374fc1d03a53aeea97618
[4]: https://codecov.io/github/01org/parameter-framework/compare/9a5416965ad2a1d311d572863487e15f2dedbb4e...e3809053b266a21306c374fc1d03a53aeea97618
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.
- <a href='https://github.com/tcahuzax'><img border=0 src='https://avatars.githubusercontent.com/u/11178583?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> @krocard Please review.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/358?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/358?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/358'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>