### PR TITLE
Fix dumpElement for ArrayParameters

### DIFF
--- a/parameter/ArrayParameter.cpp
+++ b/parameter/ArrayParameter.cpp
@@ -171,7 +171,7 @@ bool CArrayParameter::access(std::vector<string> &astrValues, bool bSet,
 string CArrayParameter::logValue(CParameterAccessContext &context) const
 {
     // Dump values
-    return getValues(0, context);
+    return getValues(getOffset() - context.getBaseOffset(), context);
 }
 
 // Used for simulation and virtual subsystems


### PR DESCRIPTION
Use correct blackboard index while calling dumpElement (logValue
for ArrayParameter class) to fix the eratic behavior of dumpElement
for ArrayParameters.

Change-Id: I255af6969283f91cdd2efd810c7d453f3765a16d
Tracked-On:
Signed-off-by: François Gaffie <francois.gaffie@intel.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/01org/parameter-framework/pull/403%23issuecomment-292128503%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/01org/parameter-framework/pull/403%23issuecomment-292128503%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20Merging%20%5B%23403%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Ddesc%29%20into%20%5Bmaster%5D%28https%3A//codecov.io/gh/01org/parameter-framework/commit/e67846707445eaa8344e1262476521697c803cc7%3Fsrc%3Dpr%26el%3Ddesc%29%20will%20%2A%2Aincrease%2A%2A%20coverage%20by%20%60%3C.01%25%60.%5Cn%3E%20The%20diff%20coverage%20is%20%600%25%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403/graphs/tree.svg%3Fwidth%3D650%26src%3Dpr%26token%3DKWftAgadue%26height%3D150%29%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%23403%20%20%20%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Coverage%20%20%20%2074.6%25%20%20%2074.61%25%20%20%20%2B%3C.01%25%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20214%20%20%20%20%20%20214%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%206675%20%20%20%20%206677%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20845%20%20%20%20%20%20845%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%2B%20Hits%20%20%20%20%20%20%20%20%204980%20%20%20%20%204982%20%20%20%20%20%20%20%2B2%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%201224%20%20%20%20%201224%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20471%20%20%20%20%20%20471%5Cn%60%60%60%5Cn%5Cn%5Cn%7C%20%5BImpacted%20Files%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Dtree%29%20%7C%20Coverage%20%5Cu0394%20%7C%20%7C%5Cn%7C---%7C---%7C---%7C%5Cn%7C%20%5Bparameter/ArrayParameter.cpp%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Dtree%23diff-cGFyYW1ldGVyL0FycmF5UGFyYW1ldGVyLmNwcA%3D%3D%29%20%7C%20%6066%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%7C%20%5Butility/NonCopyable.hpp%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Dtree%23diff-dXRpbGl0eS9Ob25Db3B5YWJsZS5ocHA%3D%29%20%7C%20%60100%25%20%3C0%25%3E%20%28%5Cu00f8%29%60%20%7C%20%3Aarrow_up%3A%20%7C%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Be678467...d4ac41d%5D%28https%3A//codecov.io/gh/01org/parameter-framework/pull/403%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%22%2C%20%22created_at%22%3A%20%222017-04-06T10%3A06%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/8655789%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecov-io%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/01org/parameter-framework/pull/403#issuecomment-292128503'>General Comment</a></b>
- <a href='https://github.com/codecov-io'><img border=0 src='https://avatars3.githubusercontent.com/u/8655789?v=3' height=16 width=16></a> # [Codecov](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=h1) Report
> Merging [#403](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=desc) into [master](https://codecov.io/gh/01org/parameter-framework/commit/e67846707445eaa8344e1262476521697c803cc7?src=pr&el=desc) will **increase** coverage by `<.01%`.
> The diff coverage is `0%`.
[![Impacted file tree graph](https://codecov.io/gh/01org/parameter-framework/pull/403/graphs/tree.svg?width=650&src=pr&token=KWftAgadue&height=150)](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=tree)
```diff
@@            Coverage Diff             @@
##           master     #403      +/-   ##
==========================================
+ Coverage    74.6%   74.61%   +<.01%
==========================================
Files         214      214
Lines        6675     6677       +2
Branches      845      845
==========================================
+ Hits         4980     4982       +2
Misses       1224     1224
Partials      471      471
```
| [Impacted Files](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=tree) | Coverage Δ | |
|---|---|---|
| [parameter/ArrayParameter.cpp](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=tree#diff-cGFyYW1ldGVyL0FycmF5UGFyYW1ldGVyLmNwcA==) | `66% <0%> (ø)` | :arrow_up: |
| [utility/NonCopyable.hpp](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=tree#diff-dXRpbGl0eS9Ob25Db3B5YWJsZS5ocHA=) | `100% <0%> (ø)` | :arrow_up: |
------
[Continue to review full report at Codecov](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=footer). Last update [e678467...d4ac41d](https://codecov.io/gh/01org/parameter-framework/pull/403?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/403?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/01org/parameter-framework/pull/403?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/01org/parameter-framework/pull/403'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>