### PR TITLE
IntegerParameterType: Fix Min/Max XML import overflow

### DIFF
--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -117,6 +117,7 @@ bool CIntegerParameterType::fromXml(const CXmlElement &xmlElement,
         if (!xmlElement.getAttribute("Min", (int32_t &)_uiMin)) {
 
             _uiMin = iMin;
+            signExtend((int32_t &)_uiMin);
         }
 
         if (!xmlElement.getAttribute("Max", (int32_t &)_uiMax)) {

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -111,8 +111,8 @@ bool CIntegerParameterType::fromXml(const CXmlElement &xmlElement,
 
         // Signed means we have one less util bit
         sizeInBits--;
-	iMin = 1U << sizeInBits;
-	iMax = (1U << sizeInBits) - 1;
+        iMin = 1U << sizeInBits;
+        iMax = (1U << sizeInBits) - 1;
 
         if (!xmlElement.getAttribute("Min", (int32_t &)_uiMin)) {
 
@@ -127,14 +127,16 @@ bool CIntegerParameterType::fromXml(const CXmlElement &xmlElement,
         signExtend((int32_t &)iMin);
         signExtend((int32_t &)iMax);
         // Check boundary Limits (in case Min and Max value are out of range inside XML)
-        _uiMin = (uint32_t)LimitValueAgainstRange<int64_t>((int32_t)_uiMin, (int32_t)iMin, (int32_t)iMax);
-        _uiMax = (uint32_t)LimitValueAgainstRange<int64_t>((int32_t)_uiMax, (int32_t)iMin, (int32_t)iMax);
+        _uiMin = (uint32_t)LimitValueAgainstRange<int64_t>((int32_t)_uiMin, (int32_t)iMin,
+                                                           (int32_t)iMax);
+        _uiMax = (uint32_t)LimitValueAgainstRange<int64_t>((int32_t)_uiMax, (int32_t)iMin,
+                                                           (int32_t)iMax);
         signExtend((int32_t &)_uiMin);
         signExtend((int32_t &)_uiMax);
 
     } else {
-	iMin = 0;
-	iMax = ~0U >> (8 * sizeof(size_t) - sizeInBits);
+        iMin = 0;
+        iMax = ~0U >> (8 * sizeof(size_t) - sizeInBits);
 
         if (!xmlElement.getAttribute("Min", _uiMin)) {
 
@@ -450,11 +452,12 @@ bool CIntegerParameterType::checkValueAgainstRange(const string &strValue, type 
 
 // Limit Range accoridng to dynammic
 template <typename type>
-type CIntegerParameterType::LimitValueAgainstRange(type value,
-                                                   type minValue, type maxValue) const
+type CIntegerParameterType::LimitValueAgainstRange(type value, type minValue, type maxValue) const
 {
-    if (value > maxValue) return(maxValue);
-    if (value < minValue) return(minValue);
+    if (value > maxValue)
+        return (maxValue);
+    if (value < minValue)
+        return (minValue);
     return (value);
 }
 

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -103,6 +103,9 @@ bool CIntegerParameterType::fromXml(const CXmlElement &xmlElement,
     xmlElement.getAttribute("Size", sizeInBits);
 
     // Size
+    if (sizeInBits > 32) {
+        return false;
+    }
     setSize(sizeInBits / 8);
 
     // Min / Max

--- a/parameter/IntegerParameterType.cpp
+++ b/parameter/IntegerParameterType.cpp
@@ -127,10 +127,10 @@ bool CIntegerParameterType::fromXml(const CXmlElement &xmlElement,
         signExtend((int32_t &)iMin);
         signExtend((int32_t &)iMax);
         // Check boundary Limits (in case Min and Max value are out of range inside XML)
-        _uiMin = (uint32_t)LimitValueAgainstRange<int64_t>((int32_t)_uiMin, (int32_t)iMin,
-                                                           (int32_t)iMax);
-        _uiMax = (uint32_t)LimitValueAgainstRange<int64_t>((int32_t)_uiMax, (int32_t)iMin,
-                                                           (int32_t)iMax);
+        if (!minMaxValueAgainstRange<int64_t>((int32_t)_uiMin, (int32_t)_uiMax, (int32_t)iMin,
+                                              (int32_t)iMax)) {
+            return false;
+        }
         signExtend((int32_t &)_uiMin);
         signExtend((int32_t &)_uiMax);
 
@@ -148,8 +148,9 @@ bool CIntegerParameterType::fromXml(const CXmlElement &xmlElement,
             _uiMax = iMax;
         }
         // Check boundary Limits (in case Min and Max value are out of range inside XML)
-        _uiMin = (uint32_t)LimitValueAgainstRange<uint64_t>(_uiMin, iMin, iMax);
-        _uiMax = (uint32_t)LimitValueAgainstRange<uint64_t>(_uiMax, iMin, iMax);
+        if (!minMaxValueAgainstRange<uint64_t>(_uiMin, _uiMax, iMin, iMax)) {
+            return false;
+        }
     }
 
     // Base
@@ -450,15 +451,21 @@ bool CIntegerParameterType::checkValueAgainstRange(const string &strValue, type 
     return true;
 }
 
-// Limit Range accoridng to dynammic
+// MinMax Range check accoridng to dynammic
 template <typename type>
-type CIntegerParameterType::LimitValueAgainstRange(type value, type minValue, type maxValue) const
+bool CIntegerParameterType::minMaxValueAgainstRange(type valueMin, type valueMax, type minValue,
+                                                    type maxValue) const
 {
-    if (value > maxValue)
-        return (maxValue);
-    if (value < minValue)
-        return (minValue);
-    return (value);
+    if ((valueMin > maxValue) || (valueMin < minValue)) {
+        return false;
+    }
+    if ((valueMax > maxValue) || (valueMax < minValue)) {
+        return false;
+    }
+    if (valueMin > valueMax) {
+        return false;
+    }
+    return true;
 }
 
 // Adaptation element retrieval

--- a/parameter/IntegerParameterType.h
+++ b/parameter/IntegerParameterType.h
@@ -95,9 +95,9 @@ private:
     bool checkValueAgainstRange(const std::string &strValue, type value, type minValue,
                                 type maxValue, CParameterAccessContext &parameterAccessContext,
                                 bool bHexaValue) const;
-    // Limit Range checking
+    // MinMax Range checking
     template <typename type>
-    type LimitValueAgainstRange(type value, type minValue, type maxValue) const;
+    bool minMaxValueAgainstRange(type valueMin, type valueMax, type minValue, type maxValue) const;
 
     // Adaptation element retrieval
     const CParameterAdaptation *getParameterAdaptation() const;

--- a/parameter/IntegerParameterType.h
+++ b/parameter/IntegerParameterType.h
@@ -95,6 +95,9 @@ private:
     bool checkValueAgainstRange(const std::string &strValue, type value, type minValue,
                                 type maxValue, CParameterAccessContext &parameterAccessContext,
                                 bool bHexaValue) const;
+    // Limit Range checking
+    template <typename type>
+    type LimitValueAgainstRange(type value, type minValue, type maxValue) const;
 
     // Adaptation element retrieval
     const CParameterAdaptation *getParameterAdaptation() const;

--- a/test/functional-tests/CMakeLists.txt
+++ b/test/functional-tests/CMakeLists.txt
@@ -36,6 +36,7 @@ if(BUILD_TESTING)
     add_executable(parameterFunctionalTest
                    Basic.cpp
                    FloatingPoint.cpp
+                   Integer.cpp
                    Handle.cpp
                    AutoSync.cpp)
 

--- a/test/functional-tests/Integer.cpp
+++ b/test/functional-tests/Integer.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2016, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.hpp"
+#include "ParameterFramework.hpp"
+#include "ElementHandle.hpp"
+#include "Test.hpp"
+#include "BinaryCopy.hpp"
+
+#include <catch.hpp>
+
+#include <string>
+
+using std::string;
+
+namespace parameterFramework
+{
+
+const auto validIntegerInstances = Config{&Config::instances,
+                                          // Size is fixed at 8 for test */
+                                          R"(<IntegerParameter Name="Empty"/>
+    <IntegerParameter Name="trivial" Size="8" Signed="true"/>
+    <IntegerParameter Name="nominal" Size="8" Signed="true" Min="-50" Max="12"/>
+    <IntegerParameter Name="negMinMaxS8" Size="8" Signed="true" Min="-120" Max="-110"/>
+    <IntegerParameter Name="posMinMaxS8" Size="8" Signed="true" Min="90" Max="100"/>
+    <IntegerParameter Name="defaultMinS8" Size="8" Signed="true" Min="-128"/>
+    <IntegerParameter Name="defaultMaxS8" Size="8" Signed="true" Max="127"/>
+    <IntegerParameter Name="defaultMinU8" Size="8" Signed="false" Min="0"/>
+    <IntegerParameter Name="defaultMaxU8" Size="8" Signed="false" Max="255"/>
+    <IntegerParameter Name="defaultMinS16" Size="16" Signed="true" Min="-32768"/>
+    <IntegerParameter Name="defaultMaxS16" Size="16" Signed="true" Max="32767"/>
+    <IntegerParameter Name="defaultMinU16" Size="16" Signed="false" Min="0"/>
+    <IntegerParameter Name="defaultMaxU16" Size="16" Signed="false" Max="65535"/>
+    <IntegerParameter Name="defaultMinS32" Size="32" Signed="true" Min="-2147483648"/>
+    <IntegerParameter Name="defaultMaxS32" Size="32" Signed="true" Max="2147483647"/>)"};
+const auto &invalidIntegerParameters = Tests<string>{
+    {"minimum > maximum", "<IntegerParameter Name='error' Min='1' Max='0'/>"},
+    {"S8 minimum > MaxRange", "<IntegerParameter Name='error' Size='8' Signed='true' Min='128'/>"},
+    {"S8 minimum < MinRange", "<IntegerParameter Name='error' Size='8' Signed='true' Min='-129'/>"},
+    {"S8 maximum > MaxRange", "<IntegerParameter Name='error' Size='8' Signed='true' Max='128'/>"},
+    {"S8 maximum < MinRange", "<IntegerParameter Name='error' Size='8' Signed='true' Max='-129'/>"},
+    {"U8 minimum > MaxRange", "<IntegerParameter Name='error' Size='8' Signed='false' Min='256'/>"},
+    {"U8 maximum > MaxRange", "<IntegerParameter Name='error' Size='8' Signed='false' Max='256'/>"},
+    {"S16 minimum > MaxRange",
+     "<IntegerParameter Name='error' Size='16' Signed='true' Min='32768'/>"},
+    {"S16 minimum < MinRange",
+     "<IntegerParameter Name='error' Size='16' Signed='true' Min='-32769'/>"},
+    {"S16 maximum > MaxRange",
+     "<IntegerParameter Name='error' Size='16' Signed='true' Max='32768'/>"},
+    {"S16 maximum < MinRange",
+     "<IntegerParameter Name='error' Size='16' Signed='true' Max='-32769'/>"},
+    {"U16 minimum > MaxRange",
+     "<IntegerParameter Name='error' Size='16' Signed='false' Min='65536'/>"},
+    {"U16 maximum > MaxRange",
+     "<IntegerParameter Name='error' Size='16' Signed='false' Max='65536'/>"}};
+
+struct IntegerPF : public ParameterFramework
+{
+    IntegerPF() : ParameterFramework{std::move(validIntegerInstances)} {}
+};
+
+SCENARIO_METHOD(LazyPF, "Invalid Integer types XML structure", "[Integer types]")
+{
+    for (auto &vec : invalidIntegerParameters) {
+        GIVEN ("intentional error: " + vec.title) {
+            create(Config{&Config::instances, vec.payload});
+            THEN ("Start should fail") {
+                CHECK_THROWS_AS(mPf->start(), Exception);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(IntegerPF, "Integer types", "[Integer types]")
+{
+    GIVEN ("A valid XML structure file") {
+        THEN ("Start should succeed") {
+            CHECK_NOTHROW(start());
+            REQUIRE_NOTHROW(setTuningMode(true));
+            string path = "/test/test/nominal";
+
+            AND_THEN ("Set/Get a integer type parameter in real value space") {
+
+                for (auto &vec : Tests<string>{
+                         {"(too high)", "13"}, {"(too low)", "-51"}, {"(not a number)", "foobar"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "12"}, {"(lower limit)", "-50"}, {"(inside range)", "0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get integer type parameter handle") {
+                ElementHandle handle{*this, path};
+                /** @FIXME: 'set' operations on a ParameterHandle are silently
+                 * ignored in tuning mode. Does it make sense ? */
+                REQUIRE_NOTHROW(setTuningMode(false));
+
+                /* warning: even though the API below takes a double as
+                 * argument, we need to define the test vector as integers in
+                 * order to prevent rounding issues */
+                for (auto &vec : Tests<int32_t>{
+                         {"(upper limit)", 12}, {"(lower limit)", -50}, {"(inside range)", 0},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(handle.setAsSignedInteger(vec.payload));
+                        int32_t getValueBack;
+                        REQUIRE_NOTHROW(handle.getAsSignedInteger(getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+                for (auto &vec : Tests<int32_t>{
+                         {"(too high)", 13}, {"(too low)", -51},
+                     }) {
+                    GIVEN ("An invalid value " + vec.title) {
+                        CHECK_THROWS_AS(handle.setAsSignedInteger(vec.payload), Exception);
+                    }
+                }
+            }
+        }
+    }
+}
+}

--- a/test/functional-tests/Integer.cpp
+++ b/test/functional-tests/Integer.cpp
@@ -61,6 +61,7 @@ const auto validIntegerInstances = Config{&Config::instances,
     <IntegerParameter Name="defaultMinS32" Size="32" Signed="true" Min="-2147483648"/>
     <IntegerParameter Name="defaultMaxS32" Size="32" Signed="true" Max="2147483647"/>)"};
 const auto &invalidIntegerParameters = Tests<string>{
+    {"invalid Size(64)", "<IntegerParameter Name='error' Size='64'/>"},
     {"minimum > maximum", "<IntegerParameter Name='error' Min='1' Max='0'/>"},
     {"S8 minimum > MaxRange", "<IntegerParameter Name='error' Size='8' Signed='true' Min='128'/>"},
     {"S8 minimum < MinRange", "<IntegerParameter Name='error' Size='8' Signed='true' Min='-129'/>"},


### PR DESCRIPTION
In case XML data for Min and Max values are wrongly set (out of range). The
Import function is not checking out of range format. In order to avoid
roll over some additional boundary check need to be done.

For exemple if we have Sign integer on 8 bits and we set Max value to 200
the new code will initialize the Max value to 127.

Signed-off-by: Sebastien Guiriec <sebastien.guiriec@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/375%23issuecomment-250185082%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/375%23discussion_r81094555%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/375%23discussion_r81096590%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/375%23discussion_r81096908%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/375%23issuecomment-250418839%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/375%23discussion_r81114649%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/375%23issuecomment-250185082%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40dwagner%20please%20have%20a%20look%20related%20to%20boundary%20check.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-09-28T14%3A35%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/124108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sguiriec%22%7D%7D%2C%20%7B%22body%22%3A%20%22%23%23%20%5BCurrent%20coverage%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/375%3Fsrc%3Dpr%29%20is%2072.04%25%20%28diff%3A%2075.00%25%29%5Cn%3E%20Merging%20%5B%23375%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/375%3Fsrc%3Dpr%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/01org/parameter-framework/branch/master%3Fsrc%3Dpr%29%20will%20increase%20coverage%20by%20%2A%2A%3C.01%25%2A%2A%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%20%23375%20%20%20diff%20%40%40%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20211%20%20%20%20%20%20%20%20211%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%206683%20%20%20%20%20%20%206699%20%20%20%20%2B16%20%20%20%5Cn%20%20Methods%20%20%20%20%20%20%20%201438%20%20%20%20%20%20%201439%20%20%20%20%20%2B1%20%20%20%5Cn%20%20Messages%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%200%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20857%20%20%20%20%20%20%20%20859%20%20%20%20%20%2B2%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%20%20%204814%20%20%20%20%20%20%204826%20%20%20%20%2B12%20%20%20%5Cn-%20Misses%20%20%20%20%20%20%20%20%201397%20%20%20%20%20%20%201399%20%20%20%20%20%2B2%20%20%20%5Cn-%20Partials%20%20%20%20%20%20%20%20472%20%20%20%20%20%20%20%20474%20%20%20%20%20%2B2%20%20%20%5Cn%60%60%60%5Cn%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io%3Fsrc%3Dpr%29.%20Last%20update%20%5Bb871a8f...ba4e6ae%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/b871a8f3b79677ec33642cd16f06868b3c87e740...ba4e6aeb4859f10f53215b9b51a2d7050bf4379f%3Fsrc%3Dpr%29%22%2C%20%22created_at%22%3A%20%222016-09-29T09%3A39%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2014123028502e1d13cea32d3796fa240afe04478d%20parameter/IntegerParameterType.cpp%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/375%23discussion_r81094555%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60iMin%20%3D%20-%281U%20%3C%3C%20sizeInBits%29%3B%60%22%2C%20%22created_at%22%3A%20%222016-09-29T09%3A12%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/IntegerParameterType.cpp%3AL111-154%22%7D%2C%20%22Pull%2014123028502e1d13cea32d3796fa240afe04478d%20parameter/IntegerParameterType.cpp%2066%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/375%23discussion_r81114649%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20of%20today%20.xsd%20doesn%27t%20check%20the%20range.%20So%20this%20method%20allows%20to%20have%20same%20behavior%20as%20when%20we%20do%20not%20specify%20Min%20and%20Max.%5Cr%5CnIn%20case%20of%20ERROR%20a%20tool%20should%20be%20provided%20in%20order%20to%20check%20XML%20mix/max%20range%20as%20I%20am%20not%20sure%20that%20the%20error%20will%20be%20explicit%20for%20a%20full%20platform%20XML%20loading.%22%2C%20%22created_at%22%3A%20%222016-09-29T11%3A20%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/124108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sguiriec%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/IntegerParameterType.cpp%3AL448-464%22%7D%2C%20%22Pull%2014123028502e1d13cea32d3796fa240afe04478d%20parameter/IntegerParameterType.cpp%2063%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/375%23discussion_r81096590%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22coding%20style%3A%20method%20names%20start%20with%20a%20lowercase%20letter.%22%2C%20%22created_at%22%3A%20%222016-09-29T09%3A24%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/IntegerParameterType.cpp%3AL448-464%22%7D%2C%20%22Pull%20ba4e6aeb4859f10f53215b9b51a2d7050bf4379f%20parameter/IntegerParameterType.cpp%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/375%23discussion_r81096908%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22coding%20style%20%28not%20covered%20by%20clang-format%2C%20unfortunately%29%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cnif%20%28condition%29%20%7B%5Cr%5Cn%20%20%20%20statement%3B%5Cr%5Cn%7D%22%2C%20%22created_at%22%3A%20%222016-09-29T09%3A26%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6430928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dawagner%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20parameter/IntegerParameterType.cpp%3AL450-467%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/375#issuecomment-250185082'>General Comment</a></b>
- <a href='https://github.com/sguiriec'><img border=0 src='https://avatars.githubusercontent.com/u/124108?v=3' height=16 width=16'></a> @dwagner please have a look related to boundary check.
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16'></a> ## [Current coverage](https://codecov.io/gh/01org/parameter-framework/pull/375?src=pr) is 72.04% (diff: 75.00%)
> Merging [#375](https://codecov.io/gh/01org/parameter-framework/pull/375?src=pr) into [master](https://codecov.io/gh/01org/parameter-framework/branch/master?src=pr) will increase coverage by **<.01%**
```diff
@@             master       #375   diff @@
==========================================
Files           211        211
Lines          6683       6699    +16
Methods        1438       1439     +1
Messages          0          0
Branches        857        859     +2
==========================================
+ Hits           4814       4826    +12
- Misses         1397       1399     +2
- Partials        472        474     +2
```
> Powered by [Codecov](https://codecov.io?src=pr). Last update [b871a8f...ba4e6ae](https://codecov.io/gh/01org/parameter-framework/compare/b871a8f3b79677ec33642cd16f06868b3c87e740...ba4e6aeb4859f10f53215b9b51a2d7050bf4379f?src=pr)
- [ ] <a href='#crh-comment-Pull 14123028502e1d13cea32d3796fa240afe04478d parameter/IntegerParameterType.cpp 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/375#discussion_r81094555'>File: parameter/IntegerParameterType.cpp:L111-154</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> `iMin = -(1U << sizeInBits);`
- [ ] <a href='#crh-comment-Pull 14123028502e1d13cea32d3796fa240afe04478d parameter/IntegerParameterType.cpp 63'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/375#discussion_r81096590'>File: parameter/IntegerParameterType.cpp:L448-464</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> coding style: method names start with a lowercase letter.
- [ ] <a href='#crh-comment-Pull ba4e6aeb4859f10f53215b9b51a2d7050bf4379f parameter/IntegerParameterType.cpp 67'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/375#discussion_r81096908'>File: parameter/IntegerParameterType.cpp:L450-467</a></b>
- <a href='https://github.com/dawagner'><img border=0 src='https://avatars.githubusercontent.com/u/6430928?v=3' height=16 width=16'></a> coding style (not covered by clang-format, unfortunately):
```
if (condition) {
statement;
}
- [ ] <a href='#crh-comment-Pull 14123028502e1d13cea32d3796fa240afe04478d parameter/IntegerParameterType.cpp 66'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/375#discussion_r81114649'>File: parameter/IntegerParameterType.cpp:L448-464</a></b>
- <a href='https://github.com/sguiriec'><img border=0 src='https://avatars.githubusercontent.com/u/124108?v=3' height=16 width=16'></a> As of today .xsd doesn't check the range. So this method allows to have same behavior as when we do not specify Min and Max.
In case of ERROR a tool should be provided in order to check XML mix/max range as I am not sure that the error will be explicit for a full platform XML loading.


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/375?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/375?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/375'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>