### PR TITLE
CMake: Use add_compile_options when applicable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,12 @@ if(WIN32)
     # and thus are not to be used by the client. A better fix would be to export
     # only public methods instead of the whole class, but they are too many to
     # do that. A separated plugin interface would fix that.
-    set_property(DIRECTORY PROPERTY COMPILE_OPTIONS /W4 /FIiso646.h -wd4127 -wd4251)
+    add_compile_options(/W4 /FIiso646.h -wd4127 -wd4251)
 
     # FIXME: Once we have removed all warnings on windows, add the /WX flags if
     # FATAL_WARNINGS is enabled
 else()
-    set_property(DIRECTORY PROPERTY COMPILE_OPTIONS -Wall -Wextra -Wconversion -Wno-sign-conversion
+    add_compile_options(-Wall -Wextra -Wconversion -Wno-sign-conversion
                  $<$<BOOL:FATAL_WARNINGS>:-Werror>)
 endif()
 


### PR DESCRIPTION
Instead of using set_property(DIRECTORY COMPILE_OPTIONS), use
add_compile_options, which applies to the current directory and all
subdirs.

Signed-off-by: David Wagner <david.wagner@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/370?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/370'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>