### PR TITLE
cmake: reverse logic order to retrieve PF version

### DIFF
--- a/SetVersion.cmake
+++ b/SetVersion.cmake
@@ -37,24 +37,25 @@ set(PF_VERSION_DIRTY "")
 # Find and set the Parameter Framework's version
 # First, let's see if the user forced a version (i.e. "vX.Y.Z-N")
 if(NOT DEFINED PF_VERSION)
-    # Else, try to get it from git
-    execute_process(COMMAND git describe --tags --long --dirty --abbrev=12
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        OUTPUT_VARIABLE PF_VERSION
-        RESULT_VARIABLE GIT_DESCRIBE_RESULT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET)
 
-    if(GIT_DESCRIBE_RESULT GREATER 0)
-        # Or fall back to reading it from .version (this will happen when
-        # building from an archive)
-        file(READ "${PROJECT_SOURCE_DIR}/.version" PF_VERSION_FILE_CONTENT)
+    # Else, try to get it from .version (this will happen when
+    # building from an archive)
+    file(READ "${PROJECT_SOURCE_DIR}/.version" PF_VERSION_FILE_CONTENT)
 
-        set(REGEX "tag: (v[0-9.]+)")
-        if(PF_VERSION_FILE_CONTENT MATCHES ${REGEX})
-            set(PF_VERSION "${CMAKE_MATCH_1}-0")
-        endif()
+    set(REGEX "tag: (v[0-9.]+)")
+    if(PF_VERSION_FILE_CONTENT MATCHES ${REGEX})
+        set(PF_VERSION "${CMAKE_MATCH_1}-0")
+
+    else()
+        # Or fall back from git
+        execute_process(COMMAND git describe --tags --long --dirty --abbrev=12
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            OUTPUT_VARIABLE PF_VERSION
+            RESULT_VARIABLE GIT_DESCRIBE_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
     endif()
+
 else()
     # Set the "nice version string" to the one forced by the user
     set(NICE_PF_VERSION "${PF_VERSION}")


### PR DESCRIPTION
Prioritize .version filled for achrive and make 
fallback from git revision.

Signed-off-by: Miguel Gaio <miguel.gaio@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/365%23discussion_r58512285%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/365%23issuecomment-205737462%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/365%23issuecomment-206205251%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/365%23issuecomment-205737462%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good%20to%20me%20except%20for%20a%20minor%20remark.%20Also%2C%20due%20to%20a%20github%20outtage%2C%20the%20CIs%20failed%20to%20run.%5Cr%5Cn%5Cr%5Cn%40krocard%20Please%20review.%22%2C%20%22created_at%22%3A%20%222016-04-05T10%3A02%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%5B1%5D%20is%20%6080.34%25%60%5Cn%3E%20Merging%20%2A%2A%23365%2A%2A%20into%20%2A%2Amaster%2A%2A%20will%20not%20affect%20coverage%20as%20of%20%5B%60eb68f72%60%5D%5B3%5D%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%23365%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20211%20%20%20%20%20211%20%20%20%20%20%20%20%5Cn%20%20Stmts%20%20%20%20%20%20%20%20%207169%20%20%20%207169%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hit%20%20%20%20%20%20%20%20%20%20%205760%20%20%20%205760%20%20%20%20%20%20%20%5Cn%20%20Partial%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%200%20%20%20%20%20%20%20%5Cn%20%20Missed%20%20%20%20%20%20%20%201409%20%20%20%201409%20%20%20%20%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Review%20entire%20%5BCoverage%20Diff%5D%5B4%5D%20as%20of%20%5B%60eb68f72%60%5D%5B3%5D%5Cn%5Cn%5Cn%5B1%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework%3Fref%3Deb68f72b60ce0a118f4c54c75fb301d6bc6ad616%5Cn%5B2%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/features/suggestions%3Fref%3Deb68f72b60ce0a118f4c54c75fb301d6bc6ad616%5Cn%5B3%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/commit/eb68f72b60ce0a118f4c54c75fb301d6bc6ad616%5Cn%5B4%5D%3A%20https%3A//codecov.io/github/01org/parameter-framework/compare/9f3007705f19216adac7f462f4053008273b37f8...eb68f72b60ce0a118f4c54c75fb301d6bc6ad616%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%29.%20Updated%20on%20successful%20CI%20builds.%22%2C%20%22created_at%22%3A%20%222016-04-06T08%3A09%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204ffda00d2a597aecf15334e7b5a6ffddd2b5621e%20SetVersion.cmake%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/365%23discussion_r58512285%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20can%20merge%20the%20%5C%22endif/if%5C%22%20couple%20with%20an%20%5C%22else%5C%22.%22%2C%20%22created_at%22%3A%20%222016-04-05T10%3A00%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20SetVersion.cmake%3AL37-63%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 4ffda00d2a597aecf15334e7b5a6ffddd2b5621e SetVersion.cmake 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/365#discussion_r58512285'>File: SetVersion.cmake:L37-63</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> you can merge the "endif/if" couple with an "else".
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/365#issuecomment-205737462'>General Comment</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> Looks good to me except for a minor remark. Also, due to a github outtage, the CIs failed to run.
@krocard Please review.
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage][1] is `80.34%`
> Merging **#365** into **master** will not affect coverage as of [`eb68f72`][3]
```diff
@@            master    #365   diff @@
======================================
Files          211     211
Stmts         7169    7169
Branches         0       0
Methods          0       0
======================================
Hit           5760    5760
Partial          0       0
Missed        1409    1409
```
> Review entire [Coverage Diff][4] as of [`eb68f72`][3]
[1]: https://codecov.io/github/01org/parameter-framework?ref=eb68f72b60ce0a118f4c54c75fb301d6bc6ad616
[2]: https://codecov.io/github/01org/parameter-framework/features/suggestions?ref=eb68f72b60ce0a118f4c54c75fb301d6bc6ad616
[3]: https://codecov.io/github/01org/parameter-framework/commit/eb68f72b60ce0a118f4c54c75fb301d6bc6ad616
[4]: https://codecov.io/github/01org/parameter-framework/compare/9f3007705f19216adac7f462f4053008273b37f8...eb68f72b60ce0a118f4c54c75fb301d6bc6ad616
> Powered by [Codecov](https://codecov.io). Updated on successful CI builds.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/365?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/365?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/365'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>