### PR TITLE
Make catch.hpp a system header to avoid compilation warnings

### DIFF
--- a/test/catch/CMakeLists.txt
+++ b/test/catch/CMakeLists.txt
@@ -47,5 +47,5 @@ if(BUILD_TESTING)
     endif()
 
     add_library(catch STATIC catch.cpp)
-    target_include_directories(catch PUBLIC "${CATCH_HEADER}")
+    target_include_directories(catch SYSTEM PUBLIC "${CATCH_HEADER}")
 endif()


### PR DESCRIPTION
catch.hpp may contain warnings that are turned to error by -Werror; this
will cause the compilation to fail unless catch.hpp is a "system"
header. Tweak the CMakefile to make it so.

Signed-off-by: David Wagner <david.wagner@intel.com>