### PR TITLE
cmake: Make client simulator a subdir instead of a subproject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     global:
         - PREFIX=$HOME/prefix
         - MY_CMAKE_OPTIONS="-DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$HOME/install"
+        - OSX_CMAKE_OPTIONS="-DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF -DCLIENT_SIMULATOR=OFF"
         - CTEST_OUTPUT_ON_FAILURE=1
         - LINUX=false
         - OSX=false
@@ -89,7 +90,7 @@ before_script:
           coverage=ON;
           export CCACHE_CPP2=1;
       fi
-    - if $OSX; then export MY_CMAKE_OPTIONS+=" -DBUILD_TESTING=OFF -DPYTHON_BINDINGS=OFF"; fi
+    - if $OSX; then export MY_CMAKE_OPTIONS+=" $OSX_CMAKE_OPTIONS"; fi
 
 # how to build
 script:
@@ -112,12 +113,6 @@ script:
         make -j$(nproc) &&
         (if $LINUX; then make ExperimentalTest ExperimentalMemCheck; fi) &&
         make install )
-  - if $LINUX; then ( cd tools/clientSimulator &&
-        echo "TODO - install the generated .deb instead of using \$HOME/install."
-             "This would permit to test the packaging" &&
-        cmake $MY_CMAKE_OPTIONS . &&
-        make &&
-        make install ); fi
   # Check that all installed files are in a component (no "unspecified
   # component" archive created)
   - (cd build && cpack -G TGZ -D CPACK_ARCHIVE_COMPONENT_INSTALL=ON &&
@@ -126,7 +121,7 @@ script:
   - ( mkdir build_less_features && cd build_less_features &&
         rm -rf $PREFIX/asio-1.10.6 &&
         cmake $MY_CMAKE_OPTIONS -DCMAKE_BUILD_TYPE=Debug
-        -DNETWORKING=OFF -DPYTHON_BINDINGS=OFF -DC_BINDINGS=OFF .. &&
+        -DNETWORKING=OFF -DPYTHON_BINDINGS=OFF -DC_BINDINGS=OFF -DCLIENT_SIMULATOR=OFF .. &&
         make -j$(nproc) &&
         (if $LINUX; then make test; fi) )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(PYTHON_BINDINGS "Python library to use the Parameter Framework from pytho
 option(C_BINDINGS "Library to use the Parameter Framework using a C API" ON)
 option(FATAL_WARNINGS "Turn warnings into errors (-Werror flag)" ON)
 option(NETWORKING "Set to OFF in order to stub networking code" ON)
+option(CLIENT_SIMULATOR "Set to OFF to disable client simulator" ON)
 
 include(SetVersion.cmake)
 
@@ -126,6 +127,9 @@ endif()
 
 add_subdirectory(tools/xmlGenerator)
 add_subdirectory(tools/xmlValidator)
+if (CLIENT_SIMULATOR)
+    add_subdirectory(tools/clientSimulator)
+endif()
 
 add_subdirectory(bindings)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ build_script:
   - mkdir 64bits-debug && cd 64bits-debug
   # Add debug libxml2.dll in the path so that tests can find it
   - set TEST_PATH=%DEBUG_LIBXML2_PATH%\bin
-  - cmake -G "NMake Makefiles" -DPYTHON_BINDINGS=OFF -DCMAKE_PREFIX_PATH="%PREFIX_PATH%;%DEBUG_LIBXML2_PATH%" ..\..
+  - cmake -G "NMake Makefiles" -DPYTHON_BINDINGS=OFF -DCLIENT_SIMULATOR=OFF -DCMAKE_PREFIX_PATH="%PREFIX_PATH%;%DEBUG_LIBXML2_PATH%" ..\..
   - cmake --build . --config debug
   - ctest --build-config debug %CTEST_PARAMS%
   - cd ..
@@ -74,7 +74,7 @@ build_script:
   - mkdir 64bits-release & cd 64bits-release
   # Add debug libxml2.dll in the path so that tests can find it
   - set TEST_PATH=%RELEASE_LIBXML2_PATH%\bin
-  - cmake -G "Visual Studio 14 2015 Win64" -DPYTHON_BINDINGS=OFF -DCMAKE_PREFIX_PATH="%PREFIX_PATH%;%RELEASE_LIBXML2_PATH%" -DCMAKE_INSTALL_PREFIX=%INSTALL% ..\..
+  - cmake -G "Visual Studio 14 2015 Win64" -DPYTHON_BINDINGS=OFF -DCLIENT_SIMULATOR=OFF -DCMAKE_PREFIX_PATH="%PREFIX_PATH%;%RELEASE_LIBXML2_PATH%" -DCMAKE_INSTALL_PREFIX=%INSTALL% ..\..
   # Build, test and install
   - cmake --build . --config release
   - ctest --build-config release %CTEST_PARAMS%

--- a/tools/clientSimulator/CMakeLists.txt
+++ b/tools/clientSimulator/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2017, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -26,27 +26,25 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# has been tested on 2.8.11 only - should not work on older versions
-cmake_minimum_required(VERSION 2.8.11)
-
-project(parameter-framework-clientSimulator)
-
-# Force usage of Python 3.x ...
-find_package(PythonInterp 3 REQUIRED)
-# ... and force the libs to be at the same version as the interpreter
-find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT REQUIRED)
-include_directories(${PYTHON_INCLUDE_DIRS})
+# Force usage of Python 3.x; here, we use find_program instead of find_package
+# because other parts of Parameter Framework request Python 2.x and CMake has
+# troubles with the cohabitation.
+find_program(PYTHON3 python3 REQUIRED)
 
 # Find the python modules install path.
 # plat_specific is needed because we are installing a shared-library python
 # module and not only a pure python module.
 # prefix='' makes get_python_lib return a relative path.
 execute_process(COMMAND
-    ${PYTHON_EXECUTABLE} -c
+    ${PYTHON3} -c
         "from distutils import sysconfig;\\
          print(sysconfig.get_python_lib(plat_specific=True, prefix=''))"
     OUTPUT_VARIABLE PYTHON_MODULE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-install(DIRECTORY clientsimulator DESTINATION ${PYTHON_MODULE_PATH})
+install(DIRECTORY clientsimulator
+        DESTINATION ${PYTHON_MODULE_PATH}
+        COMPONENT client_simulator)
 
-install(PROGRAMS pfClientSimulator.py DESTINATION bin)
+install(PROGRAMS pfClientSimulator.py
+        DESTINATION bin
+        COMPONENT client_simulator)


### PR DESCRIPTION
Add opt-out option to disable client simulator build.

@mgaio I reused the patch you previously submitted.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/392?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/392'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>