### PR TITLE
Functional test: Add logarithmic format test

### DIFF
--- a/parameter/BooleanParameterType.cpp
+++ b/parameter/BooleanParameterType.cpp
@@ -108,6 +108,7 @@ bool CBooleanParameterType::toBlackboard(uint32_t uiUserValue, uint32_t &uiValue
     if (uiUserValue > 1) {
 
         parameterAccessContext.setError("Value out of range");
+        return false;
     }
 
     uiValue = uiUserValue;

--- a/test/functional-tests/BitParameter.cpp
+++ b/test/functional-tests/BitParameter.cpp
@@ -45,7 +45,7 @@ namespace parameterFramework
 const auto validBitParameterInstances = Config{
     &Config::instances,
     // Default for integers is unsigned/32bits
-    R"(<BitParameterBlock Name="nominal" Size="16"><BitParameter Pos="1" Size="2" Name="twobits"/><BitParameter Pos="3" Size="3" Max="6" Name="treebits"/></BitParameterBlock>)"};
+    R"(<BitParameterBlock Name="nominal" Size="16"><BitParameter Pos="0" Size="1" Name="bool"/><BitParameter Pos="1" Size="2" Name="twobits"/><BitParameter Pos="3" Size="3" Max="6" Name="treebits"/></BitParameterBlock>)"};
 
 const auto &invalidBitParameterParameters =
     Tests<string>{{"Too much bits", "<BitParameterBlock Name='toomuchbits' Size='8'><BitParameter "
@@ -120,6 +120,40 @@ SCENARIO_METHOD(BitParameterPF, "BitParameter types", "[BitParameter types]")
                         CHECK_NOTHROW(setParameter(path, vec.payload));
                         string getValueBack;
                         REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get a BitParameter type parameter in boolean") {
+                ElementHandle handle{*this, path};
+                /** @FIXME: 'set' operations on a ParameterHandle are silently
+                 * ignored in tuning mode. Does it make sense ? */
+                REQUIRE_NOTHROW(setTuningMode(false));
+
+                for (auto &vec : Tests<bool>{
+                         {"(upper limit)", true}, {"(lower limit)", false},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(handle.setAsBoolean(vec.payload), Exception);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get a BitParameter type parameter in boolean") {
+                path = "/test/test/nominal/bool";
+                ElementHandle handle{*this, path};
+                /** @FIXME: 'set' operations on a ParameterHandle are silently
+                 * ignored in tuning mode. Does it make sense ? */
+                REQUIRE_NOTHROW(setTuningMode(false));
+
+                for (auto &vec : Tests<bool>{
+                         {"(upper limit)", true}, {"(lower limit)", false},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(handle.setAsBoolean(vec.payload));
+                        bool getValueBack;
+                        REQUIRE_NOTHROW(handle.getAsBoolean(getValueBack));
                         CHECK(getValueBack == vec.payload);
                     }
                 }

--- a/test/functional-tests/BitParameter.cpp
+++ b/test/functional-tests/BitParameter.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.hpp"
+#include "ParameterFramework.hpp"
+#include "ElementHandle.hpp"
+#include "Test.hpp"
+
+#include <catch.hpp>
+
+#include <string>
+
+using std::string;
+
+namespace parameterFramework
+{
+
+const auto validBitParameterInstances = Config{
+    &Config::instances,
+    // Default for integers is unsigned/32bits
+    R"(<BitParameterBlock Name="nominal" Size="16"><BitParameter Pos="1" Size="2" Name="twobits"/><BitParameter Pos="3" Size="3" Max="6" Name="treebits"/></BitParameterBlock>)"};
+
+const auto &invalidBitParameterParameters =
+    Tests<string>{{"Too much bits", "<BitParameterBlock Name='toomuchbits' Size='8'><BitParameter "
+                                    "Pos='1' Size='2' Name='twobits'/><BitParameter Pos='3' "
+                                    "Size='7' Name='toobits'/></BitParameterBlock>"},
+                  {"Max too high", "<BitParameterBlock Name='maxtoohigh' Size='8'><BitParameter "
+                                   "Pos='1' Size='2' Name='twobits'/><BitParameter Pos='3' "
+                                   "Size='2' Max='5' Name='toohigh'/></BitParameterBlock>"}};
+
+struct BitParameterPF : public ParameterFramework
+{
+    BitParameterPF() : ParameterFramework{std::move(validBitParameterInstances)} {}
+};
+
+SCENARIO_METHOD(LazyPF, "Invalid BitParameter types XML structure", "[BitParameter types]")
+{
+    for (auto &vec : invalidBitParameterParameters) {
+        GIVEN ("intentional error: " + vec.title) {
+            create(Config{&Config::instances, vec.payload});
+            THEN ("Start should fail") {
+                CHECK_THROWS_AS(mPf->start(), Exception);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(BitParameterPF, "BitParameter types", "[BitParameter types]")
+{
+    GIVEN ("A valid XML structure file") {
+        THEN ("Start should succeed") {
+            CHECK_NOTHROW(start());
+            REQUIRE_NOTHROW(setTuningMode(true));
+            string path = "/test/test/nominal/treebits";
+
+            AND_THEN ("Set/Get a BitParameter type parameter in real value space") {
+
+                for (auto &vec : Tests<string>{
+                         {"(too high)", "7"}, {"(too low)", "-1"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "6"}, {"(lower limit)", "0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get a BitParameter type parameter in real value space") {
+                ElementHandle handle{*this, path};
+                REQUIRE_NOTHROW(setRawValueSpace(true));
+                REQUIRE_NOTHROW(setHexOutputFormat(true));
+
+                for (auto &vec : Tests<string>{
+                         {"(too high)", "0x7"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "0x6"}, {"(lower limit)", "0x0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+        }
+    }
+}
+}

--- a/test/functional-tests/Boolean.cpp
+++ b/test/functional-tests/Boolean.cpp
@@ -81,6 +81,24 @@ SCENARIO_METHOD(BooleanPF, "Boolean types", "[Boolean types]")
                 }
             }
 
+            AND_THEN ("Set/Get boolean type parameter handle") {
+                ElementHandle handle{*this, path};
+                /** @FIXME: 'set' operations on a ParameterHandle are silently
+                 * ignored in tuning mode. Does it make sense ? */
+                REQUIRE_NOTHROW(setTuningMode(false));
+
+                for (auto &vec : Tests<bool>{
+                         {"(upper limit)", true}, {"(lower limit)", false},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(handle.setAsBoolean(vec.payload));
+                        bool getValueBack;
+                        REQUIRE_NOTHROW(handle.getAsBoolean(getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
             AND_THEN ("Set/Get integer type parameter handle") {
                 ElementHandle handle{*this, path};
                 /** @FIXME: 'set' operations on a ParameterHandle are silently

--- a/test/functional-tests/Boolean.cpp
+++ b/test/functional-tests/Boolean.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.hpp"
+#include "ParameterFramework.hpp"
+#include "ElementHandle.hpp"
+#include "Test.hpp"
+
+#include <catch.hpp>
+
+#include <string>
+
+using std::string;
+
+namespace parameterFramework
+{
+
+const auto validBooleanInstances = Config{&Config::instances,
+                                          // Default for integers is unsigned/32bits
+                                          R"(<BooleanParameter Name="Empty"/>
+    <BooleanParameter Name="nominal"/>)"};
+
+struct BooleanPF : public ParameterFramework
+{
+    BooleanPF() : ParameterFramework{std::move(validBooleanInstances)} {}
+};
+
+SCENARIO_METHOD(BooleanPF, "Boolean types", "[Boolean types]")
+{
+    GIVEN ("A valid XML structure file") {
+        THEN ("Start should succeed") {
+            CHECK_NOTHROW(start());
+            REQUIRE_NOTHROW(setTuningMode(true));
+            string path = "/test/test/nominal";
+
+            AND_THEN ("Set/Get a Boolean type parameter in real value space") {
+
+                for (auto &vec : Tests<string>{
+                         {"(too high)", "2"}, {"(too low)", "-1"}, {"(not a number)", "foobar"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "1"}, {"(lower limit)", "0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get integer type parameter handle") {
+                ElementHandle handle{*this, path};
+                /** @FIXME: 'set' operations on a ParameterHandle are silently
+                 * ignored in tuning mode. Does it make sense ? */
+                REQUIRE_NOTHROW(setTuningMode(false));
+
+                for (auto &vec : Tests<uint32_t>{
+                         {"(upper limit)", 1}, {"(lower limit)", 0},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(handle.setAsInteger(vec.payload));
+                        uint32_t getValueBack;
+                        REQUIRE_NOTHROW(handle.getAsInteger(getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+                for (auto &vec : Tests<uint32_t>{
+                         {"(too high)", 2},
+                     }) {
+                    GIVEN ("An invalid value " + vec.title) {
+                        CHECK_THROWS_AS(handle.setAsInteger(vec.payload), Exception);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get a Boolean type parameter in real value space") {
+                ElementHandle handle{*this, path};
+                REQUIRE_NOTHROW(setRawValueSpace(true));
+
+                for (auto &vec : Tests<string>{
+                         {"(too high hexa)", "0x2"},
+                         {"(too high dec)", "2"},
+                         {"(too low hexa )", "0xFF"},
+                         {"(not a number)", "foobar"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(TRUE hexa)", "0x1"}, {"(TRUE dec)", "1"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == "1");
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(FALSE hexa)", "0x0"}, {"(FALSE dec)", "0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == "0");
+                    }
+                }
+            }
+        }
+    }
+}
+}

--- a/test/functional-tests/CMakeLists.txt
+++ b/test/functional-tests/CMakeLists.txt
@@ -35,6 +35,7 @@ if(BUILD_TESTING)
     # Add unit test
     add_executable(parameterFunctionalTest
                    Basic.cpp
+                   Boolean.cpp
                    FloatingPoint.cpp
                    FixedPoint.cpp
                    Integer.cpp

--- a/test/functional-tests/CMakeLists.txt
+++ b/test/functional-tests/CMakeLists.txt
@@ -38,6 +38,7 @@ if(BUILD_TESTING)
                    FloatingPoint.cpp
                    FixedPoint.cpp
                    Integer.cpp
+                   Logarithmic.cpp
                    Handle.cpp
                    AutoSync.cpp)
 

--- a/test/functional-tests/CMakeLists.txt
+++ b/test/functional-tests/CMakeLists.txt
@@ -37,6 +37,7 @@ if(BUILD_TESTING)
                    Basic.cpp
                    Boolean.cpp
                    BitParameter.cpp
+                   EnumParameter.cpp
                    FloatingPoint.cpp
                    FixedPoint.cpp
                    Integer.cpp

--- a/test/functional-tests/CMakeLists.txt
+++ b/test/functional-tests/CMakeLists.txt
@@ -38,6 +38,7 @@ if(BUILD_TESTING)
                    FloatingPoint.cpp
                    FixedPoint.cpp
                    Integer.cpp
+                   Linear.cpp
                    Logarithmic.cpp
                    Handle.cpp
                    AutoSync.cpp)

--- a/test/functional-tests/CMakeLists.txt
+++ b/test/functional-tests/CMakeLists.txt
@@ -36,6 +36,7 @@ if(BUILD_TESTING)
     add_executable(parameterFunctionalTest
                    Basic.cpp
                    Boolean.cpp
+                   BitParameter.cpp
                    FloatingPoint.cpp
                    FixedPoint.cpp
                    Integer.cpp

--- a/test/functional-tests/EnumParameter.cpp
+++ b/test/functional-tests/EnumParameter.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.hpp"
+#include "ParameterFramework.hpp"
+#include "ElementHandle.hpp"
+#include "Test.hpp"
+
+#include <catch.hpp>
+
+#include <string>
+
+using std::string;
+
+namespace parameterFramework
+{
+
+const auto validEnumParameterInstances = Config{
+    &Config::instances,
+    // Default for integers is unsigned/32bits
+    R"(<EnumParameter Name="nominal" Size="8"><ValuePair Literal="on" Numerical="3"/><ValuePair Literal="off" Numerical="0"/></EnumParameter>)"};
+
+const auto &invalidEnumParameterParameters = Tests<string>{
+    {"No Size", "<EnumParameter Name='nosize'><ValuePair Literal='on' Numerical='3'/><ValuePair "
+                "Literal='off' Numerical='0'/></EnumParameter>"}};
+
+struct EnumParameterPF : public ParameterFramework
+{
+    EnumParameterPF() : ParameterFramework{std::move(validEnumParameterInstances)} {}
+};
+
+SCENARIO_METHOD(LazyPF, "Invalid EnumParameter types XML structure", "[EnumParameter types]")
+{
+    for (auto &vec : invalidEnumParameterParameters) {
+        GIVEN ("intentional error: " + vec.title) {
+            create(Config{&Config::instances, vec.payload});
+            THEN ("Start should fail") {
+                CHECK_THROWS_AS(mPf->start(), Exception);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(EnumParameterPF, "EnumParameter types", "[EnumParameter types]")
+{
+    GIVEN ("A valid XML structure file") {
+        THEN ("Start should succeed") {
+            CHECK_NOTHROW(start());
+            REQUIRE_NOTHROW(setTuningMode(true));
+            string path = "/test/test/nominal";
+
+            AND_THEN ("Set/Get a EnumParameter type parameter in real value space") {
+
+                for (auto &vec : Tests<string>{
+                         {"(not a number)", "foobar"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "on"}, {"(lower limit)", "off"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get a EnumParameter type parameter in raw value space") {
+                ElementHandle handle{*this, path};
+                REQUIRE_NOTHROW(setRawValueSpace(true));
+
+                for (auto &vec : Tests<string>{{"(too high)", "7"}, {"(too low)", "-1"}}) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "3"}, {"(lower limit)", "0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+
+                REQUIRE_NOTHROW(setHexOutputFormat(true));
+
+                for (auto &vec : Tests<string>{{"(too high)", "0x7"}, {"(too low)", "0xFF"}}) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "0x03"}, {"(lower limit)", "0x00"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get a EnumParameter type parameter in Integer value space") {
+                ElementHandle handle{*this, path};
+                /** @FIXME: 'set' operations on a ParameterHandle are silently
+                 * ignored in tuning mode. Does it make sense ? */
+                REQUIRE_NOTHROW(setTuningMode(false));
+
+                for (auto &vec : Tests<int32_t>{
+                         {"(upper limit)", 3}, {"(lower limit)", 0},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(handle.setAsSignedInteger(vec.payload));
+                        int32_t getValueBack;
+                        REQUIRE_NOTHROW(handle.getAsSignedInteger(getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+                for (auto &vec : Tests<int32_t>{
+                         {"(too high)", 13}, {"(too low)", -51},
+                     }) {
+                    GIVEN ("An invalid value " + vec.title) {
+                        CHECK_THROWS_AS(handle.setAsSignedInteger(vec.payload), Exception);
+                    }
+                }
+            }
+        }
+    }
+}
+}

--- a/test/functional-tests/Integer.cpp
+++ b/test/functional-tests/Integer.cpp
@@ -154,6 +154,30 @@ SCENARIO_METHOD(IntegerPF, "Integer types", "[Integer types]")
                     }
                 }
             }
+
+            AND_THEN ("Set/Get double type parameter handle") {
+                ElementHandle handle{*this, path};
+                /** @FIXME: 'set' operations on a ParameterHandle are silently
+                 * ignored in tuning mode. Does it make sense ? */
+                REQUIRE_NOTHROW(setTuningMode(false));
+
+                for (auto &vec : Tests<double>{
+                         {"(upper limit)", 12.0f},
+                         {"(lower limit)", -50.0f},
+                         {"(inside range)", 0.0f},
+                     }) {
+                    GIVEN ("A valid value (rejected not supported)" + vec.title) {
+                        CHECK_THROWS_AS(handle.setAsDouble(vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<double>{
+                         {"(too high)", 12.01f}, {"(too low)", -50.01f},
+                     }) {
+                    GIVEN ("An invalid value " + vec.title) {
+                        CHECK_THROWS_AS(handle.setAsDouble(vec.payload), Exception);
+                    }
+                }
+            }
         }
     }
 }

--- a/test/functional-tests/Integer.cpp
+++ b/test/functional-tests/Integer.cpp
@@ -130,6 +130,31 @@ SCENARIO_METHOD(IntegerPF, "Integer types", "[Integer types]")
                 }
             }
 
+            AND_THEN ("Set/Get a integer type parameter in raw value space") {
+                REQUIRE_NOTHROW(setRawValueSpace(true));
+                REQUIRE_NOTHROW(setHexOutputFormat(true));
+
+                for (auto &vec : Tests<string>{
+                         {"(too high)", "0x0D"}, {"(too low)", "0xCD"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "0x0C"},
+                         {"(lower limit)", "0xCE"},
+                         {"(inside range)", "0x00"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
             AND_THEN ("Set/Get integer type parameter handle") {
                 ElementHandle handle{*this, path};
                 /** @FIXME: 'set' operations on a ParameterHandle are silently

--- a/test/functional-tests/Linear.cpp
+++ b/test/functional-tests/Linear.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.hpp"
+#include "ParameterFramework.hpp"
+#include "ElementHandle.hpp"
+#include "Test.hpp"
+#include "BinaryCopy.hpp"
+
+#include <catch.hpp>
+
+#include <string>
+
+using std::string;
+
+namespace parameterFramework
+{
+
+const auto validLinearInstances = Config{
+    &Config::instances,
+    // Size is fixed at 32 and as such is optional */
+    R"(<IntegerParameter Name="trivial" Signed="true"> <LinearAdaptation SlopeNumerator="200" SlopeDenominator="10"/> </IntegerParameter>
+    <IntegerParameter Name="nominal" Size="32" Signed="true" Min="-1440" Max="300"> <LinearAdaptation SlopeNumerator="10" SlopeDenominator="100"/> </IntegerParameter>)"};
+const auto &invalidLinearParameters = Tests<string>{
+    {"invalid Size(64)", "<IntegerParameter Name='nominal' Size='64' Signed='true' Min='-144' "
+                         "Max='30'> <LinearAdaptation SlopeNumerator='200' SlopeDenominator='10'/> "
+                         "</IntegerParameter>"},
+    {"minimum > maximum", "<IntegerParameter Name='nominal' Size='32' Signed='true' Min='30' "
+                          "Max='-144'> <LinearAdaptation SlopeNumerator='1' "
+                          "SlopeDenominator='10'/> </IntegerParameter>"},
+    {"SlopeDenominator=0",
+     "<IntegerParameter Name='nominal' Size='32' Signed='true' Min='-144' Max='30'> "
+     "<LinearAdaptation SlopeNumerator='1' SlopeDenominator='0'/> "
+     "</IntegerParameter>"}};
+
+struct LinearsPF : public ParameterFramework
+{
+    LinearsPF() : ParameterFramework{std::move(validLinearInstances)} {}
+};
+
+SCENARIO_METHOD(LazyPF, "Invalid Linear points XML structure", "[Linear Type]")
+{
+    for (auto &vec : invalidLinearParameters) {
+        GIVEN ("intentional error: " + vec.title) {
+            create(Config{&Config::instances, vec.payload});
+            THEN ("Start should fail") {
+                CHECK_THROWS_AS(mPf->start(), Exception);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(LinearsPF, "Linear points", "[Linear Type]")
+{
+    GIVEN ("A valid XML structure file") {
+        THEN ("Start should succeed") {
+            CHECK_NOTHROW(start());
+            REQUIRE_NOTHROW(setTuningMode(true));
+            string path = "/test/test/nominal";
+            AND_THEN ("Set/Get a Loagaritmic point parameter in real value space") {
+
+                for (auto &vec : Tests<string>{
+                         {"(too high)", "301"},
+                         {"(too low)", "-1441"},
+                         {"(not a number)", "foobar"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "300"},
+                         {"(lower limit)", "-1440"},
+                         {"(inside range)", "0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack = "-11";
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+
+            AND_THEN ("Set/Get double type parameter handle") {
+                ElementHandle handle{*this, path};
+                /** @FIXME: 'set' operations on a ParameterHandle are silently
+                 * ignored in tuning mode. Does it make sense ? */
+                REQUIRE_NOTHROW(setTuningMode(false));
+                REQUIRE_NOTHROW(setRawValueSpace(true));
+
+                /* nominal is defined as a Num=10,Denum=100 (division by 10). So limits should be 10
+                 * above Mina dn Max Integer value in order to get exception. */
+                for (auto &vec : Tests<double>{
+                         {"(upper limit)", 3000.0f},
+                         {"(lower limit)", -14400.0f},
+                         {"(inside range)", 0.0f},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(handle.setAsDouble(vec.payload));
+                        double getValueBack = 1.0f;
+                        REQUIRE_NOTHROW(handle.getAsDouble(getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+                for (auto &vec : Tests<double>{
+                         {"(too high)", 3010.0f}, {"(too low)", -14410.00f},
+                     }) {
+                    GIVEN ("An invalid value " + vec.title) {
+                        CHECK_THROWS_AS(handle.setAsDouble(vec.payload), Exception);
+                    }
+                }
+            }
+        }
+    }
+}
+} // namespace parameterFramework

--- a/test/functional-tests/Logarithmic.cpp
+++ b/test/functional-tests/Logarithmic.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Config.hpp"
+#include "ParameterFramework.hpp"
+#include "ElementHandle.hpp"
+#include "Test.hpp"
+#include "BinaryCopy.hpp"
+
+#include <catch.hpp>
+
+#include <string>
+
+using std::string;
+
+namespace parameterFramework
+{
+
+const auto validLogarithmicInstances = Config{
+    &Config::instances,
+    // Size is fixed at 32 and as such is optional */
+    R"(<IntegerParameter Name="trivial" Signed="true"> <LogarithmicAdaptation SlopeNumerator="200" LogarithmBase="10"/> </IntegerParameter>
+    <IntegerParameter Name="nominal" Size="32" Signed="true" Min="-144" Max="30"> <LogarithmicAdaptation SlopeNumerator="1" LogarithmBase="10"/> </IntegerParameter>)"};
+const auto &invalidLogarithmicParameters = Tests<string>{
+    {"invalid Size(64)", "<IntegerParameter Name='nominal' Size='64' Signed='true' Min='-144' "
+                         "Max='30'> <LogarithmicAdaptation SlopeNumerator='1' LogarithmBase='10'/> "
+                         "</IntegerParameter>"},
+    {"minimum > maximum", "<IntegerParameter Name='nominal' Size='32' Signed='true' Min='30' "
+                          "Max='-144'> <LogarithmicAdaptation SlopeNumerator='1' "
+                          "LogarithmBase='10'/> </IntegerParameter>"},
+    {"logBase =1", "<IntegerParameter Name='nominal' Size='32' Signed='true' Min='-144' Max='30'> "
+                   "<LogarithmicAdaptation SlopeNumerator='1' LogarithmBase='1'/> "
+                   "</IntegerParameter>"},
+    {"logBase negative", "<IntegerParameter Name='nominal' Size='32' Signed='true' Min='-144' "
+                         "Max='30'> <LogarithmicAdaptation SlopeNumerator='1' "
+                         "LogarithmBase='-10'/> </IntegerParameter>"}};
+
+struct LogarithmicsPF : public ParameterFramework
+{
+    LogarithmicsPF() : ParameterFramework{std::move(validLogarithmicInstances)} {}
+};
+
+SCENARIO_METHOD(LazyPF, "Invalid Logarithmic points XML structure", "[Logarithmic Type]")
+{
+    for (auto &vec : invalidLogarithmicParameters) {
+        GIVEN ("intentional error: " + vec.title) {
+            create(Config{&Config::instances, vec.payload});
+            THEN ("Start should fail") {
+                CHECK_THROWS_AS(mPf->start(), Exception);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(LogarithmicsPF, "Logarithmic points", "[Logarithmic Type]")
+{
+    GIVEN ("A valid XML structure file") {
+        THEN ("Start should succeed") {
+            CHECK_NOTHROW(start());
+            REQUIRE_NOTHROW(setTuningMode(true));
+            string path = "/test/test/nominal";
+            AND_THEN ("Set/Get a Loagaritmic point parameter in real value space") {
+
+                for (auto &vec : Tests<string>{
+                         {"(too high)", "31"}, {"(too low)", "-145"}, {"(not a number)", "foobar"},
+                     }) {
+                    GIVEN ("Invalid value " + vec.title) {
+                        CHECK_THROWS_AS(setParameter(path, vec.payload), Exception);
+                    }
+                }
+                for (auto &vec : Tests<string>{
+                         {"(upper limit)", "30"},
+                         {"(lower limit)", "-144"},
+                         {"(inside range)", "0"},
+                     }) {
+                    GIVEN ("A valid value " + vec.title) {
+                        CHECK_NOTHROW(setParameter(path, vec.payload));
+                        string getValueBack;
+                        REQUIRE_NOTHROW(getParameter(path, getValueBack));
+                        CHECK(getValueBack == vec.payload);
+                    }
+                }
+            }
+        }
+    }
+}
+} // namespace parameterFramework

--- a/test/functional-tests/include/ElementHandle.hpp
+++ b/test/functional-tests/include/ElementHandle.hpp
@@ -76,6 +76,9 @@ public:
     /** Wrap EH::getAsDouble to throw an exception on failure. */
     void getAsDouble(double &value) const { mayFailCall(&EH::getAsDouble, value); }
 
+    void setAsBoolean(bool value) { mayFailCall(&EH::setAsBoolean, value); }
+    void getAsBoolean(bool &value) const { mayFailCall(&EH::getAsBoolean, value); }
+
     void setAsInteger(uint32_t value) { mayFailCall(&EH::setAsInteger, value); }
     void getAsInteger(uint32_t &value) const { mayFailCall(&EH::getAsInteger, value); }
     void setAsIntegerArray(const std::vector<uint32_t> &value)


### PR DESCRIPTION
This patch is adding basic test for Logarithmic format.

Signed-off-by: Sebastien Guiriec <sebastien.guiriec@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/402%23issuecomment-276985165%22%2C%20%22https%3A//github.com/01org/parameter-framework/pull/402%23issuecomment-279333932%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/402%23issuecomment-276985165%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/402%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23402%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/402%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/01org/parameter-framework/commit/cf265b19b1063630d090f0a807d1de312f301b1e%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%600.34%25%60.%5Cn%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23402%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2072.7%25%20%20%2073.04%25%20%20%20%2B0.34%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20214%20%20%20%20%20%20214%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%206674%20%20%20%20%206674%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20845%20%20%20%20%20%20845%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%204852%20%20%20%20%204875%20%20%20%20%20%20%2B23%20%20%20%20%20%5Cn%2B%20Misses%20%20%20%20%20%20%201355%20%20%20%20%201330%20%20%20%20%20%20-25%20%20%20%20%20%5Cn-%20Partials%20%20%20%20%20%20467%20%20%20%20%20%20469%20%20%20%20%20%20%20%2B2%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/402%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bparameter/BaseIntegerParameterType.cpp%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36%3Fsrc%3Dpr%26el%3Dtree%23diff-cGFyYW1ldGVyL0Jhc2VJbnRlZ2VyUGFyYW1ldGVyVHlwZS5jcHA%3D%29%20%7C%20%60100%25%20%3C%5Cu00f8%3E%20%28%2B14.28%25%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%7C%20%5Bparameter/LinearParameterAdaptation.cpp%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36%3Fsrc%3Dpr%26el%3Dtree%23diff-cGFyYW1ldGVyL0xpbmVhclBhcmFtZXRlckFkYXB0YXRpb24uY3Bw%29%20%7C%20%6018.18%25%20%3C%5Cu00f8%3E%20%28%2B18.18%25%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%7C%20%5Bparameter/ParameterAdaptation.cpp%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36%3Fsrc%3Dpr%26el%3Dtree%23diff-cGFyYW1ldGVyL1BhcmFtZXRlckFkYXB0YXRpb24uY3Bw%29%20%7C%20%6021.05%25%20%3C%5Cu00f8%3E%20%28%2B21.05%25%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%7C%20%5Bparameter/LogarithmicParameterAdaptation.cpp%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36%3Fsrc%3Dpr%26el%3Dtree%23diff-cGFyYW1ldGVyL0xvZ2FyaXRobWljUGFyYW1ldGVyQWRhcHRhdGlvbi5jcHA%3D%29%20%7C%20%6038.09%25%20%3C%5Cu00f8%3E%20%28%2B38.09%25%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%7C%20%5Bparameter/LinearParameterAdaptation.h%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36%3Fsrc%3Dpr%26el%3Dtree%23diff-cGFyYW1ldGVyL0xpbmVhclBhcmFtZXRlckFkYXB0YXRpb24uaA%3D%3D%29%20%7C%20%60100%25%20%3C%5Cu00f8%3E%20%28%2B100%25%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%7C%20%5Bparameter/ParameterAdaptation.h%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36%3Fsrc%3Dpr%26el%3Dtree%23diff-cGFyYW1ldGVyL1BhcmFtZXRlckFkYXB0YXRpb24uaA%3D%3D%29%20%7C%20%60100%25%20%3C%5Cu00f8%3E%20%28%2B100%25%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%7C%20%5Bparameter/LogarithmicParameterAdaptation.h%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36%3Fsrc%3Dpr%26el%3Dtree%23diff-cGFyYW1ldGVyL0xvZ2FyaXRobWljUGFyYW1ldGVyQWRhcHRhdGlvbi5o%29%20%7C%20%60100%25%20%3C%5Cu00f8%3E%20%28%2B100%25%29%60%20%7C%20%3Awhite_check_mark%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/402%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/402%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bcf265b1...d8f1b76%5D%28https%3A//codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36%3Fel%3Dfooter%26src%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%22%2C%20%22created_at%22%3A%20%222017-02-02T15%3A16%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40gdenneul%20Please%20review%22%2C%20%22created_at%22%3A%20%222017-02-13T09%3A25%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/124108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sguiriec%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/402#issuecomment-276985165'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/01org/parameter-framework/pull/402?src=pr&el=h1) Report
> Merging [#402](https://codecov.io/gh/01org/parameter-framework/pull/402?src=pr&el=desc) into [master](https://codecov.io/gh/01org/parameter-framework/commit/cf265b19b1063630d090f0a807d1de312f301b1e?src=pr&el=desc) will **increase** coverage by `0.34%`.
```diff
@@            Coverage Diff             @@
##           master     #402      +/-   ##
==========================================
+ Coverage    72.7%   73.04%   +0.34%
==========================================
Files         214      214
Lines        6674     6674
Branches      845      845
==========================================
+ Hits         4852     4875      +23
+ Misses       1355     1330      -25
- Partials      467      469       +2
```
| [Impacted Files](https://codecov.io/gh/01org/parameter-framework/pull/402?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [parameter/BaseIntegerParameterType.cpp](https://codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36?src=pr&el=tree#diff-cGFyYW1ldGVyL0Jhc2VJbnRlZ2VyUGFyYW1ldGVyVHlwZS5jcHA=) | `100% <ø> (+14.28%)` | :white_check_mark: |
| [parameter/LinearParameterAdaptation.cpp](https://codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36?src=pr&el=tree#diff-cGFyYW1ldGVyL0xpbmVhclBhcmFtZXRlckFkYXB0YXRpb24uY3Bw) | `18.18% <ø> (+18.18%)` | :white_check_mark: |
| [parameter/ParameterAdaptation.cpp](https://codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36?src=pr&el=tree#diff-cGFyYW1ldGVyL1BhcmFtZXRlckFkYXB0YXRpb24uY3Bw) | `21.05% <ø> (+21.05%)` | :white_check_mark: |
| [parameter/LogarithmicParameterAdaptation.cpp](https://codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36?src=pr&el=tree#diff-cGFyYW1ldGVyL0xvZ2FyaXRobWljUGFyYW1ldGVyQWRhcHRhdGlvbi5jcHA=) | `38.09% <ø> (+38.09%)` | :white_check_mark: |
| [parameter/LinearParameterAdaptation.h](https://codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36?src=pr&el=tree#diff-cGFyYW1ldGVyL0xpbmVhclBhcmFtZXRlckFkYXB0YXRpb24uaA==) | `100% <ø> (+100%)` | :white_check_mark: |
| [parameter/ParameterAdaptation.h](https://codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36?src=pr&el=tree#diff-cGFyYW1ldGVyL1BhcmFtZXRlckFkYXB0YXRpb24uaA==) | `100% <ø> (+100%)` | :white_check_mark: |
| [parameter/LogarithmicParameterAdaptation.h](https://codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36?src=pr&el=tree#diff-cGFyYW1ldGVyL0xvZ2FyaXRobWljUGFyYW1ldGVyQWRhcHRhdGlvbi5o) | `100% <ø> (+100%)` | :white_check_mark: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/01org/parameter-framework/pull/402?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/01org/parameter-framework/pull/402?src=pr&el=footer). Last update [cf265b1...d8f1b76](https://codecov.io/gh/01org/parameter-framework/compare/cf265b19b1063630d090f0a807d1de312f301b1e...d8f1b760e463a5477cd8f04c5171c76607caea36?el=footer&src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).
- <a href='https://github.com/sguiriec'><img border=0 src='https://avatars.githubusercontent.com/u/124108?v=3' height=16 width=16></a> @gdenneul Please review


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/402?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/402?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/402'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>