### PR TITLE
cmake: Integrate client simulator as a subproject.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(PYTHON_BINDINGS "Python library to use the Parameter Framework from pytho
 option(C_BINDINGS "Library to use the Parameter Framework using a C API" ON)
 option(FATAL_WARNINGS "Turn warnings into errors (-Werror flag)" ON)
 option(NETWORKING "Set to OFF in order to stub networking code" ON)
+option(CLIENT_SIMULATOR "Set to ON to enable client simulator" OFF)
 
 include(SetVersion.cmake)
 
@@ -126,6 +127,9 @@ endif()
 
 add_subdirectory(tools/xmlGenerator)
 add_subdirectory(tools/xmlValidator)
+if (CLIENT_SIMULATOR)
+    add_subdirectory(tools/clientSimulator)
+endif()
 
 add_subdirectory(bindings)
 


### PR DESCRIPTION
Add opt-out option to disable client simulator build.

Signed-off-by: Miguel Gaio miguel.gaio@intel.com
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/371?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/371'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
