### PR TITLE
travis.yml: download asio from github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ install:
     # This version of catch is known to work.
     - wget --directory-prefix $PREFIX/include
               https://raw.github.com/philsquared/Catch/v1.2.1/single_include/catch.hpp
-    - wget 'https://01.org/sites/default/files/asio-1.10.6.tar.gz'
-    - tar xf asio-1.10.6.tar.gz -C $PREFIX --strip-components=1
+    - wget -O asio-1.10.6.tar.gz https://github.com/chriskohlhoff/asio/archive/asio-1-10-6.tar.gz
+    - tar xf asio-1.10.6.tar.gz -C $PREFIX --strip-components=2 asio-asio-1-10-6/asio
     # Current limitations on OSX builds: no testing, no client-simulator
     # (because we haven't found a straightforward way to have CMake find the
     # python libraries (find_package(PythonLibs)).


### PR DESCRIPTION
01.org only accepts TLSv1.2 connections but Travis' Ubuntu Precise
images don't support it.

Signed-off-by: David Wagner <david.wagner@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/373%23issuecomment-235927176%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/373%23issuecomment-235927176%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/373%3Fsrc%3Dpr%29%20is%2071.94%25%20%28diff%3A%20100%25%29%5Cn%5Cn%5Cn%5Cn%3E%20No%20coverage%20report%20found%20for%20%2A%2Amaster%2A%2A%20at%20d492194.%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20update%20%5Bd492194...aaf3ac8%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/d49219437b4e9100d0a23e54d297d35dce706e12...aaf3ac894e4d62eb40f159f343334c86e1de6ef5%3Fsrc%3Dpr%29%22%2C%20%22created_at%22%3A%20%222016-07-28T15%3A17%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/373#issuecomment-235927176'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage](https://codecov.io/gh/01org/parameter-framework/pull/373?src=pr) is 71.94% (diff: 100%)
> No coverage report found for **master** at d492194.
> Powered by [Codecov](https://codecov.io?src=pr). Last update [d492194...aaf3ac8](https://codecov.io/gh/01org/parameter-framework/compare/d49219437b4e9100d0a23e54d297d35dce706e12...aaf3ac894e4d62eb40f159f343334c86e1de6ef5?src=pr)


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/373?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/373?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/373'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>