### PR TITLE
Have Codecov ignore the STL and ASIO headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,8 @@ after_success:
     # Ignore generated files, samples and tests
     - if [ "${coverage}" = "ON" ]; then
           $HOME/codecov
+               -g "/usr/include/*"
+               -g "$PREFIX/include/*"
                -g "*/build_debug/bindings/python/*"
                -g "*/build_debug/CMakeFiles/*"
                -g "*/build/*"


### PR DESCRIPTION
We don't care about their coverage and it takes up a lot of time during CI
builds.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/360?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/360'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>